### PR TITLE
feat(robotiq_tsf): tactile sensor RViz visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ build/
 install/
 log/
 serial/
+__pycache__/
+*.pyc
 
 # IDE / per-machine cmake config
 .qtcreator/

--- a/README.md
+++ b/README.md
@@ -45,6 +45,31 @@ The node publishes on the following topics:
 
 > Note: `EulerAngle` and `Quaternion` are only published after the IMU bias calibration period completes at startup.
 
+### Tactile visualization (RViz)
+
+`tactile_viz_node` renders `TactileSensor/StaticData` as per-taxel 3D markers and per-finger 2D heatmap images, with the pad TFs to place them. Two launches:
+
+```bash
+ros2 launch robotiq_tsf tactile_viz.launch.py                 # driver + viz + RViz, standalone
+ros2 launch robotiq_tsf gripper_tactile_viz.launch.py \
+    com_port:=/dev/ttyUSB0                                    # single window: 2F-85 gripper + pads on its fingertips
+```
+
+Common args (see `--show-args` for the full list):
+
+| Arg | Default | Description |
+|---|---|---|
+| `poller` | `poll_data_node` | Driver executable publishing `StaticData` — override to use an alternative poller |
+| `rviz` / `rviz_config` | `true` / packaged config | Toggle RViz / point it at your own config (`tactile_viz.launch.py`) |
+| `use_fake_hardware` | `false` | Gripper `ros2_control` mock (`gripper_tactile_viz.launch.py`) |
+| `tactile_delay` | `8.0` | Seconds to delay the viz start so the baseline is captured after gripper activation (`gripper_tactile_viz.launch.py`) |
+
+The node publishes `visualization_msgs/MarkerArray` on `/tactile/markers` and `sensor_msgs/Image` heatmaps on `/tactile_viz/finger1_heatmap` / `/tactile_viz/finger2_heatmap`. On startup it averages the first `baseline_frames` messages into a per-taxel baseline and subtracts it (re-zero anytime: `ros2 topic pub --once /tactile_viz/zero std_msgs/msg/Empty`); readings below `noise_floor` render quiet. Pad geometry, frames, color scale, and heatmap options are parameters of `tactile_viz_node`.
+
+In the combined launch the pad frames are TF-mounted on the gripper fingertip links, so the heatmaps follow the fingers as the gripper opens and closes.
+
+> Note: depending on the USB enumeration state (it can toggle with a replug), `poll_data_node` can emit corrupted `StaticData` on the TSF-85, rendering as saturated/flashing heatmaps — a driver parsing issue addressed separately by the SDK-backed poller; the visualization itself is unaffected.
+
 ## Grippers
 
 ROS 2 `ros2_control` driver for Robotiq grippers (2F-85 / 2F-140, Hand-E), under [`grippers/`](grippers/).

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Common args (see `--show-args` for the full list):
 | `use_fake_hardware` | `false` | Gripper `ros2_control` mock (`gripper_tactile_viz.launch.py`) |
 | `tactile_delay` | `8.0` | Seconds to delay the viz start so the baseline is captured after gripper activation (`gripper_tactile_viz.launch.py`) |
 
-The node publishes `visualization_msgs/MarkerArray` on `/tactile/markers` and `sensor_msgs/Image` heatmaps on `/tactile_viz/finger1_heatmap` / `/tactile_viz/finger2_heatmap`. On startup it averages the first `baseline_frames` messages into a per-taxel baseline and subtracts it (re-zero anytime: `ros2 topic pub --once /tactile_viz/zero std_msgs/msg/Empty`); readings below `noise_floor` render quiet. Pad geometry, frames, color scale, and heatmap options are parameters of `tactile_viz_node`.
+The node publishes `visualization_msgs/MarkerArray` on `/tactile/markers` and `sensor_msgs/Image` heatmaps on `/tactile_viz/finger0_heatmap` / `/tactile_viz/finger1_heatmap`. On startup it averages the first `baseline_frames` messages into a per-taxel baseline and subtracts it (re-zero anytime: `ros2 topic pub --once /tactile_viz/zero std_msgs/msg/Empty`); readings below `noise_floor` render quiet. Pad geometry, frames, color scale, and heatmap options are parameters of `tactile_viz_node`.
 
 In the combined launch the pad frames are TF-mounted on the gripper fingertip links, so the heatmaps follow the fingers as the gripper opens and closes.
 

--- a/robotiq_tsf/CMakeLists.txt
+++ b/robotiq_tsf/CMakeLists.txt
@@ -121,6 +121,16 @@ install(TARGETS
   DESTINATION lib/${PROJECT_NAME}
 )
 
+# Python RViz visualization node + its launch and config.
+install(PROGRAMS
+  scripts/tactile_viz_node
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(DIRECTORY launch rviz
+  DESTINATION share/${PROJECT_NAME}
+)
+
 install(DIRECTORY include/
   DESTINATION include
 )

--- a/robotiq_tsf/launch/gripper_tactile_viz.launch.py
+++ b/robotiq_tsf/launch/gripper_tactile_viz.launch.py
@@ -22,12 +22,16 @@ from launch.actions import (
     DeclareLaunchArgument, IncludeLaunchDescription, TimerAction,
 )
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import (
+    LaunchConfiguration, PathJoinSubstitution, PythonExpression,
+)
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
 # Tactile pad mount relative to its fingertip link, mirrored left/right:
 # lateral offset toward the pad surface and height along the finger.
+# Defaults for the 2F-85; override the mount_* / *_tip_link launch args to
+# remount the pads or use another gripper (e.g. 2F-140).
 TACTILE_MOUNT_X_M = 0.0252
 TACTILE_MOUNT_Z_M = 0.032
 
@@ -45,12 +49,22 @@ def generate_launch_description():
             'com_port', default_value='/dev/ttyUSB0',
             description='Gripper serial port.'),
         DeclareLaunchArgument(
-            'poller', default_value='poll_data_node',
-            description='Driver executable publishing StaticData. Override to '
-                        'point the viz at an alternative poller.'),
-        DeclareLaunchArgument(
             'use_fake_hardware', default_value='false',
             description='Gripper ros2_control mock instead of real hardware.'),
+        DeclareLaunchArgument(
+            'mount_x', default_value=str(TACTILE_MOUNT_X_M),
+            description='Pad lateral offset from its fingertip link [m] '
+                        '(negated for the left finger).'),
+        DeclareLaunchArgument(
+            'mount_z', default_value=str(TACTILE_MOUNT_Z_M),
+            description='Pad height along the finger from its fingertip '
+                        'link [m].'),
+        DeclareLaunchArgument(
+            'left_tip_link', default_value='robotiq_85_left_finger_tip_link',
+            description='Parent link for the finger-0 pad frame.'),
+        DeclareLaunchArgument(
+            'right_tip_link', default_value='robotiq_85_right_finger_tip_link',
+            description='Parent link for the finger-1 pad frame.'),
         DeclareLaunchArgument(
             'rviz_config', default_value=default_rviz,
             description='Combined gripper + tactile RViz config.'),
@@ -81,23 +95,25 @@ def generate_launch_description():
     anchor_0 = Node(
         package='tf2_ros', executable='static_transform_publisher',
         name='finger_tip_to_tactile_finger_0',
-        arguments=['--x', str(-TACTILE_MOUNT_X_M), '--y', '0',
-                   '--z', str(TACTILE_MOUNT_Z_M),
-                   '--frame-id', 'robotiq_85_left_finger_tip_link',
+        arguments=['--x', PythonExpression(['-', LaunchConfiguration('mount_x')]),
+                   '--y', '0',
+                   '--z', LaunchConfiguration('mount_z'),
+                   '--frame-id', LaunchConfiguration('left_tip_link'),
                    '--child-frame-id', 'tactile_finger_0'])
     anchor_1 = Node(
         package='tf2_ros', executable='static_transform_publisher',
         name='finger_tip_to_tactile_finger_1',
-        arguments=['--x', str(TACTILE_MOUNT_X_M), '--y', '0',
-                   '--z', str(TACTILE_MOUNT_Z_M),
+        arguments=['--x', LaunchConfiguration('mount_x'),
+                   '--y', '0',
+                   '--z', LaunchConfiguration('mount_z'),
                    '--yaw', str(math.pi),
-                   '--frame-id', 'robotiq_85_right_finger_tip_link',
+                   '--frame-id', LaunchConfiguration('right_tip_link'),
                    '--child-frame-id', 'tactile_finger_1'])
 
-    # Sensor driver — autodetects the device.
-    poll = Node(
-        package='robotiq_tsf', executable=LaunchConfiguration('poller'),
-        name='poll_data', output='screen')
+    # Sensor driver (poller:= arg declared there).
+    driver = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(PathJoinSubstitution([
+            FindPackageShare('robotiq_tsf'), 'launch', 'tsf_driver.launch.py'])))
 
     # publish_static_tfs:=false — render into the gripper-mounted tactile_finger_*
     # frames (from the anchors above) instead of the node's standalone frames.
@@ -122,4 +138,4 @@ def generate_launch_description():
         period=LaunchConfiguration('tactile_delay'), actions=[viz])
 
     return LaunchDescription(
-        args + [gripper, anchor_0, anchor_1, poll, viz_delayed, rviz])
+        args + [gripper, anchor_0, anchor_1, driver, viz_delayed, rviz])

