### PR TITLE
fix(robotiq_tsf): force raw tty mode in poll_data_node

### DIFF
--- a/robotiq_tsf/CMakeLists.txt
+++ b/robotiq_tsf/CMakeLists.txt
@@ -71,6 +71,17 @@ target_link_libraries(${PROJECT_NAME}_algorithms
     ${OpenCV_LIBRARIES}
 )
 
+# Serial-port helpers (raw-mode tty setup). Dependency-free so the unit tests
+# can link it without pulling in OpenCV/ROS.
+add_library(${PROJECT_NAME}_serial
+  src/serial_port.cpp
+)
+target_include_directories(${PROJECT_NAME}_serial
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
 add_executable(poll_data_node src/PollData.cpp)
 target_include_directories(poll_data_node
   PRIVATE
@@ -78,6 +89,7 @@ target_include_directories(poll_data_node
 )
 target_link_libraries(poll_data_node
   ${PROJECT_NAME}_algorithms
+  ${PROJECT_NAME}_serial
   ${cpp_typesupport_target}
   ${LIBUSB_LIBRARIES}
   ${OpenCV_LIBRARIES}
@@ -109,7 +121,7 @@ ament_target_dependencies(tactile_total_sum_node
   ament_index_cpp
 )
 
-install(TARGETS ${PROJECT_NAME}_algorithms
+install(TARGETS ${PROJECT_NAME}_algorithms ${PROJECT_NAME}_serial
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
@@ -149,7 +161,7 @@ ament_export_dependencies(
 )
 
 ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME}_algorithms)
+ament_export_libraries(${PROJECT_NAME}_algorithms ${PROJECT_NAME}_serial)
 
 if(BUILD_TESTING)
   add_subdirectory(test)

--- a/robotiq_tsf/include/robotiq_tsf/serial_port.hpp
+++ b/robotiq_tsf/include/robotiq_tsf/serial_port.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace robotiq_tsf
+{
+
+// Configure an already-open tty file descriptor for the tactile sensor:
+//   * raw mode (cfmakeraw) so the binary sensor stream is delivered byte-for-byte;
+//   * 115200 baud, 8N1, no flow control;
+//   * non-blocking reads (VMIN=0, VTIME=0).
+//
+// The raw-mode step is the important one. A tty that has just been created by a
+// USB (CDC-ACM) re-enumeration comes up in *cooked* mode, where c_iflag has
+// ICRNL (translates 0x0D -> 0x0A) and IXON (consumes 0x11/0x13 as XON/XOFF).
+// Those byte values occur throughout the binary sensor stream, so without raw
+// mode the stream is silently mangled -> the packet framing desyncs -> the
+// taxels read as rail-to-rail garbage ("flashing red"). termios settings
+// persist on the tty across opens, so a reader that does not force raw mode is
+// at the mercy of whatever the previous opener left behind.
+//
+// Returns true on success, false if tcgetattr/tcsetattr failed (errno set).
+bool configureSensorTty(int fd);
+
+}  // namespace robotiq_tsf

--- a/robotiq_tsf/src/PollData.cpp
+++ b/robotiq_tsf/src/PollData.cpp
@@ -80,6 +80,7 @@ rosrun tactilesensors PollData [-device PATH_TO_DEV]
 #include "robotiq_tsf/msg/timestamp.hpp"
 #include "robotiq_tsf/srv/tactile_sensors.hpp"
 #include "robotiq_tsf/MadgwickAHRS.h"
+#include "robotiq_tsf/serial_port.hpp"
 
 #include <algorithm>
 #include <array>
@@ -666,33 +667,13 @@ bool OpenAndConfigurePort(int *USB, char const * TheDevice)
         return false;
     }
 
-    /**** Configure Port ****/
-    struct termios tty;
-    memset(&tty, 0, sizeof tty);
-    if ( tcgetattr ( (*USB), &tty ) != 0 ) {
-        cout << "Error " << errno << " from tcgetattr: " << strerror(errno) << endl;
-        return false;
-    }
-
-    /* Set Baud Rate */
-    cfsetospeed (&tty, (speed_t)B115200);
-    cfsetispeed (&tty, (speed_t)B115200);
-
-    /* Setting other Port Stuff */
-    tty.c_cflag     &=  ~PARENB;            // Make 8n1
-    tty.c_cflag     &=  ~CSTOPB;
-    tty.c_cflag     &=  ~CSIZE;
-    tty.c_lflag     &=  ~ICANON;            // Remove canonical mode
-    tty.c_cflag     |=  CS8;
-    tty.c_cflag     &=  ~CRTSCTS;           // no flow control
-    tty.c_cc[VMIN]   =  0;        // read doesn't block
-    tty.c_cc[VTIME]  =  0;       // 0.0 seconds read timeout between each byte max
-    tty.c_cflag     |=  CREAD | CLOCAL;     // turn on READ & ignore ctrl lines
-
-    /* Flush Port, then applies attributes */
-    tcflush( (*USB), TCIFLUSH );
-    if ( tcsetattr ( (*USB), TCSANOW, &tty ) != 0) {
-        cout << "Error " << errno << " from tcsetattr" << endl;
+    // Configure the port: raw mode + 115200 8N1 + non-blocking. Raw mode is
+    // essential — a freshly re-enumerated tty defaults to cooked line discipline
+    // (ICRNL/IXON), which mangles the binary sensor stream and makes the taxels
+    // read as rail-to-rail garbage ("flashing red"). See serial_port.hpp.
+    if (!robotiq_tsf::configureSensorTty(*USB))
+    {
+        cout << "Error " << errno << " configuring " << TheDevice << ": " << strerror(errno) << endl;
         return false;
     }
     return true;

--- a/robotiq_tsf/src/serial_port.cpp
+++ b/robotiq_tsf/src/serial_port.cpp
@@ -1,0 +1,34 @@
+#include "robotiq_tsf/serial_port.hpp"
+
+#include <termios.h>
+#include <unistd.h>
+
+namespace robotiq_tsf
+{
+
+bool configureSensorTty(int fd)
+{
+    struct termios tty;
+    if (tcgetattr(fd, &tty) != 0)
+        return false;
+
+    // Raw mode: clears ICRNL/IXON/INLCR/IGNCR/ISTRIP/BRKINT (c_iflag), OPOST
+    // (c_oflag) and ICANON/ECHO/ISIG/IEXTEN (c_lflag), and sets 8-bit chars.
+    // This is what keeps the binary stream from being mangled — see header.
+    cfmakeraw(&tty);
+
+    cfsetospeed(&tty, B115200);
+    cfsetispeed(&tty, B115200);
+
+    tty.c_cflag &= ~CSTOPB;             // 1 stop bit
+    tty.c_cflag &= ~CRTSCTS;            // no hardware flow control
+    tty.c_cflag |= (CREAD | CLOCAL);    // enable receiver, ignore modem control lines
+
+    tty.c_cc[VMIN] = 0;                 // non-blocking read
+    tty.c_cc[VTIME] = 0;
+
+    tcflush(fd, TCIFLUSH);
+    return tcsetattr(fd, TCSANOW, &tty) == 0;
+}
+
+}  // namespace robotiq_tsf

--- a/robotiq_tsf/test/CMakeLists.txt
+++ b/robotiq_tsf/test/CMakeLists.txt
@@ -12,3 +12,10 @@ target_link_libraries(test_madgwick_ahrs ${PROJECT_NAME}_algorithms)
 # needs this package's generated Python messages, hence the deferred import
 # path added by colcon at test time).
 ament_add_pytest_test(test_tactile_viz test_tactile_viz.py TIMEOUT 120)
+
+ament_add_gtest(test_serial_port
+  test_serial_port.cpp
+  gtest_main.cpp
+  SKIP_LINKING_MAIN_LIBRARIES
+)
+target_link_libraries(test_serial_port ${PROJECT_NAME}_serial)

--- a/robotiq_tsf/test/test_serial_port.cpp
+++ b/robotiq_tsf/test/test_serial_port.cpp
@@ -1,0 +1,110 @@
+// Hermetic test for the tactile-sensor tty configuration. Uses a pseudo-terminal
+// (PTY) so it needs no hardware: the PTY slave stands in for the sensor's
+// /dev/tty* node. The regression under test is the "flashing red" root cause —
+// a tty left in cooked mode (ICRNL/IXON/OPOST) mangles the binary sensor stream.
+// configureSensorTty() must force raw mode regardless of the tty's prior state.
+
+#include <fcntl.h>
+#include <termios.h>
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+#include "robotiq_tsf/serial_port.hpp"
+
+namespace
+{
+
+// Allocate a PTY; returns the slave fd (or -1). Master fd is returned via *master
+// and must be kept open for the slave to stay usable.
+int openPtySlave(int *master)
+{
+    int m = posix_openpt(O_RDWR | O_NOCTTY);
+    if (m < 0 || grantpt(m) != 0 || unlockpt(m) != 0)
+        return -1;
+    const char *name = ptsname(m);
+    if (!name)
+        return -1;
+    int s = open(name, O_RDWR | O_NOCTTY);
+    *master = m;
+    return s;
+}
+
+// Force the tty into cooked mode — the state a CDC-ACM tty comes up in after a
+// USB re-enumeration, which is what breaks the raw binary stream.
+void makeCooked(int fd)
+{
+    struct termios t;
+    ASSERT_EQ(tcgetattr(fd, &t), 0);
+    t.c_iflag |= (ICRNL | IXON | BRKINT | ISTRIP);
+    t.c_oflag |= OPOST;
+    t.c_lflag |= (ICANON | ECHO | ISIG | IEXTEN);
+    ASSERT_EQ(tcsetattr(fd, TCSANOW, &t), 0);
+}
+
+}  // namespace
+
+// The core regression: after configureSensorTty(), the byte-mangling flags are
+// cleared even if the tty started in cooked mode.
+TEST(SerialPort, ForcesRawModeFromCooked)
+{
+    int master = -1;
+    int slave = openPtySlave(&master);
+    ASSERT_GE(slave, 0) << "could not allocate PTY: " << strerror(errno);
+
+    makeCooked(slave);
+    // sanity: the flags that mangle binary data are set before the fix runs
+    struct termios before;
+    ASSERT_EQ(tcgetattr(slave, &before), 0);
+    ASSERT_TRUE(before.c_iflag & ICRNL);
+    ASSERT_TRUE(before.c_iflag & IXON);
+
+    ASSERT_TRUE(robotiq_tsf::configureSensorTty(slave))
+        << "configureSensorTty failed: " << strerror(errno);
+
+    struct termios after;
+    ASSERT_EQ(tcgetattr(slave, &after), 0);
+    EXPECT_FALSE(after.c_iflag & ICRNL) << "ICRNL still set: CR would be rewritten to NL";
+    EXPECT_FALSE(after.c_iflag & IXON)  << "IXON still set: 0x11/0x13 would be eaten as flow control";
+    EXPECT_FALSE(after.c_iflag & ISTRIP) << "ISTRIP still set: bytes would be stripped to 7 bits";
+    EXPECT_FALSE(after.c_oflag & OPOST) << "OPOST still set: output post-processing on";
+    EXPECT_FALSE(after.c_lflag & ICANON) << "ICANON still set: line-buffered, not raw";
+    EXPECT_FALSE(after.c_lflag & ECHO);
+
+    close(slave);
+    close(master);
+}
+
+// Applying the config to an already-raw tty must keep it raw (idempotent).
+TEST(SerialPort, IdempotentOnRawTty)
+{
+    int master = -1;
+    int slave = openPtySlave(&master);
+    ASSERT_GE(slave, 0);
+
+    ASSERT_TRUE(robotiq_tsf::configureSensorTty(slave));
+    ASSERT_TRUE(robotiq_tsf::configureSensorTty(slave));
+    struct termios t;
+    ASSERT_EQ(tcgetattr(slave, &t), 0);
+    EXPECT_FALSE(t.c_iflag & ICRNL);
+    EXPECT_FALSE(t.c_iflag & IXON);
+
+    close(slave);
+    close(master);
+}
+
+// 8-bit characters must be selected (CS8) so no data bits are lost.
+TEST(SerialPort, Sets8BitChars)
+{
+    int master = -1;
+    int slave = openPtySlave(&master);
+    ASSERT_GE(slave, 0);
+
+    ASSERT_TRUE(robotiq_tsf::configureSensorTty(slave));
+    struct termios t;
+    ASSERT_EQ(tcgetattr(slave, &t), 0);
+    EXPECT_EQ(t.c_cflag & CSIZE, CS8);
+
+    close(slave);
+    close(master);
+}


### PR DESCRIPTION
## Problem

After unplugging/replugging the sensor's USB-C, `poll_data_node` publishes
rail-to-rail garbage on `TactileSensor/StaticData` — the taxels "flash red" in
RViz — and it stays broken across restarts until something else resets the port.
Plain start/stop restarts don't trigger it; a fresh USB re-enumeration does.

## Root cause

`OpenAndConfigurePort()` read the port's existing attributes with `tcgetattr`
and only adjusted `c_cflag` and `ICANON`. It **never reset `c_iflag`**.

A freshly enumerated CDC-ACM tty comes up in *cooked* line discipline, where
`c_iflag` has `ICRNL` (translate `0x0D`→`0x0A`) and `IXON` (consume `0x11`/`0x13`
as XON/XOFF flow control). Those byte values occur constantly in the binary
sensor stream, so the incoming bytes were silently rewritten/dropped, the packet
framing desynced, and every taxel decoded as noise. Because the node wrote the
cooked flags straight back, the corruption persisted across restarts.

termios settings persist on a tty across opens, which is why the failure looked
intermittent: once any raw-mode reader had touched the port, `poll_data_node`
inherited raw mode and worked — until the next replug reset it to cooked.

This was verified on hardware: on a fresh replug the tty reads `icrnl ixon opost`
and the node produces garbage; forcing raw mode makes it read clean, single
reader, on the first start.

## Fix

Put the port in raw mode. The tty setup is factored into a small, dependency-free
`serial_port` library:

```cpp
bool configureSensorTty(int fd);  // cfmakeraw() + 115200 8N1 + non-blocking
```

`OpenAndConfigurePort()` now delegates to it. `cfmakeraw()` clears the
byte-mangling `c_iflag`/`c_oflag`/`c_lflag` bits regardless of the tty's prior
state, so the reader no longer depends on what a previous opener left behind.

## Testing

**Unit (hermetic, no hardware)** — `test_serial_port.cpp` drives a pseudo-terminal:
- `ForcesRawModeFromCooked` — start the PTY in cooked mode (`ICRNL`/`IXON`/`OPOST`
  set), run `configureSensorTty`, assert those flags are cleared. This is the
  regression guard for the bug above.
- `IdempotentOnRawTty`, `Sets8BitChars`.

**On hardware**
- 2/2 physical USB replugs: fresh tty came up cooked, fixed node read clean
  (`temporal_jit=0`, no rail hits) on the first start.
- 8/8 trials from a `stty`-forced cooked state: all clean.

## Note on the SDK-backed poller

The SDK poller reads this sensor cleanly for one reason only: libserialport sets
raw mode on open. The parsing, CRC handling, and init commands are otherwise
equivalent to `poll_data_node`. This one-line-of-behavior fix addresses the
flashing-red problem in the regular poller directly, so the SDK rewrite is not
required to solve it.

Out of scope: the sensor occasionally comes up *silent* (no stream at all) after
an unclean shutdown — that's absence of data, not garbage, affects any reader,
and is not addressed here.