### PR TITLE
CI maintenance: make the ROS build/test job reliable

### DIFF
--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -22,7 +22,7 @@ jobs:
     name: Format
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.github/workflows/ci-ros-build-test.yml
+++ b/.github/workflows/ci-ros-build-test.yml
@@ -23,7 +23,7 @@ jobs:
           - ros_distro: jazzy
             os: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: ${{ matrix.ros_distro }}

--- a/.github/workflows/ci-ros-build-test.yml
+++ b/.github/workflows/ci-ros-build-test.yml
@@ -1,6 +1,9 @@
-# Build robotiq_tsf and run its unit tests (colcon test) on the CI runner.
-# First build+test workflow in the repo — the algorithm code (MadgwickAHRS)
-# is pure math and needs no sensor hardware.
+# Build robotiq_tsf and run its unit tests (colcon test) inside a ROS container.
+# Running in ros:<distro>-ros-base gives a complete, consistent ROS environment.
+# The previous setup-ros-on-a-bare-runner approach intermittently produced an
+# incomplete ROS install (missing ament_package / rosidl_typesupport_c /
+# librcl_action.so), which flaked this job; the container removes that class of
+# failure.
 # Distro policy: LTS only — matrix is [jazzy] now, add lyrical when it ships
 # (see ros-driver distro-compat policy; distro pairs with its Ubuntu LTS).
 name: ROS Build & Test (robotiq_tsf)
@@ -16,6 +19,8 @@ jobs:
   build_and_test:
     name: colcon test (${{ matrix.ros_distro }})
     runs-on: ${{ matrix.os }}
+    container:
+      image: ros:${{ matrix.ros_distro }}-ros-base
     strategy:
       fail-fast: false
       matrix:
@@ -23,10 +28,18 @@ jobs:
           - ros_distro: jazzy
             os: ubuntu-24.04
     steps:
+      # ros-base is minimal: it lacks git (needed by actions/checkout) and the
+      # colcon coverage plugins that action-ros-ci invokes by default
+      # (colcon lcov-result / coveragepy-result). Install them up front.
+      - name: Install tooling missing from ros-base
+        run: |
+          apt-get update
+          apt-get install -y git lcov \
+            python3-colcon-lcov-result python3-colcon-coveragepy-result
       - uses: actions/checkout@v5
-      - uses: ros-tooling/setup-ros@v0.7
-        with:
-          required-ros-distributions: ${{ matrix.ros_distro }}
+      # action-ros-ci runs git against the checkout as root inside the container;
+      # mark it safe to avoid git's "dubious ownership" error.
+      - run: git config --global --add safe.directory '*'
       - uses: ros-tooling/action-ros-ci@v0.4
         with:
           package-name: robotiq_tsf

--- a/.github/workflows/ci-ros-lint.yml
+++ b/.github/workflows/ci-ros-lint.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         linter: [copyright, lint_cmake]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ros-tooling/setup-ros@v0.7
       - uses: ros-tooling/action-ros-lint@v0.1
         with:
@@ -36,7 +36,7 @@ jobs:
     name: ament_cpplint
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ros-tooling/setup-ros@v0.7
       - uses: ros-tooling/action-ros-lint@v0.1
         with:

--- a/robotiq_tsf/CMakeLists.txt
+++ b/robotiq_tsf/CMakeLists.txt
@@ -8,14 +8,11 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 find_package(ament_cmake REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(OpenCV REQUIRED)
-find_package(PkgConfig REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(Threads REQUIRED)
-
-pkg_check_modules(LIBUSB REQUIRED libusb-1.0)
 
 set(MSG_FILES
   "msg/Accelerometer.msg"
@@ -52,7 +49,6 @@ list(APPEND interface_targets_installed ${PROJECT_NAME}__rosidl_generator_py)
 include_directories(
   include
   include/robotiq_tsf
-  ${LIBUSB_INCLUDE_DIRS}
   ${OpenCV_INCLUDE_DIRS}
 )
 
@@ -79,7 +75,6 @@ target_include_directories(poll_data_node
 target_link_libraries(poll_data_node
   ${PROJECT_NAME}_algorithms
   ${cpp_typesupport_target}
-  ${LIBUSB_LIBRARIES}
   ${OpenCV_LIBRARIES}
   Threads::Threads
 )

--- a/robotiq_tsf/package.xml
+++ b/robotiq_tsf/package.xml
@@ -15,7 +15,6 @@
   <url type="website">https://github.com/ets-laboratory/tactilesensors4</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>pkg-config</buildtool_depend>
 
   <build_depend>rosidl_default_generators</build_depend>
   <build_depend>std_msgs</build_depend>
@@ -30,7 +29,6 @@
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <depend>libopencv-dev</depend>
-  <depend>libusb-1.0</depend>
 
   <!-- tactile_viz_node (Python RViz visualization) + its launch/rviz. -->
   <exec_depend>rclpy</exec_depend>


### PR DESCRIPTION
## Why

The `ROS Build & Test (robotiq_tsf)` workflow was flaking. `setup-ros` assembling
ROS via apt on a bare `ubuntu-24.04` runner intermittently produced an incomplete
environment, so the job failed with assorted, non-reproducible errors —
`No module named 'ament_package'`, `rosidl_typesupport_c not found`,
`librcl_action.so: cannot open shared object file` — none related to our code.

## What changed (3 commits)

1. **Run build/test in a ROS container** (`ros:<distro>-ros-base`) instead of
   `setup-ros` on a bare runner. The image ships a complete, consistent ROS
   install, which removes that whole class of flake. The minimal image lacks a
   couple of things `action-ros-ci` expects, so the job installs them up front:
   `git` (for checkout) and the `colcon-lcov-result` / `colcon-coveragepy-result`
   plugins (for the default coverage step).

2. **Drop the unused `libusb` dependency from `robotiq_tsf`.** Nothing in the
   package includes or calls libusb (the poller uses serial/termios), but CMake
   ran `pkg_check_modules(libusb-1.0)` and `package.xml` declared it. It only
   built on the bare runner because `libusb-1.0-0-dev` happened to be
   preinstalled; the clean container surfaced the dead dependency.

3. **Bump `actions/checkout` v4 → v5** across the workflows, clearing the Node 20
   deprecation warning.

## Validation

All three workflows pass on the branch: Build & Test, Format, and Lint.

## Note / possible follow-up

The lint workflow still uses `setup-ros` on a bare runner, so it retains the same
occasional flakiness (a transient here cleared on re-run). If it becomes a
recurring nuisance, containerizing those jobs the same way is the durable fix.