--- a/robotiq_tsf/launch/gripper_tactile_viz.launch.py
+++ b/robotiq_tsf/launch/gripper_tactile_viz.launch.py
@@ -1,0 +1,125 @@
+"""Single-window view: the 2F-85 gripper with the tactile heatmaps mounted on
+its fingers.
+
+Brings up, in one RViz:
+  - the gripper (robotiq_control.launch.py: ros2_control + robot_state_publisher),
+  - two static TFs mounting the tactile pad frames on the gripper fingertip
+    links (values from the demo), so the heatmaps move with the fingers,
+  - the tactile driver + tactile_viz_node (publish_static_tfs:=false, so it
+    renders into the gripper-mounted frames rather than its own),
+  - RViz showing the RobotModel + MarkerArray + per-finger Image heatmaps.
+
+  ros2 launch robotiq_tsf gripper_tactile_viz.launch.py com_port:=/dev/ttyUSB0
+
+Run this INSTEAD of the separate gripper / tactile_viz launches.
+"""
+import math
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument, IncludeLaunchDescription, TimerAction,
+)
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+# Tactile pad mount relative to its fingertip link, mirrored left/right:
+# lateral offset toward the pad surface and height along the finger.
+TACTILE_MOUNT_X_M = 0.0252
+TACTILE_MOUNT_Z_M = 0.032
+
+
+def generate_launch_description():
+    pkg_tsf = get_package_share_directory('robotiq_tsf')
+    default_rviz = os.path.join(pkg_tsf, 'rviz', 'gripper_tactile.rviz')
+
+    com_port = LaunchConfiguration('com_port')
+    use_fake_hardware = LaunchConfiguration('use_fake_hardware')
+    rviz_config = LaunchConfiguration('rviz_config')
+
+    args = [
+        DeclareLaunchArgument(
+            'com_port', default_value='/dev/ttyUSB0',
+            description='Gripper serial port.'),
+        DeclareLaunchArgument(
+            'poller', default_value='poll_data_node',
+            description='Driver executable publishing StaticData. Override to '
+                        'point the viz at an alternative poller.'),
+        DeclareLaunchArgument(
+            'use_fake_hardware', default_value='false',
+            description='Gripper ros2_control mock instead of real hardware.'),
+        DeclareLaunchArgument(
+            'rviz_config', default_value=default_rviz,
+            description='Combined gripper + tactile RViz config.'),
+        DeclareLaunchArgument(
+            'tactile_delay', default_value='8.0',
+            description='Seconds to wait before starting tactile_viz (and thus '
+                        'its baseline capture), so the gripper finishes its '
+                        'activation open/close and settles OPEN — pads clear — '
+                        'first. The driver streams from t=0 regardless.'),
+    ]
+
+    # Gripper: ros2_control + robot_state_publisher (its own RViz suppressed —
+    # we run the combined one below).
+    gripper = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(PathJoinSubstitution([
+            FindPackageShare('robotiq_description'), 'launch',
+            'robotiq_control.launch.py'])),
+        launch_arguments={
+            'com_port': com_port,
+            'use_fake_hardware': use_fake_hardware,
+            'launch_rviz': 'false',
+        }.items(),
+    )
+
+    # Mount the tactile pad frames on the gripper fingertip links.
+    # Children of the finger_tip links, so
+    # they follow the fingers as the gripper opens/closes.
+    anchor_0 = Node(
+        package='tf2_ros', executable='static_transform_publisher',
+        name='finger_tip_to_tactile_finger_0',
+        arguments=['--x', str(-TACTILE_MOUNT_X_M), '--y', '0',
+                   '--z', str(TACTILE_MOUNT_Z_M),
+                   '--frame-id', 'robotiq_85_left_finger_tip_link',
+                   '--child-frame-id', 'tactile_finger_0'])
+    anchor_1 = Node(
+        package='tf2_ros', executable='static_transform_publisher',
+        name='finger_tip_to_tactile_finger_1',
+        arguments=['--x', str(TACTILE_MOUNT_X_M), '--y', '0',
+                   '--z', str(TACTILE_MOUNT_Z_M),
+                   '--yaw', str(math.pi),
+                   '--frame-id', 'robotiq_85_right_finger_tip_link',
+                   '--child-frame-id', 'tactile_finger_1'])
+
+    # Sensor driver — autodetects the device.
+    poll = Node(
+        package='robotiq_tsf', executable=LaunchConfiguration('poller'),
+        name='poll_data', output='screen')
+
+    # publish_static_tfs:=false — render into the gripper-mounted tactile_finger_*
+    # frames (from the anchors above) instead of the node's standalone frames.
+    viz = Node(
+        package='robotiq_tsf', executable='tactile_viz_node',
+        name='tactile_viz', output='screen',
+        parameters=[{
+            'input_topic': 'TactileSensor/StaticData',
+            'publish_static_tfs': False,
+            'frame_id_finger_0': 'tactile_finger_0',
+            'frame_id_finger_1': 'tactile_finger_1',
+        }])
+
+    rviz = Node(
+        package='rviz2', executable='rviz2', name='rviz2', output='screen',
+        arguments=['-d', rviz_config])
+
+    # Delay tactile_viz so its baseline is captured AFTER the gripper's
+    # activation open/close finishes (gripper settled open, pads clear).
+    # The driver still starts at t=0, so the raw stream is available.
+    viz_delayed = TimerAction(
+        period=LaunchConfiguration('tactile_delay'), actions=[viz])
+
+    return LaunchDescription(
+        args + [gripper, anchor_0, anchor_1, poll, viz_delayed, rviz])

--- a/robotiq_tsf/launch/tactile_viz.launch.py
+++ b/robotiq_tsf/launch/tactile_viz.launch.py
@@ -9,10 +9,12 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.conditions import IfCondition
-from launch.substitutions import LaunchConfiguration
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
@@ -28,15 +30,11 @@ def generate_launch_description():
     input_topic_arg = DeclareLaunchArgument(
         'input_topic', default_value='TactileSensor/StaticData',
         description='Raw StaticData topic published by the driver.')
-    poller_arg = DeclareLaunchArgument(
-        'poller', default_value='poll_data_node',
-        description='Driver executable publishing StaticData. Override to '
-                    'point the viz at an alternative poller.')
 
-    # Sensor driver — autodetects the device.
-    poll = Node(
-        package='robotiq_tsf', executable=LaunchConfiguration('poller'),
-        name='poll_data', output='screen')
+    # Sensor driver (poller:= arg declared there).
+    driver = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(PathJoinSubstitution([
+            FindPackageShare('robotiq_tsf'), 'launch', 'tsf_driver.launch.py'])))
 
     viz = Node(
         package='robotiq_tsf', executable='tactile_viz_node',
@@ -49,4 +47,4 @@ def generate_launch_description():
         condition=IfCondition(LaunchConfiguration('rviz')))
 
     return LaunchDescription(
-        [rviz_arg, rviz_config_arg, input_topic_arg, poller_arg, poll, viz, rviz])
+        [rviz_arg, rviz_config_arg, input_topic_arg, driver, viz, rviz])

