### PR TITLE
Fix CMake install layout so librobotiq_tsf_algorithms.so is on linker path

### DIFF
--- a/robotiq_tsf/CMakeLists.txt
+++ b/robotiq_tsf/CMakeLists.txt
@@ -111,8 +111,13 @@ ament_target_dependencies(tactile_total_sum_node
   ament_index_cpp
 )
 
+install(TARGETS ${PROJECT_NAME}_algorithms
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
 install(TARGETS
-  ${PROJECT_NAME}_algorithms
   poll_data_node
   tactile_total_sum_node
   DESTINATION lib/${PROJECT_NAME}


### PR DESCRIPTION
## Summary
- Split `install(TARGETS ...)` in `robotiq_tsf/CMakeLists.txt` so the shared library `robotiq_tsf_algorithms` installs to `lib/` (LIBRARY/ARCHIVE/RUNTIME destinations) while the executables continue to install to `lib/${PROJECT_NAME}/`.
- Previously everything was installed under `lib/${PROJECT_NAME}/`, which is not added to `LD_LIBRARY_PATH` by ament. That caused `ros2 run robotiq_tsf poll_data_node` to fail with `error while loading shared libraries: librobotiq_tsf_algorithms.so: cannot open shared object file`.

## Test plan
- [x] `colcon build --packages-select robotiq_tsf` succeeds
- [x] `install/robotiq_tsf/lib/librobotiq_tsf_algorithms.so` is present
- [x] `install/robotiq_tsf/lib/robotiq_tsf/poll_data_node` is present
- [ ] `ros2 run robotiq_tsf poll_data_node` launches without the missing-library error

🤖 Generated with [Claude Code](https://claude.com/claude-code)