### PR TITLE
Restore gripper ci infrastructure

### DIFF
--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -1,0 +1,40 @@
+# pre-commit (black, flake8, codespell, clang-format, whitespace/eol hooks)
+# over the vendored gripper tree, using grippers/.pre-commit-config.yaml.
+#
+# Scoping: this repo is multi-package, but only grippers/ carries a pre-commit
+# config, so we restrict the run to grippers/** files. pre-commit runs hooks
+# from the git root, so flake8 wouldn't find grippers/.flake8 on its own — we
+# place it at the root for the run (clang-format finds grippers/.clang-format
+# by walking up per-file, so it needs no such help).
+name: Format (grippers)
+
+on:
+  pull_request:
+    paths:
+      - "grippers/**"
+      - ".github/workflows/ci-format.yml"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  pre-commit:
+    name: Format
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Make grippers' flake8 config discoverable from the git root
+        run: cp grippers/.flake8 .flake8
+      - name: Run pre-commit on grippers/
+        run: |
+          python -m pip install --upgrade pre-commit
+          # Restrict to tracked files under grippers/ (paths are relative to the
+          # git root, which is where pre-commit runs hooks from).
+          mapfile -t files < <(git ls-files grippers)
+          pre-commit run \
+            --config grippers/.pre-commit-config.yaml \
+            --files "${files[@]}" \
+            --show-diff-on-failure

--- a/.github/workflows/ci-ros-lint.yml
+++ b/.github/workflows/ci-ros-lint.yml
@@ -1,0 +1,50 @@
+# ament linters for the vendored gripper packages (grippers/).
+# Adapted from PickNik's ros2_robotiq_gripper CI: distribution -> jazzy,
+# runner -> ubuntu-24.04 (Noble), scoped to grippers/** so it only runs when
+# the vendored tree changes.
+name: ROS Lint (grippers)
+
+on:
+  pull_request:
+    paths:
+      - "grippers/**"
+      - ".github/workflows/ci-ros-lint.yml"
+  workflow_dispatch:
+
+jobs:
+  ament_lint:
+    name: ament_${{ matrix.linter }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        linter: [copyright, lint_cmake]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ros-tooling/setup-ros@v0.7
+      - uses: ros-tooling/action-ros-lint@v0.1
+        with:
+          distribution: jazzy
+          linter: ${{ matrix.linter }}
+          package-name: >-
+            robotiq_driver
+            robotiq_controllers
+            robotiq_description
+            robotiq_hardware_tests
+
+  ament_cpplint:
+    name: ament_cpplint
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ros-tooling/setup-ros@v0.7
+      - uses: ros-tooling/action-ros-lint@v0.1
+        with:
+          distribution: jazzy
+          linter: cpplint
+          arguments: "--linelength=121 --filter=-whitespace/newline"
+          package-name: >-
+            robotiq_driver
+            robotiq_controllers
+            robotiq_description
+            robotiq_hardware_tests


### PR DESCRIPTION
## Add lint + format CI for the gripper packages

Restores static-analysis CI for the vendored `grippers/` packages. When the
PickNik driver was vendored in (#6), its workflows came along under
`grippers/.github/workflows/` — a subdirectory GitHub Actions never runs — so
the repo had no CI covering them. This adds them back at the repo root.

Two workflows, both scoped to `grippers/**` (they only run when that tree changes):

- **`ci-ros-lint.yml`** — `ament_copyright`, `ament_cpplint`, `ament_lint_cmake`
  over the four gripper packages on ROS 2 Jazzy (via `ros-tooling/action-ros-lint`).
  Adapted from PickNik's `ci-ros-lint` (rolling → jazzy, ubuntu-24.04).
- **`ci-format.yml`** — pre-commit (black, flake8, codespell, clang-format,
  whitespace/eol) using the vendored `grippers/.pre-commit-config.yaml`.
  pre-commit runs hooks from the git root, so `grippers/.flake8` is placed at the
  root for the run; clang-format finds `grippers/.clang-format` by walking up per file.

**Scope:** grippers only — `robotiq_tsf` has no lint/format config, so widening CI
to the sensor package is a separate follow-up.