--- a/robotiq_tsf/launch/tactile_viz.launch.py
+++ b/robotiq_tsf/launch/tactile_viz.launch.py
@@ -1,0 +1,52 @@
+"""Bring up the TSF-85 driver + a minimal RViz tactile heatmap.
+
+  ros2 launch robotiq_tsf tactile_viz.launch.py            # driver + viz + rviz
+  ros2 launch robotiq_tsf tactile_viz.launch.py rviz:=false
+
+Assumes the sensor is connected (see docker/run.sh sensor for device mapping).
+"""
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    pkg_share = get_package_share_directory('robotiq_tsf')
+    default_rviz = os.path.join(pkg_share, 'rviz', 'tactile_viz.rviz')
+
+    rviz_arg = DeclareLaunchArgument(
+        'rviz', default_value='true',
+        description='Launch RViz with the tactile viz config.')
+    rviz_config_arg = DeclareLaunchArgument(
+        'rviz_config', default_value=default_rviz,
+        description='Path to an RViz config file.')
+    input_topic_arg = DeclareLaunchArgument(
+        'input_topic', default_value='TactileSensor/StaticData',
+        description='Raw StaticData topic published by the driver.')
+    poller_arg = DeclareLaunchArgument(
+        'poller', default_value='poll_data_node',
+        description='Driver executable publishing StaticData. Override to '
+                    'point the viz at an alternative poller.')
+
+    # Sensor driver — autodetects the device.
+    poll = Node(
+        package='robotiq_tsf', executable=LaunchConfiguration('poller'),
+        name='poll_data', output='screen')
+
+    viz = Node(
+        package='robotiq_tsf', executable='tactile_viz_node',
+        name='tactile_viz', output='screen',
+        parameters=[{'input_topic': LaunchConfiguration('input_topic')}])
+
+    rviz = Node(
+        package='rviz2', executable='rviz2', name='rviz2', output='screen',
+        arguments=['-d', LaunchConfiguration('rviz_config')],
+        condition=IfCondition(LaunchConfiguration('rviz')))
+
+    return LaunchDescription(
+        [rviz_arg, rviz_config_arg, input_topic_arg, poller_arg, poll, viz, rviz])

--- a/robotiq_tsf/launch/tsf_driver.launch.py
+++ b/robotiq_tsf/launch/tsf_driver.launch.py
@@ -1,0 +1,23 @@
+"""Bring up the TSF-85 driver (StaticData publisher) only.
+
+Included by tactile_viz.launch.py and gripper_tactile_viz.launch.py; usable
+standalone for a headless driver.
+"""
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    poller_arg = DeclareLaunchArgument(
+        'poller', default_value='poll_data_node',
+        description='Driver executable publishing StaticData. Override to '
+                    'point the viz at an alternative poller.')
+
+    # Sensor driver — autodetects the device.
+    poll = Node(
+        package='robotiq_tsf', executable=LaunchConfiguration('poller'),
+        name='poll_data', output='screen')
+
+    return LaunchDescription([poller_arg, poll])

--- a/robotiq_tsf/package.xml
+++ b/robotiq_tsf/package.xml
@@ -32,7 +32,21 @@
   <depend>libopencv-dev</depend>
   <depend>libusb-1.0</depend>
 
+  <!-- tactile_viz_node (Python RViz visualization) + its launch/rviz. -->
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>visualization_msgs</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>rviz2</exec_depend>
+  <!-- gripper_tactile_viz.launch.py includes the gripper bringup. -->
+  <exec_depend>robotiq_description</exec_depend>
+
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>python3-pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/robotiq_tsf/rviz/gripper_tactile.rviz
+++ b/robotiq_tsf/rviz/gripper_tactile.rviz
@@ -1,0 +1,138 @@
+Panels:
+  - Class: rviz_common/Displays
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /RobotModel1
+        - /TF1
+      Splitter Ratio: 0.5
+    Tree Height: 700
+  - Class: rviz_common/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 0.009999999776482582
+      Class: rviz_default_plugins/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 20
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Class: rviz_default_plugins/RobotModel
+      Collision Enabled: false
+      Description File: ""
+      Description Source: Topic
+      Description Topic:
+        Depth: 5
+        Durability Policy: Transient Local
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /robot_description
+      Enabled: true
+      Name: RobotModel
+      Visual Enabled: true
+    - Class: rviz_default_plugins/TF
+      Enabled: true
+      Frame Timeout: 15
+      Marker Scale: 0.05000000074505806
+      Name: TF
+      Show Arrows: false
+      Show Axes: true
+      Show Names: true
+      Update Interval: 0
+      Value: true
+    - Class: rviz_default_plugins/MarkerArray
+      Enabled: true
+      Name: TactileMarkers
+      Namespaces:
+        tactile_finger_0: true
+        tactile_finger_1: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /tactile/markers
+      Value: true
+    - Class: rviz_default_plugins/Image
+      Enabled: true
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Finger 1 Pressure Image
+      Normalize Range: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /tactile_viz/finger1_heatmap
+      Value: true
+    - Class: rviz_default_plugins/Image
+      Enabled: true
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Finger 2 Pressure Image
+      Normalize Range: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /tactile_viz/finger2_heatmap
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: world
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
+  Value: true
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Distance: 0.35
+      Focal Point:
+        X: 0.0
+        Y: 0.0
+        Z: 0.12
+      Name: Current View
+      Near Clip Distance: 0.0010000000474974513
+      Pitch: 0.3
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz_default_plugins)
+      Yaw: 0.785
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1000
+  Hide Left Dock: false
+  Hide Right Dock: false
+  Width: 1600
+  X: 100
+  Y: 100

--- a/robotiq_tsf/rviz/gripper_tactile.rviz
+++ b/robotiq_tsf/rviz/gripper_tactile.rviz
@@ -76,6 +76,20 @@ Visualization Manager:
       Max Value: 1
       Median window: 5
       Min Value: 0
+      Name: Finger 0 Pressure Image
+      Normalize Range: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /tactile_viz/finger0_heatmap
+      Value: true
+    - Class: rviz_default_plugins/Image
+      Enabled: true
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
       Name: Finger 1 Pressure Image
       Normalize Range: true
       Topic:
@@ -84,20 +98,6 @@ Visualization Manager:
         History Policy: Keep Last
         Reliability Policy: Reliable
         Value: /tactile_viz/finger1_heatmap
-      Value: true
-    - Class: rviz_default_plugins/Image
-      Enabled: true
-      Max Value: 1
-      Median window: 5
-      Min Value: 0
-      Name: Finger 2 Pressure Image
-      Normalize Range: true
-      Topic:
-        Depth: 5
-        Durability Policy: Volatile
-        History Policy: Keep Last
-        Reliability Policy: Reliable
-        Value: /tactile_viz/finger2_heatmap
       Value: true
   Enabled: true
   Global Options:

--- a/robotiq_tsf/rviz/tactile_viz.rviz
+++ b/robotiq_tsf/rviz/tactile_viz.rviz
@@ -79,6 +79,20 @@ Visualization Manager:
       Max Value: 1
       Median window: 5
       Min Value: 0
+      Name: Finger 0 Pressure Image
+      Normalize Range: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /tactile_viz/finger0_heatmap
+      Value: true
+    - Class: rviz_default_plugins/Image
+      Enabled: true
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
       Name: Finger 1 Pressure Image
       Normalize Range: true
       Topic:
@@ -87,20 +101,6 @@ Visualization Manager:
         History Policy: Keep Last
         Reliability Policy: Reliable
         Value: /tactile_viz/finger1_heatmap
-      Value: true
-    - Class: rviz_default_plugins/Image
-      Enabled: true
-      Max Value: 1
-      Median window: 5
-      Min Value: 0
-      Name: Finger 2 Pressure Image
-      Normalize Range: true
-      Topic:
-        Depth: 5
-        Durability Policy: Volatile
-        History Policy: Keep Last
-        Reliability Policy: Reliable
-        Value: /tactile_viz/finger2_heatmap
       Value: true
   Enabled: true
   Global Options:

