### PR TITLE
fix(robotiq_description): use exported interface names in controller …

### DIFF
--- a/.github/workflows/ci-ros-build-test.yml
+++ b/.github/workflows/ci-ros-build-test.yml
@@ -1,4 +1,5 @@
-# Build robotiq_tsf and run its unit tests (colcon test) inside a ROS container.
+# Build robotiq_tsf and the gripper packages and run their unit tests
+# (colcon test) inside a ROS container.
 # Running in ros:<distro>-ros-base gives a complete, consistent ROS environment.
 # The previous setup-ros-on-a-bare-runner approach intermittently produced an
 # incomplete ROS install (missing ament_package / rosidl_typesupport_c /
@@ -6,12 +7,13 @@
 # failure.
 # Distro policy: LTS only — matrix is [jazzy] now, add lyrical when it ships
 # (see ros-driver distro-compat policy; distro pairs with its Ubuntu LTS).
-name: ROS Build & Test (robotiq_tsf)
+name: ROS Build & Test
 
 on:
   pull_request:
     paths:
       - "robotiq_tsf/**"
+      - "grippers/**"
       - ".github/workflows/ci-ros-build-test.yml"
   workflow_dispatch:
 
@@ -42,9 +44,13 @@ jobs:
       - run: git config --global --add safe.directory '*'
       - uses: ros-tooling/action-ros-ci@v0.4
         with:
-          package-name: robotiq_tsf
+          package-name: >-
+            robotiq_tsf
+            robotiq_driver
+            robotiq_controllers
+            robotiq_description
+            robotiq_hardware_tests
           target-ros2-distro: ${{ matrix.ros_distro }}
-          # robotiq_driver's `serial` dep has no rosdep rule — it is imported
-          # from source (vcs) only when the grippers are built. This workflow
-          # only builds robotiq_tsf, so skip the key rather than import it.
-          rosdep-skip-keys: serial
+          # robotiq_driver's `serial` dep has no rosdep rule — import it from
+          # source via the upstream .repos file.
+          vcs-repo-file-url: "${{ github.workspace }}/grippers/ros2_robotiq_gripper.rolling.repos"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,15 +44,6 @@ COPY grippers    /ws/src/grippers
 # Gripper's external `serial` dep (tylerjw/serial), via the upstream .repos file.
 RUN cd /ws/src && vcs import < grippers/ros2_robotiq_gripper.rolling.repos
 
-# Temporary (PickNik issue #114): the controller config references command
-# interfaces the hardware does not expose; rename so robotiq_gripper_controller
-# activates. The forked source stays pristine — the patch is applied only in
-# this image, and drops out once the wrapper uses canonical interface names.
-RUN sed -i \
-    -e 's|robotiq_85_left_knuckle_joint/effort|robotiq_85_left_knuckle_joint/set_gripper_max_effort|g' \
-    -e 's|robotiq_85_left_knuckle_joint/velocity|robotiq_85_left_knuckle_joint/set_gripper_max_velocity|g' \
-    /ws/src/grippers/robotiq_description/config/robotiq_controllers.yaml
-
 # Resolve any remaining rosdeps from the package manifests, then build Release.
 RUN apt-get update \
     && rosdep install --from-paths /ws/src --ignore-src -y --rosdistro ${ROS_DISTRO} \

--- a/grippers/robotiq_description/CMakeLists.txt
+++ b/grippers/robotiq_description/CMakeLists.txt
@@ -19,4 +19,9 @@ install(
     share/${PROJECT_NAME}
 )
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(test_controller_config test/test_controller_config.py)
+endif()
+
 ament_package()

--- a/grippers/robotiq_description/config/robotiq_controllers.yaml
+++ b/grippers/robotiq_description/config/robotiq_controllers.yaml
@@ -14,11 +14,11 @@ robotiq_gripper_controller:
     joint: robotiq_85_left_knuckle_joint
 
     # Enable effort control (replacement for use_effort_interface)
-    max_effort_interface: "robotiq_85_left_knuckle_joint/effort"
+    max_effort_interface: "robotiq_85_left_knuckle_joint/set_gripper_max_effort"
     max_effort: 50.0   # TODO tune
 
     # Enable velocity/speed control (replacement for use_speed_interface)
-    max_velocity_interface: "robotiq_85_left_knuckle_joint/velocity"
+    max_velocity_interface: "robotiq_85_left_knuckle_joint/set_gripper_max_velocity"
     max_velocity: 0.5    # TODO tune
 
     # Optional (recommended)

