### PR TITLE
fix(robotiq_driver): actionable errors when the gripper does not respond

### DIFF
--- a/grippers/robotiq_driver/src/default_driver.cpp
+++ b/grippers/robotiq_driver/src/default_driver.cpp
@@ -103,7 +103,11 @@ std::vector<uint8_t> DefaultDriver::send(const std::vector<uint8_t>& request, si
 
   if (retry_count == kMaxRetries)
   {
-    RCLCPP_ERROR(kLogger, "Reached maximum retries. Operation failed.");
+    RCLCPP_ERROR(kLogger,
+                 "The gripper did not respond after %d attempts. Check that the gripper is powered "
+                 "(24 V supply connected), the RS-485 cable is plugged in, and slave_address/baudrate "
+                 "match the gripper configuration.",
+                 kMaxRetries);
     return {};
   }
 

--- a/grippers/robotiq_driver/src/default_serial.cpp
+++ b/grippers/robotiq_driver/src/default_serial.cpp
@@ -58,7 +58,11 @@ std::vector<uint8_t> DefaultSerial::read(size_t size)
   size_t bytes_read = serial_->read(data, size);
   if (bytes_read != size)
   {
-    const auto error_msg = "Requested " + std::to_string(size) + " bytes, but got " + std::to_string(bytes_read);
+    // 0 bytes = the gripper never answered (vs. a partial/garbled response),
+    // which almost always means no power or no RS-485 connection.
+    const auto error_msg = bytes_read == 0 ?
+                               "No response from the gripper (0 of " + std::to_string(size) + " bytes read)" :
+                               "Requested " + std::to_string(size) + " bytes, but got " + std::to_string(bytes_read);
     THROW(serial::IOException, error_msg.c_str());
   }
   return data;


### PR DESCRIPTION
An unpowered gripper previously surfaced as 'Requested 8 bytes, but got 0' x5 followed by a controller_manager abort — nothing pointed at the likely cause. Now a fully silent gripper reads 'No response from the gripper', and exhausting the retries states the checks: 24 V power, RS-485 cable, slave_address/baudrate. Message-only change (same exceptions, same control flow); verified on hardware against an unpowered gripper.