### PR TITLE
docs: fix stale repo links in package table

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ROS packages for Robotiq grippers and sensors.
 
 | Package | Description | ROS Version |
 |---|---|---|
-| [robotiq_tsf](robotiq_tsf/) | TSF-85 tactile sensor driver | ROS 2 Jazzy ([main](https://github.com/robotiq/ROS_Packages/tree/main)) / ROS 1 Noetic ([noetic](https://github.com/robotiq/ROS_Packages/tree/noetic)) |
+| [robotiq_tsf](robotiq_tsf/) | TSF-85 tactile sensor driver | ROS 2 Jazzy ([main](https://github.com/robotiq/ros/tree/main)) / ROS 1 Noetic ([noetic](https://github.com/robotiq/ros/tree/noetic)) |
 
 ## Legacy
 


### PR DESCRIPTION
The main/noetic branch links pointed at robotiq/ROS_Packages, which no longer exists; point them at robotiq/ros.