--- a/robotiq_tsf/rviz/tactile_viz.rviz
+++ b/robotiq_tsf/rviz/tactile_viz.rviz
@@ -1,0 +1,141 @@
+Panels:
+  - Class: rviz_common/Displays
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /TF1
+      Splitter Ratio: 0.5
+    Tree Height: 776
+  - Class: rviz_common/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 0.009999999776482582
+      Class: rviz_default_plugins/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 20
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz_default_plugins/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        tactile_finger_0:
+          Value: true
+        tactile_finger_1:
+          Value: true
+        tactile_tip:
+          Value: true
+        tactile_world:
+          Value: true
+      Marker Scale: 0.05000000074505806
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        tactile_world:
+          tactile_finger_0:
+            {}
+          tactile_finger_1:
+            {}
+          tactile_tip:
+            {}
+      Update Interval: 0
+      Value: true
+    - Class: rviz_default_plugins/MarkerArray
+      Enabled: true
+      Name: TactileMarkers
+      Namespaces:
+        tactile_finger_0: true
+        tactile_finger_1: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /tactile/markers
+      Value: true
+    - Class: rviz_default_plugins/Image
+      Enabled: true
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Finger 1 Pressure Image
+      Normalize Range: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /tactile_viz/finger1_heatmap
+      Value: true
+    - Class: rviz_default_plugins/Image
+      Enabled: true
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Finger 2 Pressure Image
+      Normalize Range: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /tactile_viz/finger2_heatmap
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: tactile_world
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
+  Value: true
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Distance: 0.2
+      Focal Point:
+        X: 0.0
+        Y: 0.0
+        Z: 0.0
+      Name: Current View
+      Near Clip Distance: 0.0010000000474974513
+      Pitch: 0.3
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz_default_plugins)
+      Yaw: 0.875
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1000
+  Hide Left Dock: false
+  Hide Right Dock: false
+  Width: 1600
+  X: 100
+  Y: 100