--- a/grippers/robotiq_description/package.xml
+++ b/grippers/robotiq_description/package.xml
@@ -26,8 +26,10 @@
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>parallel_gripper_controller</exec_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>python3-yaml</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/grippers/robotiq_description/test/test_controller_config.py
+++ b/grippers/robotiq_description/test/test_controller_config.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026 Robotiq
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the copyright holder nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# The gripper controller can only activate if the command interfaces it is
+# configured to claim exist under the exact names the hardware exports (see
+# RobotiqGripperHardwareInterface::export_command_interfaces in
+# robotiq_driver). A mismatch is silent until runtime, where
+# robotiq_gripper_controller fails to activate.
+
+from pathlib import Path
+
+import yaml
+
+CONFIG = Path(__file__).parents[1] / "config" / "robotiq_controllers.yaml"
+
+# Names exported by robotiq_driver's hardware interface. Kept in sync by
+# robotiq_driver's test_robotiq_gripper_hardware_interface, which asserts the
+# hardware exports exactly these.
+JOINT = "robotiq_85_left_knuckle_joint"
+EXPORTED_COMMAND_INTERFACES = {
+    f"{JOINT}/position",
+    f"{JOINT}/set_gripper_max_velocity",
+    f"{JOINT}/set_gripper_max_effort",
+}
+
+
+def gripper_controller_params():
+    with open(CONFIG) as f:
+        config = yaml.safe_load(f)
+    return config["robotiq_gripper_controller"]["ros__parameters"]
+
+
+def test_max_effort_interface_is_exported():
+    params = gripper_controller_params()
+    assert params["max_effort_interface"] in EXPORTED_COMMAND_INTERFACES
+
+
+def test_max_velocity_interface_is_exported():
+    params = gripper_controller_params()
+    assert params["max_velocity_interface"] in EXPORTED_COMMAND_INTERFACES
+
+
+def test_joint_matches_exported_interfaces():
+    params = gripper_controller_params()
+    assert params["joint"] == JOINT

--- a/grippers/robotiq_driver/tests/test_robotiq_gripper_hardware_interface.cpp
+++ b/grippers/robotiq_driver/tests/test_robotiq_gripper_hardware_interface.cpp
@@ -26,6 +26,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <hardware_interface/resource_manager.hpp>
@@ -40,13 +41,11 @@
 namespace robotiq_driver::test
 {
 
-/**
- * This test generates a minimal xacro robot configuration and loads the
- * hardware interface plugin.
- */
-TEST(TestRobotiqGripperHardwareInterface, load_urdf)
+namespace
 {
-  std::string urdf =
+std::string minimal_robot_urdf()
+{
+  return
       R"(
         <?xml version="1.0" encoding="utf-8"?>
         <robot name="test_robot">
@@ -77,6 +76,16 @@ TEST(TestRobotiqGripperHardwareInterface, load_urdf)
           </ros2_control>
         </robot>
         )";
+}
+}  // namespace
+
+/**
+ * This test generates a minimal xacro robot configuration and loads the
+ * hardware interface plugin.
+ */
+TEST(TestRobotiqGripperHardwareInterface, load_urdf)
+{
+  const std::string urdf = minimal_robot_urdf();
 
   rclcpp::Node node{ "test_robotiq_gripper_hardware_interface" };
 
@@ -89,6 +98,30 @@ TEST(TestRobotiqGripperHardwareInterface, load_urdf)
 
   // Check interfaces
   EXPECT_EQ(1u, rm.system_components_size());
+}
+
+/**
+ * The controller configuration shipped in robotiq_description
+ * (robotiq_controllers.yaml) claims these command interfaces by name; if the
+ * hardware stops exporting them under these exact names the gripper controller
+ * fails to activate at runtime.
+ */
+TEST(TestRobotiqGripperHardwareInterface, exports_expected_command_interfaces)
+{
+  const std::string urdf = minimal_robot_urdf();
+
+  rclcpp::Node node{ "test_robotiq_gripper_hardware_interface" };
+
+#if HARDWARE_INTERFACE_VERSION_GTE(4, 13, 0)
+  hardware_interface::ResourceManager rm(urdf, node.get_node_clock_interface(), node.get_node_logging_interface());
+#else
+  hardware_interface::ResourceManager rm(urdf);
+#endif
+
+  const auto keys = rm.command_interface_keys();
+  EXPECT_THAT(keys, testing::IsSupersetOf({ "robotiq_85_left_knuckle_joint/position",
+                                            "robotiq_85_left_knuckle_joint/set_gripper_max_velocity",
+                                            "robotiq_85_left_knuckle_joint/set_gripper_max_effort" }));
 }
 
 }  // namespace robotiq_driver::test


### PR DESCRIPTION
Fixes upstream [PickNik issue #114](https://github.com/PickNikRobotics/ros2_robotiq_gripper/issues/114).

`robotiq_controllers.yaml` claims `<joint>/effort` and `<joint>/velocity`, but the hardware exports `set_gripper_max_effort` / `set_gripper_max_velocity`, so `robotiq_gripper_controller` fails to activate on source builds. Previously masked by a `sed` patch in `docker/Dockerfile` that rewrote the yaml inside the image only.

- Rename the two interfaces in `robotiq_controllers.yaml` to the exported names; drop the `sed` patch.
- Regression tests: `robotiq_driver` gtest pins the exported `set_gripper_max_*` names; new `robotiq_description` pytest asserts the yaml only claims exported interfaces (fails on the pre-fix yaml).

Verified on a real 2F-85: controllers activate, and per-goal speed reaches the gripper (full stroke ~0.6 s at `velocity: [0.15]` vs ~1.7 s at `[0.02]`), including in a docker image rebuilt without the patch. Fake-hardware activation remains broken for a different reason (mock hardware only creates URDF-declared interfaces) and will be addressed separately.

PTI @JonathanBeaudoinRq 