--- a/robotiq_tsf/scripts/tactile_viz_node
+++ b/robotiq_tsf/scripts/tactile_viz_node
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Minimal RViz visualization for the Robotiq TSF-85.
+
+Subscribes to the raw ``robotiq_tsf/StaticData`` topic (two 4x7 taxel pads) and
+republishes it in forms RViz can draw:
+  * a ``visualization_msgs/MarkerArray`` of colored CUBE markers (one per taxel)
+    on ``/tactile/markers``, with static TFs standing the two pads up facing each
+    other, and
+  * one ``sensor_msgs/Image`` heatmap per finger for RViz Image displays.
+
+"""
+from __future__ import annotations
+
+import math
+from typing import List, Sequence, Tuple
+
+import numpy as np
+import rclpy
+from builtin_interfaces.msg import Duration
+from geometry_msgs.msg import Point, Quaternion, TransformStamped, Vector3
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, qos_profile_sensor_data
+from rclpy.time import Time
+from robotiq_tsf.msg import StaticData
+from sensor_msgs.msg import Image
+from std_msgs.msg import ColorRGBA, Empty
+from tf2_ros import StaticTransformBroadcaster
+from visualization_msgs.msg import Marker, MarkerArray
+
+_GRID_ROWS = 7
+_GRID_COLS = 4
+_TAXELS = _GRID_ROWS*_GRID_COLS
+
+
+def _rpy_to_quat(roll: float, pitch: float, yaw: float) -> Quaternion:
+    # Hand-rolled: rclpy has no euler->quat helper; the alternative is the
+    # tf_transformations package (+ transforms3d), two deps for one call site.
+    cr, sr = math.cos(roll*0.5), math.sin(roll*0.5)
+    cp, sp = math.cos(pitch*0.5), math.sin(pitch*0.5)
+    cy, sy = math.cos(yaw*0.5), math.sin(yaw*0.5)
+    q = Quaternion()
+    q.w = cr*cp*cy + sr*sp*sy
+    q.x = sr*cp*cy - cr*sp*sy
+    q.y = cr*sp*cy + sr*cp*sy
+    q.z = cr*cp*sy - sr*sp*cy
+    return q
+
+
+def _colormap(t: float) -> Tuple[float, float, float]:
+    """Map a scalar in [0,1] to (r,g,b) via a 4-stop navy->cyan->yellow->red ramp."""
+    t = max(0.0, min(1.0, t))
+    stops = (
+        (0.0, (0.05, 0.05, 0.35)),
+        (1.0/3.0, (0.0, 0.7, 0.9)),
+        (2.0/3.0, (1.0, 0.95, 0.2)),
+        (1.0, (0.9, 0.1, 0.1)),
+    )
+    for i in range(len(stops) - 1):
+        x0, c0 = stops[i]
+        x1, c1 = stops[i + 1]
+        if t <= x1:
+            f = 0.0 if x1 == x0 else (t - x0)/(x1 - x0)
+            return (
+                c0[0] + f*(c1[0] - c0[0]),
+                c0[1] + f*(c1[1] - c0[1]),
+                c0[2] + f*(c1[2] - c0[2]),
+            )
+    return stops[-1][1]
+
+
+class TactileVizNode(Node):
+
+    def __init__(self, **node_kwargs) -> None:
+        super().__init__('tactile_viz', **node_kwargs)
+
+        self.declare_parameter('input_topic', 'TactileSensor/StaticData')
+        self.declare_parameter('marker_topic', '/tactile/markers')
+        self.declare_parameter('frame_id_world', 'tactile_world')
+        self.declare_parameter('frame_id_finger_0', 'tactile_finger_0')
+        self.declare_parameter('frame_id_finger_1', 'tactile_finger_1')
+        self.declare_parameter('frame_id_tip', 'tactile_tip')
+        # 4x7 array: Y = 4 cols x 5.5 mm, Z = 7 rows x ~5.29 mm.
+        self.declare_parameter('taxel_pitch_y_m', 0.022/4)
+        self.declare_parameter('taxel_pitch_z_m', 0.037/7)
+        self.declare_parameter('taxel_size_m', 0.005)
+        # Pads sit ±42.5 mm along X, finger 1 yawed by pi to face finger 0.
+        self.declare_parameter('finger_0_xyz', [-0.0425, 0.0, 0.0])
+        self.declare_parameter('finger_0_rpy', [0.0, 0.0, 0.0])
+        self.declare_parameter('finger_1_xyz', [0.0425, 0.0, 0.0])
+        self.declare_parameter('finger_1_rpy', [0.0, 0.0, math.pi])
+        self.declare_parameter('tip_xyz', [0.0, 0.0, 0.0209])
+        self.declare_parameter('tip_rpy', [0.0, 0.0, 0.0])
+        self.declare_parameter('vmin', 0.0)
+        self.declare_parameter('vmax', 700.0)
+        # Set true only if one pad is physically wired with reversed columns.
+        self.declare_parameter('flip_finger_1', False)
+        self.declare_parameter('publish_2d_heatmaps', True)
+        self.declare_parameter('heatmap_topic_finger_0', '/tactile_viz/finger1_heatmap')
+        self.declare_parameter('heatmap_topic_finger_1', '/tactile_viz/finger2_heatmap')
+        self.declare_parameter('heatmap_scale_px', 20)
+        self.declare_parameter('heatmap_publish_hz', 30.0)
+        self.declare_parameter('heatmap_autoscale', True)
+        self.declare_parameter('heatmap_floor', 50.0)
+        self.declare_parameter('publish_static_tfs', True)
+        self.declare_parameter('qos', 'sensor_data')
+        # Baseline zeroing: raw StaticData carries a large per-taxel offset, so
+        # without subtraction every cell saturates. Capture a baseline over the
+        # first N frames (keep the sensor untouched at startup) and subtract it;
+        # re-zero any time by publishing std_msgs/Empty on ``zero_topic``.
+        self.declare_parameter('zero_on_start', True)
+        self.declare_parameter('baseline_frames', 500)
+        self.declare_parameter('zero_topic', '/tactile_viz/zero')
+        # Residuals below this (post-baseline) render as zero, so sensor noise
+        # doesn't flash the display. Mirrors the demo's noise floor. Raise if
+        # noise still shows; lower for sensitivity to light touches.
+        self.declare_parameter('noise_floor', 50.0)
+
+        p = self.get_parameter
+        input_topic = str(p('input_topic').value)
+        marker_topic = str(p('marker_topic').value)
+        self._world_frame = str(p('frame_id_world').value)
+        self._frame_ids = [
+            str(p('frame_id_finger_0').value),
+            str(p('frame_id_finger_1').value),
+        ]
+        self._tip_frame_id = str(p('frame_id_tip').value)
+        self._pitch_y = float(p('taxel_pitch_y_m').value)
+        self._pitch_z = float(p('taxel_pitch_z_m').value)
+        self._size = float(p('taxel_size_m').value)
+        self._poses = [
+            (list(p('finger_0_xyz').value), list(p('finger_0_rpy').value)),
+            (list(p('finger_1_xyz').value), list(p('finger_1_rpy').value)),
+        ]
+        self._tip_pose = (list(p('tip_xyz').value), list(p('tip_rpy').value))
+        self._vmin = float(p('vmin').value)
+        self._vmax = float(p('vmax').value)
+        if self._vmax <= self._vmin:
+            self._vmax = self._vmin + 1.0
+        self._flip_f1 = bool(p('flip_finger_1').value)
+        self._publish_2d_heatmaps = bool(p('publish_2d_heatmaps').value)
+        heatmap_topics = [
+            str(p('heatmap_topic_finger_0').value),
+            str(p('heatmap_topic_finger_1').value),
+        ]
+        self._heatmap_scale = max(1, int(p('heatmap_scale_px').value))
+        heatmap_hz = float(p('heatmap_publish_hz').value)
+        self._heatmap_interval_ns = int(1e9/heatmap_hz) if heatmap_hz > 0.0 else 0
+        self._heatmap_autoscale = bool(p('heatmap_autoscale').value)
+        self._heatmap_floor = float(p('heatmap_floor').value)
+        self._heatmap_scale_max = [1.0, 1.0]
+        self._last_heatmap_publish_ns = 0
+
+        self._baseline_frames = max(1, int(p('baseline_frames').value))
+        zero_topic = str(p('zero_topic').value)
+        self._noise_floor = float(p('noise_floor').value)
+        self._baseline = None          # (2, _TAXELS) once captured
+        self._baseline_accum = None
+        self._baseline_n = 0
+        self._collecting = bool(p('zero_on_start').value)
+
+        # Subscription QoS matches the driver (SensorDataQoS = best effort).
+        sub_qos = QoSProfile(depth=10) if str(p('qos').value).lower() == 'reliable' \
+            else qos_profile_sensor_data
+        # RViz's MarkerArray/Image displays subscribe RELIABLE by default, and a
+        # best-effort publisher can't satisfy a reliable subscriber (RViz would
+        # receive nothing). Publish the viz topics RELIABLE — they're low-rate.
+        pub_qos = QoSProfile(depth=10)
+
+        if bool(p('publish_static_tfs').value):
+            self._tf_broadcaster = StaticTransformBroadcaster(self)
+            self._publish_static_tfs()
+
+        self._marker_pub = self.create_publisher(MarkerArray, marker_topic, pub_qos)
+        self._heatmap_pubs = []
+        if self._publish_2d_heatmaps:
+            self._heatmap_pubs = [
+                self.create_publisher(Image, heatmap_topics[0], pub_qos),
+                self.create_publisher(Image, heatmap_topics[1], pub_qos),
+            ]
+
+        self._sub = self.create_subscription(StaticData, input_topic, self._on_data, sub_qos)
+        self._zero_sub = self.create_subscription(Empty, zero_topic, self._on_zero, pub_qos)
+
+        self.get_logger().info(
+            f'tactile_viz: subscribed to "{input_topic}", publishing MarkerArray on '
+            f'"{marker_topic}"'
+            + (f' and 2D heatmaps on "{heatmap_topics[0]}", "{heatmap_topics[1]}"'
+               if self._publish_2d_heatmaps else ''))
+
+    def _publish_static_tfs(self) -> None:
+        now = self.get_clock().now().to_msg()
+        transforms: List[TransformStamped] = []
+        for fi in (0, 1):
+            xyz, rpy = self._poses[fi]
+            t = TransformStamped()
+            t.header.stamp = now
+            t.header.frame_id = self._world_frame
+            t.child_frame_id = self._frame_ids[fi]
+            # float(): rosidl float64 fields reject ints, and *_xyz parameter
+            # overrides like [0, 0, -1] arrive as integer arrays.
+            t.transform.translation = Vector3(x=float(xyz[0]), y=float(xyz[1]), z=float(xyz[2]))
+            t.transform.rotation = _rpy_to_quat(rpy[0], rpy[1], rpy[2])
+            transforms.append(t)
+        tip_xyz, tip_rpy = self._tip_pose
+        tip = TransformStamped()
+        tip.header.stamp = now
+        tip.header.frame_id = self._world_frame
+        tip.child_frame_id = self._tip_frame_id
+        tip.transform.translation = Vector3(
+            x=float(tip_xyz[0]), y=float(tip_xyz[1]), z=float(tip_xyz[2]))
+        tip.transform.rotation = _rpy_to_quat(tip_rpy[0], tip_rpy[1], tip_rpy[2])
+        transforms.append(tip)
+        self._tf_broadcaster.sendTransform(transforms)
+
+    def _extract_values(self, msg) -> List[np.ndarray]:
+        out: List[np.ndarray] = []
+        for fi in (0, 1):
+            values = msg.taxels[fi].values
+            if len(values) != _TAXELS:
+                self.get_logger().warn(
+                    f'finger_{fi}: expected {_TAXELS} taxels, got {len(values)}',
+                    throttle_duration_sec=2.0)
+                return []
+            out.append(np.asarray(values, dtype=np.float64))
+        return out
+
+    def _on_zero(self, msg) -> None:
+        del msg
+        self._baseline = None
+        self._baseline_accum = None
+        self._baseline_n = 0
+        self._collecting = True
+        self.get_logger().info('re-zeroing: recapturing baseline')
+
+    def _on_data(self, msg) -> None:
+        values = self._extract_values(msg)
+        if not values:
+            return
+
+        # Baseline capture / subtraction. While collecting, accumulate the
+        # first N frames; once done, subtract the per-taxel baseline (clamped
+        # at 0) so the display shows pressure deltas rather than raw offsets.
+        stack = np.stack(values).astype(np.float64)  # (2, _TAXELS)
+        if self._collecting:
+            if self._baseline_accum is None:
+                self._baseline_accum = np.zeros((2, _TAXELS))
+                self._baseline_n = 0
+            self._baseline_accum += stack
+            self._baseline_n += 1
+            if self._baseline_n == 1 or self._baseline_n % 100 == 0:
+                self.get_logger().info(
+                    f'calibrating baseline: {self._baseline_n}/'
+                    f'{self._baseline_frames} (keep the sensor untouched)')
+            if self._baseline_n >= self._baseline_frames:
+                self._baseline = self._baseline_accum/self._baseline_n
+                self._collecting = False
+                self.get_logger().info(
+                    f'baseline captured over {self._baseline_n} frames; '
+                    'showing pressure deltas')
+            # While calibrating, display zeros so the panels don't saturate.
+            stack = np.zeros((2, _TAXELS))
+        elif self._baseline is not None:
+            stack = np.clip(stack - self._baseline, 0.0, None)
+            if self._noise_floor > 0.0:
+                stack = np.where(stack >= self._noise_floor, stack, 0.0)
+        values = [stack[0], stack[1]]
+
+        stamp = Time().to_msg()  # "latest available transform" for RViz
+        array = MarkerArray()
+        grids: List[np.ndarray] = []
+        for fi in (0, 1):
+            grid = values[fi].reshape(_GRID_ROWS, _GRID_COLS)
+            if fi == 1 and self._flip_f1:
+                grid = grid[:, ::-1]
+            grids.append(grid)
+            array.markers.extend(self._build_markers(fi, grid, stamp))
+        self._marker_pub.publish(array)
+        self._publish_heatmaps(grids)
+
+    def _build_markers(self, fi: int, grid: np.ndarray, stamp) -> Sequence[Marker]:
+        markers: List[Marker] = []
+        frame = self._frame_ids[fi]
+        y_half = (_GRID_COLS - 1)*0.5*self._pitch_y
+        z_half = (_GRID_ROWS - 1)*0.5*self._pitch_z
+        span = self._vmax - self._vmin
+        for r in range(_GRID_ROWS):
+            for c in range(_GRID_COLS):
+                idx = r*_GRID_COLS + c
+                rr, gg, bb = _colormap((float(grid[r, c]) - self._vmin)/span)
+                m = Marker()
+                m.header.frame_id = frame
+                m.header.stamp = stamp
+                m.ns = f'tactile_finger_{fi}'
+                m.id = idx
+                m.type = Marker.CUBE
+                m.action = Marker.ADD
+                m.pose.position = Point(
+                    x=0.0, y=y_half - c*self._pitch_y, z=z_half - r*self._pitch_z)
+                m.pose.orientation.w = 1.0
+                m.scale = Vector3(x=self._size, y=self._size, z=self._size)
+                m.color = ColorRGBA(r=rr, g=gg, b=bb, a=1.0)
+                m.lifetime = Duration(sec=0, nanosec=0)
+                markers.append(m)
+        return markers
+
+    def _publish_heatmaps(self, grids: Sequence[np.ndarray]) -> None:
+        if not self._publish_2d_heatmaps:
+            return
+        for fi, grid in enumerate(grids):
+            local_max = float(np.nanmax(grid)) if grid.size else 0.0
+            if local_max > self._heatmap_scale_max[fi]:
+                self._heatmap_scale_max[fi] = local_max
+        now = self.get_clock().now()
+        now_ns = now.nanoseconds
+        if (self._heatmap_interval_ns > 0 and self._last_heatmap_publish_ns
+                and now_ns - self._last_heatmap_publish_ns < self._heatmap_interval_ns):
+            return
+        self._last_heatmap_publish_ns = now_ns
+        stamp = now.to_msg()
+        for fi, grid in enumerate(grids):
+            msg = self._grid_to_image(fi, grid)
+            msg.header.stamp = stamp
+            msg.header.frame_id = self._frame_ids[fi]
+            self._heatmap_pubs[fi].publish(msg)
+
+    def _grid_to_image(self, fi: int, grid: np.ndarray) -> Image:
+        if self._heatmap_floor > 0.0:
+            grid = np.where(grid >= self._heatmap_floor, grid, 0.0)
+        if self._heatmap_autoscale:
+            norm = np.clip(grid/max(self._heatmap_scale_max[fi], 1.0), 0.0, 1.0)
+        else:
+            norm = np.clip((grid - self._vmin)/(self._vmax - self._vmin), 0.0, 1.0)
+        rgb = np.empty((_GRID_ROWS, _GRID_COLS, 3), dtype=np.uint8)
+        for r in range(_GRID_ROWS):
+            for c in range(_GRID_COLS):
+                rr, gg, bb = _colormap(float(norm[r, c]))
+                rgb[r, c] = (round(rr*255.0), round(gg*255.0), round(bb*255.0))
+        scale = self._heatmap_scale
+        if scale > 1:
+            rgb = np.repeat(np.repeat(rgb, scale, axis=0), scale, axis=1)
+        msg = Image()
+        msg.height = int(rgb.shape[0])
+        msg.width = int(rgb.shape[1])
+        msg.encoding = 'rgb8'
+        msg.is_bigendian = 0
+        msg.step = int(msg.width*3)
+        msg.data = rgb.tobytes()
+        return msg
+
+
+def main(args=None) -> None:
+    rclpy.init(args=args)
+    node = TactileVizNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/robotiq_tsf/scripts/tactile_viz_node
+++ b/robotiq_tsf/scripts/tactile_viz_node
@@ -95,12 +95,15 @@ class TactileVizNode(Node):
         # Set true only if one pad is physically wired with reversed columns.
         self.declare_parameter('flip_finger_1', False)
         self.declare_parameter('publish_2d_heatmaps', True)
-        self.declare_parameter('heatmap_topic_finger_0', '/tactile_viz/finger1_heatmap')
-        self.declare_parameter('heatmap_topic_finger_1', '/tactile_viz/finger2_heatmap')
+        self.declare_parameter('heatmap_topic_finger_0', '/tactile_viz/finger0_heatmap')
+        self.declare_parameter('heatmap_topic_finger_1', '/tactile_viz/finger1_heatmap')
         self.declare_parameter('heatmap_scale_px', 20)
         self.declare_parameter('heatmap_publish_hz', 30.0)
         self.declare_parameter('heatmap_autoscale', True)
-        self.declare_parameter('heatmap_floor', 50.0)
+        # Extra heatmap-only floor on top of noise_floor (which already zeroes
+        # small residuals for markers AND heatmaps). Leave at 0 unless the
+        # heatmaps specifically need a harsher cutoff than the 3D view.
+        self.declare_parameter('heatmap_floor', 0.0)
         self.declare_parameter('publish_static_tfs', True)
         self.declare_parameter('qos', 'sensor_data')
         # Baseline zeroing: raw StaticData carries a large per-taxel offset, so
@@ -136,6 +139,9 @@ class TactileVizNode(Node):
         self._vmax = float(p('vmax').value)
         if self._vmax <= self._vmin:
             self._vmax = self._vmin + 1.0
+            self.get_logger().warn(
+                f'vmax ({p("vmax").value}) <= vmin ({self._vmin}); '
+                f'using vmax = {self._vmax}')
         self._flip_f1 = bool(p('flip_finger_1').value)
         self._publish_2d_heatmaps = bool(p('publish_2d_heatmaps').value)
         heatmap_topics = [
@@ -300,6 +306,9 @@ class TactileVizNode(Node):
                 m.scale = Vector3(x=self._size, y=self._size, z=self._size)
                 m.color = ColorRGBA(r=rr, g=gg, b=bb, a=1.0)
                 m.lifetime = Duration(sec=0, nanosec=0)
+                # Re-transform every render frame — the pad frames move with
+                # the gripper fingers between marker updates.
+                m.frame_locked = True
                 markers.append(m)
         return markers
 

--- a/robotiq_tsf/test/CMakeLists.txt
+++ b/robotiq_tsf/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(ament_cmake_gtest REQUIRED)
+find_package(ament_cmake_pytest REQUIRED)
 
 ament_add_gtest(test_madgwick_ahrs
   test_madgwick_ahrs.cpp
@@ -6,3 +7,8 @@ ament_add_gtest(test_madgwick_ahrs
   SKIP_LINKING_MAIN_LIBRARIES
 )
 target_link_libraries(test_madgwick_ahrs ${PROJECT_NAME}_algorithms)
+
+# Unit tests for scripts/tactile_viz_node (drives the node callbacks directly;
+# needs this package's generated Python messages, hence the deferred import
+# path added by colcon at test time).
+ament_add_pytest_test(test_tactile_viz test_tactile_viz.py TIMEOUT 120)

--- a/robotiq_tsf/test/test_tactile_viz.py
+++ b/robotiq_tsf/test/test_tactile_viz.py
@@ -270,3 +270,55 @@ def test_wrong_taxel_count_is_dropped():
         assert node._marker_pub.msgs == []     # dropped, nothing published
     finally:
         node.destroy_node()
+
+
+def test_publish_static_tfs():
+    class RecordingBroadcaster:
+        def __init__(self):
+            self.transforms = []
+
+        def sendTransform(self, transforms):
+            self.transforms.extend(transforms)
+
+    node = make_node(zero_on_start=False)
+    try:
+        bc = RecordingBroadcaster()
+        node._tf_broadcaster = bc
+        node._publish_static_tfs()
+        assert [t.child_frame_id for t in bc.transforms] == [
+            'tactile_finger_0', 'tactile_finger_1', 'tactile_tip']
+        assert all(t.header.frame_id == 'tactile_world' for t in bc.transforms)
+        f0, f1, tip = bc.transforms
+        assert f0.transform.translation.x == pytest.approx(-0.0425)
+        assert f1.transform.translation.x == pytest.approx(0.0425)
+        assert tip.transform.translation.z == pytest.approx(0.0209)
+        assert f0.transform.rotation.w == pytest.approx(1.0)
+        q = f1.transform.rotation                # finger 1 yawed pi to face finger 0
+        assert (q.w, q.x, q.y, abs(q.z)) == pytest.approx((0.0, 0.0, 0.0, 1.0), abs=1e-9)
+    finally:
+        node.destroy_node()
+
+
+def test_heatmap_pixel_orientation():
+    # Ramp value = r*COLS + c: every pixel unique, pinning the image's
+    # row/column orientation, not just pixel (0,0).
+    ramp = list(range(TAXELS))
+    node = make_node(zero_on_start=False, heatmap_scale_px=1,
+                     heatmap_publish_hz=0.0, heatmap_autoscale=False,
+                     vmin=0.0, vmax=float(TAXELS - 1), noise_floor=0.0)
+    try:
+        node._on_data(make_msg(ramp, ramp))
+        img = node._heatmap_pubs[0].msgs[-1]
+
+        def px(r, c):
+            o = (r*img.width + c)*3
+            return bytes(img.data[o:o + 3])
+
+        def expected(r, c):
+            t = (r*COLS + c)/(TAXELS - 1)
+            return bytes(round(v*255) for v in viz._colormap(t))
+
+        for r, c in [(0, 0), (0, 3), (2, 1), (4, 3), (6, 0), (6, 3)]:
+            assert px(r, c) == expected(r, c), f'pixel ({r},{c})'
+    finally:
+        node.destroy_node()

--- a/robotiq_tsf/test/test_tactile_viz.py
+++ b/robotiq_tsf/test/test_tactile_viz.py
@@ -1,0 +1,272 @@
+"""Unit tests for scripts/tactile_viz_node (baseline zeroing, noise floor,
+marker/heatmap generation, colormap, rpy->quat).
+
+The script has no .py extension, so it is loaded via importlib; the node's
+callbacks are driven directly with constructed StaticData messages and the
+publishers are replaced with recording stubs — no executor or driver needed.
+"""
+import importlib.machinery
+import importlib.util
+import math
+import pathlib
+
+import pytest
+import rclpy
+from rclpy.parameter import Parameter
+from robotiq_tsf.msg import StaticData
+
+_SCRIPT = pathlib.Path(__file__).resolve().parent.parent / 'scripts' / 'tactile_viz_node'
+_loader = importlib.machinery.SourceFileLoader('tactile_viz_node', str(_SCRIPT))
+_spec = importlib.util.spec_from_loader('tactile_viz_node', _loader)
+viz = importlib.util.module_from_spec(_spec)
+_loader.exec_module(viz)
+
+ROWS, COLS, TAXELS = viz._GRID_ROWS, viz._GRID_COLS, viz._TAXELS
+NAVY = (0.05, 0.05, 0.35)
+RED = (0.9, 0.1, 0.1)
+
+
+class _RecordingPub:
+    def __init__(self):
+        self.msgs = []
+
+    def publish(self, msg):
+        self.msgs.append(msg)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def ros():
+    rclpy.init()
+    yield
+    rclpy.try_shutdown()
+
+
+def make_node(**params):
+    overrides = [Parameter(k, value=v) for k, v in params.items()]
+    node = viz.TactileVizNode(parameter_overrides=overrides,
+                              start_parameter_services=False)
+    node._marker_pub = _RecordingPub()
+    node._heatmap_pubs = [_RecordingPub(), _RecordingPub()]
+    return node
+
+
+def make_msg(f0=0, f1=None):
+    """StaticData with constant (or per-taxel list) values per finger."""
+    msg = StaticData()
+    for fi, v in enumerate((f0, f0 if f1 is None else f1)):
+        values = [v]*TAXELS if isinstance(v, int) else list(v)
+        msg.taxels[fi].values = values
+    return msg
+
+
+def marker_values(node):
+    """Colors of the last published MarkerArray, as [(r, g, b)] per finger."""
+    array = node._marker_pub.msgs[-1]
+    assert len(array.markers) == 2*TAXELS
+    out = [[], []]
+    for m in array.markers:
+        fi = int(m.ns[-1])
+        out[fi].append((m.color.r, m.color.g, m.color.b))
+    return out
+
+
+def test_colormap_endpoints_and_clamp():
+    assert viz._colormap(0.0) == pytest.approx(NAVY)
+    assert viz._colormap(1.0) == pytest.approx(RED)
+    assert viz._colormap(-5.0) == pytest.approx(NAVY)
+    assert viz._colormap(5.0) == pytest.approx(RED)
+    assert viz._colormap(1.0/3.0) == pytest.approx((0.0, 0.7, 0.9))
+    assert viz._colormap(2.0/3.0) == pytest.approx((1.0, 0.95, 0.2))
+
+
+def test_colormap_is_continuous():
+    prev = viz._colormap(0.0)
+    for i in range(1, 101):
+        cur = viz._colormap(i/100.0)
+        assert all(abs(a - b) < 0.05 for a, b in zip(prev, cur))
+        prev = cur
+
+
+def test_rpy_to_quat():
+    q = viz._rpy_to_quat(0.0, 0.0, 0.0)
+    assert (q.w, q.x, q.y, q.z) == pytest.approx((1.0, 0.0, 0.0, 0.0))
+    q = viz._rpy_to_quat(0.0, 0.0, math.pi)
+    assert (q.w, q.x, q.y, q.z) == pytest.approx((0.0, 0.0, 0.0, 1.0), abs=1e-9)
+    q = viz._rpy_to_quat(math.pi/2, 0.0, 0.0)
+    assert (q.w, q.x, q.y, q.z) == pytest.approx(
+        (math.cos(math.pi/4), math.sin(math.pi/4), 0.0, 0.0))
+    q = viz._rpy_to_quat(0.3, -0.7, 1.1)
+    assert q.w**2 + q.x**2 + q.y**2 + q.z**2 == pytest.approx(1.0)
+
+
+def test_markers_zero_during_baseline_capture():
+    node = make_node(baseline_frames=3)
+    try:
+        node._on_data(make_msg(600))
+        for finger in marker_values(node):
+            assert all(c == pytest.approx(NAVY) for c in finger)
+    finally:
+        node.destroy_node()
+
+
+def test_baseline_subtraction_and_noise_floor():
+    node = make_node(baseline_frames=2, noise_floor=50.0, vmin=0.0, vmax=700.0)
+    try:
+        node._on_data(make_msg(1000))
+        node._on_data(make_msg(1000))          # baseline = 1000 captured
+
+        node._on_data(make_msg(1049))          # residual 49 < floor -> zero
+        for finger in marker_values(node):
+            assert all(c == pytest.approx(NAVY) for c in finger)
+
+        node._on_data(make_msg(1050))          # residual 50 == floor -> kept
+        expected = viz._colormap(50.0/700.0)
+        for finger in marker_values(node):
+            assert all(c == pytest.approx(expected) for c in finger)
+
+        node._on_data(make_msg(500))           # below baseline -> clamped to 0
+        for finger in marker_values(node):
+            assert all(c == pytest.approx(NAVY) for c in finger)
+    finally:
+        node.destroy_node()
+
+
+def test_rezero_recaptures_baseline():
+    node = make_node(baseline_frames=1, noise_floor=0.0)
+    try:
+        node._on_data(make_msg(100))           # baseline = 100
+        node._on_data(make_msg(300))           # residual 200
+        assert marker_values(node)[0][0] != pytest.approx(NAVY)
+
+        node._on_zero(None)
+        node._on_data(make_msg(300))           # new baseline = 300, shows zeros
+        node._on_data(make_msg(300))           # residual 0
+        for finger in marker_values(node):
+            assert all(c == pytest.approx(NAVY) for c in finger)
+    finally:
+        node.destroy_node()
+
+
+def test_no_zero_on_start_uses_raw_values():
+    node = make_node(zero_on_start=False, noise_floor=0.0, vmin=0.0, vmax=700.0)
+    try:
+        node._on_data(make_msg(700))
+        for finger in marker_values(node):
+            assert all(c == pytest.approx(RED) for c in finger)
+    finally:
+        node.destroy_node()
+
+
+def test_marker_geometry_and_ids():
+    node = make_node(zero_on_start=False)
+    try:
+        node._on_data(make_msg(0))
+        array = node._marker_pub.msgs[-1]
+        f0 = [m for m in array.markers if m.ns == 'tactile_finger_0']
+        assert sorted(m.id for m in f0) == list(range(TAXELS))
+        assert all(m.header.frame_id == 'tactile_finger_0' for m in f0)
+        pitch_y, pitch_z = 0.022/4, 0.037/7
+        y_half = (COLS - 1)*0.5*pitch_y
+        z_half = (ROWS - 1)*0.5*pitch_z
+        top_left = next(m for m in f0 if m.id == 0)          # r=0, c=0
+        assert top_left.pose.position.y == pytest.approx(y_half)
+        assert top_left.pose.position.z == pytest.approx(z_half)
+        bottom_right = next(m for m in f0 if m.id == TAXELS - 1)
+        assert bottom_right.pose.position.y == pytest.approx(-y_half)
+        assert bottom_right.pose.position.z == pytest.approx(-z_half)
+    finally:
+        node.destroy_node()
+
+
+def test_flip_finger_1_reverses_columns():
+    ramp = list(range(TAXELS))                 # distinct value per taxel
+    node = make_node(zero_on_start=False, flip_finger_1=True, noise_floor=0.0)
+    try:
+        node._on_data(make_msg(ramp, ramp))
+        array = node._marker_pub.msgs[-1]
+        by_id = {m.id: m for m in array.markers if m.ns == 'tactile_finger_1'}
+        ref = {m.id: m for m in array.markers if m.ns == 'tactile_finger_0'}
+        for r in range(ROWS):
+            for c in range(COLS):
+                flipped = by_id[r*COLS + c].color
+                straight = ref[r*COLS + (COLS - 1 - c)].color
+                assert (flipped.r, flipped.g, flipped.b) == pytest.approx(
+                    (straight.r, straight.g, straight.b))
+    finally:
+        node.destroy_node()
+
+
+def test_heatmap_image_shape_and_scaling():
+    node = make_node(zero_on_start=False, heatmap_scale_px=10,
+                     heatmap_publish_hz=0.0, heatmap_floor=0.0)
+    try:
+        node._on_data(make_msg(100))
+        for pub in node._heatmap_pubs:
+            img = pub.msgs[-1]
+            assert (img.height, img.width) == (ROWS*10, COLS*10)
+            assert img.encoding == 'rgb8'
+            assert img.step == img.width*3
+            assert len(img.data) == img.height*img.step
+    finally:
+        node.destroy_node()
+
+
+def test_heatmap_autoscale_tracks_running_max():
+    node = make_node(zero_on_start=False, heatmap_scale_px=1,
+                     heatmap_publish_hz=0.0, heatmap_floor=0.0,
+                     heatmap_autoscale=True)
+    def px(t):
+        return bytes(round(v*255) for v in viz._colormap(t))
+
+    try:
+        node._on_data(make_msg(200))           # max: 200 -> full scale
+        assert bytes(node._heatmap_pubs[0].msgs[-1].data[0:3]) == px(1.0)
+
+        node._on_data(make_msg(400))           # new max: 400, still full scale
+        assert bytes(node._heatmap_pubs[0].msgs[-1].data[0:3]) == px(1.0)
+
+        node._on_data(make_msg(200))           # now mid-scale vs max 400
+        assert bytes(node._heatmap_pubs[0].msgs[-1].data[0:3]) == px(0.5)
+    finally:
+        node.destroy_node()
+
+
+def test_heatmap_rate_limit():
+    node = make_node(zero_on_start=False, heatmap_publish_hz=1.0,
+                     heatmap_scale_px=1)
+    try:
+        node._on_data(make_msg(100))
+        node._on_data(make_msg(100))           # within 1s window -> throttled
+        assert len(node._heatmap_pubs[0].msgs) == 1
+        assert len(node._marker_pub.msgs) == 2  # markers are never throttled
+    finally:
+        node.destroy_node()
+
+
+def test_heatmaps_disabled():
+    node = make_node(zero_on_start=False, publish_2d_heatmaps=False)
+    try:
+        node._heatmap_pubs = []
+        node._on_data(make_msg(100))
+        assert len(node._marker_pub.msgs) == 1
+    finally:
+        node.destroy_node()
+
+
+def test_wrong_taxel_count_is_dropped():
+    # rosidl's fixed-size array can't carry a short payload, so exercise the
+    # guard with a duck-typed message (e.g. a future variable-length source).
+    class FakeTaxels:
+        def __init__(self, n):
+            self.values = [0]*n
+
+    class FakeMsg:
+        def __init__(self):
+            self.taxels = [FakeTaxels(TAXELS), FakeTaxels(TAXELS - 1)]
+
+    node = make_node(zero_on_start=False)
+    try:
+        node._on_data(FakeMsg())
+        assert node._marker_pub.msgs == []     # dropped, nothing published
+    finally:
+        node.destroy_node()


### PR DESCRIPTION
## Summary

Adds RViz visualization for the TSF-85 tactile sensors: `tactile_viz_node` (Python) turns the raw `TactileSensor/StaticData` stream into per-finger heatmaps and 3D markers, with two ready-to-use launches and RViz configs.

- **`tactile_viz_node`** (`robotiq_tsf/scripts/`): subscribes to `StaticData`, publishes
  - `visualization_msgs/MarkerArray` on `/tactile/markers` (per-taxel 3D cells on each finger pad),
  - two `sensor_msgs/Image` heatmaps (one per finger) on `/tactile_viz/finger{1,2}_heatmap`,
  - the pad TFs (optional — `publish_static_tfs`).

  On startup it averages the first `baseline_frames` messages into a per-taxel baseline and subtracts it (raw taxels carry a large DC offset per cell); re-zero anytime via `std_msgs/Empty` on `/tactile_viz/zero`. Residuals below `noise_floor` render quiet. Pad geometry, frames, color scale and heatmap options are all parameters.
- **`tactile_viz.launch.py`**: driver + viz + RViz, minimal standalone view.
- **`gripper_tactile_viz.launch.py`**: single-window combined view — 2F-85 gripper bringup (`robotiq_description`) with the tactile pads TF-mounted on the fingertip links, so the heatmaps follow the fingers as the gripper opens/closes. Delays the viz start (`tactile_delay`, default 8 s) so the baseline is captured after gripper activation, with the pads clear.
- Install rules for `scripts/`, `launch/`, `rviz/`; `package.xml` exec deps; `.gitignore` for `__pycache__`/`*.pyc`.
- README: "Tactile visualization (RViz)" section under TSF-85 — launches, common args, topics, baseline zeroing/re-zero.

Both launches drive the existing `poll_data_node`. A `poller:=` launch arg (default `poll_data_node`) lets you swap the driver executable without touching the launch files.

## Note on data quality

Depending on the USB enumeration state (it can toggle with a replug), `poll_data_node` intermittently emits corrupted `StaticData` on the TSF-85 (rail-to-rail 0..65535, per-taxel std in the thousands at rest), which renders as saturated/flashing heatmaps. That is a driver parsing issue, addressed separately by the SDK-backed poller PR — it does not block this PR, which is the visualization tooling. In a healthy enumeration state the heatmaps are clean (verified on hardware with `poll_data_node`, per-taxel std ~3 counts).

## Testing

- 14 unit tests (ament pytest, `test/test_tactile_viz.py`, runs in CI via `colcon test`): baseline capture/re-zero, noise floor and zero-clamping, marker geometry/ids/colors, finger-1 column flip, heatmap image shape/encoding, autoscale, publish rate limiting, malformed-input rejection, colormap and rpy→quat.
- `docker build` passes; verified the image installs the node, launches and rviz configs, and both launches parse (`--show-args`).
- Real hardware: RViz brings up the heatmap displays against `poll_data_node`; baseline zeroing and noise floor behave as intended.

## Screencasts

1.  `./run.sh sensor` and `ros2 launch robotiq_tsf tactile_viz.launch.py` in the container :

[Screencast from 2026-07-05 23-03-09.webm](https://github.com/user-attachments/assets/ccbb1e50-8702-40dc-8f2e-673c27ea3832)

2. `./run.sh both` and `ros2 launch robotiq_tsf gripper_tactile_viz.launch.py com_port:=/dev/ttyUSB0` in the container :

[Screencast from 2026-07-05 23-19-48.webm](https://github.com/user-attachments/assets/c9664c42-e305-428d-9c27-1f8347414127)

Note that the red taxel flashing in the first video is an intermittent problem that I see quite often. It is resolved by using the PollDataSdk technique that we used in the RUC demo. I will propose this in a follow-up MR. Has anyone else encountered this problem?

FYI @l-tschreiber-a11y 