### PR TITLE
Sgrip 867/eigen linalg

### DIFF
--- a/robotiq_tsf/CMakeLists.txt
+++ b/robotiq_tsf/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_index_cpp REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(PkgConfig REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -84,6 +85,7 @@ target_include_directories(${PROJECT_NAME}_algorithms
 target_link_libraries(${PROJECT_NAME}_algorithms
   PUBLIC
     ${OpenCV_LIBRARIES}
+    Eigen3::Eigen
 )
 
 # SDK poller node logic as a static library, so the executable and the unit
@@ -163,6 +165,7 @@ install(DIRECTORY resource/
 )
 
 ament_export_dependencies(
+  Eigen3
   OpenCV
   ament_index_cpp
   rclcpp

--- a/robotiq_tsf/include/robotiq_tsf/MadgwickAHRS.h
+++ b/robotiq_tsf/include/robotiq_tsf/MadgwickAHRS.h
@@ -1,3 +1,31 @@
+// Copyright (c) 2026 Robotiq
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 // MadgwickAHRS.h
 //
 // Class wrapper around Madgwick's IMU AHRS algorithm, built on Eigen
@@ -9,39 +37,37 @@
 // quaternion algebra (the gradient-descent step stays as the reference
 // scalar expansion).
 
-#ifndef ROBOTIQ_TSF_MADGWICK_AHRS_H
-#define ROBOTIQ_TSF_MADGWICK_AHRS_H
+#pragma once
 
 #include <Eigen/Geometry>
 
-class MadgwickFilter {
+class MadgwickFilter
+{
 public:
-    explicit MadgwickFilter(float beta = 0.041f);
+   explicit MadgwickFilter(float beta = 0.041f);
 
-    void reset();
-    void setBeta(float beta);
-    void setAccelGate(float lo, float hi);
+   void reset();
+   void setBeta(float beta);
+   void setAccelGate(float lo, float hi);
 
-    // Seed the quaternion so the gravity vector in the body frame matches the
-    // supplied accelerometer reading (any units; only the direction is used).
-    // Yaw is set to zero. Use the calibration-time accel mean.
-    void initFromAccel(float ax, float ay, float az);
+   // Seed the quaternion so the gravity vector in the body frame matches the
+   // supplied accelerometer reading (any units; only the direction is used).
+   // Yaw is set to zero. Use the calibration-time accel mean.
+   void initFromAccel(float ax, float ay, float az);
 
-    // gyro in rad/s, accel in any consistent unit (normalised internally),
-    // dt in seconds (use the measured interval between samples).
-    void updateIMU(float gx, float gy, float gz,
-                   float ax, float ay, float az,
-                   float dt);
+   // gyro in rad/s, accel in any consistent unit (normalised internally),
+   // dt in seconds (use the measured interval between samples).
+   void updateIMU(float gx, float gy, float gz, float ax, float ay, float az, float dt);
 
-    Eigen::Quaternionf quaternion() const { return q_; }
-    void getQuaternion(float &q0, float &q1, float &q2, float &q3) const;
-    void getEulerDeg(float &roll, float &pitch, float &yaw) const;
+   Eigen::Quaternionf quaternion() const { return q_; }
+   void getQuaternion(float& q0, float& q1, float& q2, float& q3) const;
+   void getEulerDeg(float& roll, float& pitch, float& yaw) const;
 
 private:
-    Eigen::Quaternionf q_;
-    float beta_;
-    float accel_gate_lo_;   // expected |a| ≈ 1.0 g when stationary
-    float accel_gate_hi_;
+   Eigen::Quaternionf q_;
+   float beta_;
+   float accel_gate_lo_; // expected |a| ≈ 1.0 g when stationary
+   float accel_gate_hi_;
 };
 
 // ZYX Tait-Bryan extraction (yaw around Z, pitch around Y, roll around X),
@@ -49,7 +75,5 @@ private:
 // Eigen's eulerAngles(2, 1, 0) constrains its first angle to [0, π], which
 // does not match the convention the driver publishes (and matches the legacy
 // PollData.cpp extraction).
-void quatToEulerRad(const Eigen::Quaternionf &q, float &roll, float &pitch, float &yaw);
-void quatToEulerDeg(const Eigen::Quaternionf &q, float &roll, float &pitch, float &yaw);
-
-#endif // ROBOTIQ_TSF_MADGWICK_AHRS_H
+void quatToEulerRad(const Eigen::Quaternionf& q, float& roll, float& pitch, float& yaw);
+void quatToEulerDeg(const Eigen::Quaternionf& q, float& roll, float& pitch, float& yaw);

--- a/robotiq_tsf/include/robotiq_tsf/MadgwickAHRS.h
+++ b/robotiq_tsf/include/robotiq_tsf/MadgwickAHRS.h
@@ -1,81 +1,55 @@
-// Copyright (c) 2026 Robotiq
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above copyright
-//      notice, this list of conditions and the following disclaimer in the
-//      documentation and/or other materials provided with the distribution.
-//
-//    * Neither the name of the copyright holder nor the names of its
-//      contributors may be used to endorse or promote products derived from
-//      this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
-
 // MadgwickAHRS.h
 //
-// Class wrapper around Madgwick's IMU AHRS algorithm, plus quaternion-math
-// helpers used by the ROS node to compute relative ("zeroed") orientation.
+// Class wrapper around Madgwick's IMU AHRS algorithm, built on Eigen
+// quaternion types.
 //
 // Original algorithm: Sebastian O.H. Madgwick, 2011.
 // Refactored 2026 to: instance state (no globals), measured dt, accelerometer
-// magnitude gating, and accel-seeded initialization.
+// magnitude gating, accel-seeded initialization, and Eigen for the generic
+// quaternion algebra (the gradient-descent step stays as the reference
+// scalar expansion).
 
-#pragma once
+#ifndef ROBOTIQ_TSF_MADGWICK_AHRS_H
+#define ROBOTIQ_TSF_MADGWICK_AHRS_H
 
-class MadgwickFilter
-{
+#include <Eigen/Geometry>
+
+class MadgwickFilter {
 public:
-   explicit MadgwickFilter(float beta = 0.041f);
+    explicit MadgwickFilter(float beta = 0.041f);
 
-   void reset();
-   void setBeta(float beta);
-   void setAccelGate(float lo, float hi);
+    void reset();
+    void setBeta(float beta);
+    void setAccelGate(float lo, float hi);
 
-   // Seed the quaternion so the gravity vector in the body frame matches the
-   // supplied accelerometer reading (any units; only the direction is used).
-   // Yaw is set to zero. Use the calibration-time accel mean.
-   void initFromAccel(float ax, float ay, float az);
+    // Seed the quaternion so the gravity vector in the body frame matches the
+    // supplied accelerometer reading (any units; only the direction is used).
+    // Yaw is set to zero. Use the calibration-time accel mean.
+    void initFromAccel(float ax, float ay, float az);
 
-   // gyro in rad/s, accel in any consistent unit (normalised internally),
-   // dt in seconds (use the measured interval between samples).
-   void updateIMU(float gx, float gy, float gz, float ax, float ay, float az, float dt);
+    // gyro in rad/s, accel in any consistent unit (normalised internally),
+    // dt in seconds (use the measured interval between samples).
+    void updateIMU(float gx, float gy, float gz,
+                   float ax, float ay, float az,
+                   float dt);
 
-   void getQuaternion(float& q0, float& q1, float& q2, float& q3) const;
-   void getEulerDeg(float& roll, float& pitch, float& yaw) const;
+    Eigen::Quaternionf quaternion() const { return q_; }
+    void getQuaternion(float &q0, float &q1, float &q2, float &q3) const;
+    void getEulerDeg(float &roll, float &pitch, float &yaw) const;
 
 private:
-   float q0_, q1_, q2_, q3_;
-   float beta_;
-   float accel_gate_lo_; // expected |a| ≈ 1.0 g when stationary
-   float accel_gate_hi_;
+    Eigen::Quaternionf q_;
+    float beta_;
+    float accel_gate_lo_;   // expected |a| ≈ 1.0 g when stationary
+    float accel_gate_hi_;
 };
 
-// --- quaternion-math helpers (free functions) ---------------------------------
-// Convention: q = [w, x, y, z] = [q0, q1, q2, q3].
-// Euler order matches the Madgwick implementation's ZYX Tait-Bryan extraction
-// (yaw around Z, pitch around Y, roll around X), angles in radians for the
-// builder helpers, degrees for quatToEulerDeg.
+// ZYX Tait-Bryan extraction (yaw around Z, pitch around Y, roll around X),
+// each angle in ±180°/±90° aerospace ranges. Kept hand-written on purpose:
+// Eigen's eulerAngles(2, 1, 0) constrains its first angle to [0, π], which
+// does not match the convention the driver publishes (and matches the legacy
+// PollData.cpp extraction).
+void quatToEulerRad(const Eigen::Quaternionf &q, float &roll, float &pitch, float &yaw);
+void quatToEulerDeg(const Eigen::Quaternionf &q, float &roll, float &pitch, float &yaw);
 
-void quatMul(const float a[4], const float b[4], float out[4]);
-void quatConj(const float q[4], float out[4]);
-void quatNormalize(float q[4]);
-void quatFromAxisX(float angle_rad, float out[4]);
-void quatFromAxisY(float angle_rad, float out[4]);
-void quatFromAxisZ(float angle_rad, float out[4]);
-void quatToEulerDeg(const float q[4], float& roll, float& pitch, float& yaw);
-void quatToEulerRad(const float q[4], float& roll, float& pitch, float& yaw);
+#endif // ROBOTIQ_TSF_MADGWICK_AHRS_H

--- a/robotiq_tsf/include/robotiq_tsf/fusion.hpp
+++ b/robotiq_tsf/include/robotiq_tsf/fusion.hpp
@@ -1,5 +1,32 @@
-#ifndef ROBOTIQ_TSF_FUSION_HPP
-#define ROBOTIQ_TSF_FUSION_HPP
+// Copyright (c) 2026 Robotiq
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
 
 #include <Eigen/Core>
 
@@ -11,21 +38,20 @@
 // Reference System) fusion path, factored out of the node so they can be
 // unit-tested directly (like sdk_bridge/device_autodetect).
 
-namespace robotiq_tsf
-{
+namespace robotiq_tsf {
 
 // AHRS / fusion tunables, populated from ROS parameters (madgwick.*). Defaults
 // match the legacy poll_data_node.
 struct AhrsConfig
 {
-    float beta = 0.041f;
-    float accel_gate_lo = 0.85f;
-    float accel_gate_hi = 1.15f;
-    float bias_learn_rate = 0.0005f;    // EMA step toward residual gyro when still
-    float still_gyro_eps_deg_s = 0.8f;  // |omega| below this counts as still
-    float still_accel_eps_g = 0.05f;    // ||a| - 1g| below this counts as still
-    float dt_clamp_lo = 1e-4f;          // 0.1 ms
-    float dt_clamp_hi = 0.1f;           // 100 ms
+   float beta = 0.041f;
+   float accel_gate_lo = 0.85f;
+   float accel_gate_hi = 1.15f;
+   float bias_learn_rate = 0.0005f; // EMA step toward residual gyro when still
+   float still_gyro_eps_deg_s = 0.8f; // |omega| below this counts as still
+   float still_accel_eps_g = 0.05f; // ||a| - 1g| below this counts as still
+   float dt_clamp_lo = 1e-4f; // 0.1 ms
+   float dt_clamp_hi = 0.1f; // 100 ms
 };
 
 // Integration step (seconds) from consecutive per-finger MCU timestamps (ms).
@@ -37,29 +63,29 @@ struct AhrsConfig
 // scheduling stall, or a stop()->start() service cycle) corrupting the estimate.
 inline float deriveDt(uint64_t prev_ts_ms, uint64_t ts_ms, float lo, float hi)
 {
-    if (prev_ts_ms == 0 || ts_ms <= prev_ts_ms)
-        return 0.0f;
-    return std::clamp(static_cast<float>(ts_ms - prev_ts_ms) * 1e-3f, lo, hi);
+   if(prev_ts_ms == 0 || ts_ms <= prev_ts_ms)
+   {
+      return 0.0f;
+   }
+   return std::clamp(static_cast<float>(ts_ms - prev_ts_ms) * 1e-3f, lo, hi);
 }
 
 // True when the sample looks stationary: small angular rate and accel norm near
 // 1 g. gyro in deg/s, accel in g. Gates the online gyro-bias trim.
-inline bool sampleIsStill(const Eigen::Vector3f &gyro, const Eigen::Vector3f &accel,
-                          float gyro_eps_deg_s, float accel_eps_g)
+inline bool sampleIsStill(const Eigen::Vector3f& gyro,
+                          const Eigen::Vector3f& accel,
+                          float gyro_eps_deg_s,
+                          float accel_eps_g)
 {
-    return gyro.norm() < gyro_eps_deg_s &&
-           std::fabs(accel.norm() - 1.0f) < accel_eps_g;
+   return gyro.norm() < gyro_eps_deg_s && std::fabs(accel.norm() - 1.0f) < accel_eps_g;
 }
 
 // One EMA step of the online gyro-bias trim: nudge `bias` toward the residual
 // (post-bias-subtraction) gyro `rate` by `alpha`. Call only when still, so a
 // frozen bias can't let thermal drift accumulate as yaw drift over a session.
-inline Eigen::Vector3f trimBias(const Eigen::Vector3f &bias,
-                                const Eigen::Vector3f &rate, float alpha)
+inline Eigen::Vector3f trimBias(const Eigen::Vector3f& bias, const Eigen::Vector3f& rate, float alpha)
 {
-    return bias + alpha*rate;
+   return bias + alpha * rate;
 }
 
-}  // namespace robotiq_tsf
-
-#endif  // ROBOTIQ_TSF_FUSION_HPP
+} // namespace robotiq_tsf

--- a/robotiq_tsf/include/robotiq_tsf/fusion.hpp
+++ b/robotiq_tsf/include/robotiq_tsf/fusion.hpp
@@ -1,32 +1,7 @@
-// Copyright (c) 2026 Robotiq
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above copyright
-//      notice, this list of conditions and the following disclaimer in the
-//      documentation and/or other materials provided with the distribution.
-//
-//    * Neither the name of the copyright holder nor the names of its
-//      contributors may be used to endorse or promote products derived from
-//      this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+#ifndef ROBOTIQ_TSF_FUSION_HPP
+#define ROBOTIQ_TSF_FUSION_HPP
 
-#pragma once
+#include <Eigen/Core>
 
 #include <algorithm>
 #include <cmath>
@@ -36,20 +11,21 @@
 // Reference System) fusion path, factored out of the node so they can be
 // unit-tested directly (like sdk_bridge/device_autodetect).
 
-namespace robotiq_tsf {
+namespace robotiq_tsf
+{
 
 // AHRS / fusion tunables, populated from ROS parameters (madgwick.*). Defaults
 // match the legacy poll_data_node.
 struct AhrsConfig
 {
-   float beta = 0.041f;
-   float accel_gate_lo = 0.85f;
-   float accel_gate_hi = 1.15f;
-   float bias_learn_rate = 0.0005f; // EMA step toward residual gyro when still
-   float still_gyro_eps_deg_s = 0.8f; // |omega| below this counts as still
-   float still_accel_eps_g = 0.05f; // ||a| - 1g| below this counts as still
-   float dt_clamp_lo = 1e-4f; // 0.1 ms
-   float dt_clamp_hi = 0.1f; // 100 ms
+    float beta = 0.041f;
+    float accel_gate_lo = 0.85f;
+    float accel_gate_hi = 1.15f;
+    float bias_learn_rate = 0.0005f;    // EMA step toward residual gyro when still
+    float still_gyro_eps_deg_s = 0.8f;  // |omega| below this counts as still
+    float still_accel_eps_g = 0.05f;    // ||a| - 1g| below this counts as still
+    float dt_clamp_lo = 1e-4f;          // 0.1 ms
+    float dt_clamp_hi = 0.1f;           // 100 ms
 };
 
 // Integration step (seconds) from consecutive per-finger MCU timestamps (ms).
@@ -61,35 +37,29 @@ struct AhrsConfig
 // scheduling stall, or a stop()->start() service cycle) corrupting the estimate.
 inline float deriveDt(uint64_t prev_ts_ms, uint64_t ts_ms, float lo, float hi)
 {
-   if(prev_ts_ms == 0 || ts_ms <= prev_ts_ms)
-   {
-      return 0.0f;
-   }
-   return std::clamp(static_cast<float>(ts_ms - prev_ts_ms) * 1e-3f, lo, hi);
+    if (prev_ts_ms == 0 || ts_ms <= prev_ts_ms)
+        return 0.0f;
+    return std::clamp(static_cast<float>(ts_ms - prev_ts_ms) * 1e-3f, lo, hi);
 }
 
 // True when the sample looks stationary: small angular rate and accel norm near
 // 1 g. gyro in deg/s, accel in g. Gates the online gyro-bias trim.
-inline bool sampleIsStill(float gx,
-                          float gy,
-                          float gz,
-                          float ax,
-                          float ay,
-                          float az,
-                          float gyro_eps_deg_s,
-                          float accel_eps_g)
+inline bool sampleIsStill(const Eigen::Vector3f &gyro, const Eigen::Vector3f &accel,
+                          float gyro_eps_deg_s, float accel_eps_g)
 {
-   const float gyro_mag = std::sqrt(gx * gx + gy * gy + gz * gz);
-   const float accel_norm = std::sqrt(ax * ax + ay * ay + az * az);
-   return gyro_mag < gyro_eps_deg_s && std::fabs(accel_norm - 1.0f) < accel_eps_g;
+    return gyro.norm() < gyro_eps_deg_s &&
+           std::fabs(accel.norm() - 1.0f) < accel_eps_g;
 }
 
 // One EMA step of the online gyro-bias trim: nudge `bias` toward the residual
 // (post-bias-subtraction) gyro `rate` by `alpha`. Call only when still, so a
 // frozen bias can't let thermal drift accumulate as yaw drift over a session.
-inline float trimBias(float bias, float rate, float alpha)
+inline Eigen::Vector3f trimBias(const Eigen::Vector3f &bias,
+                                const Eigen::Vector3f &rate, float alpha)
 {
-   return bias + alpha * rate;
+    return bias + alpha*rate;
 }
 
-} // namespace robotiq_tsf
+}  // namespace robotiq_tsf
+
+#endif  // ROBOTIQ_TSF_FUSION_HPP

--- a/robotiq_tsf/include/robotiq_tsf/poll_data_sdk_node.hpp
+++ b/robotiq_tsf/include/robotiq_tsf/poll_data_sdk_node.hpp
@@ -1,5 +1,32 @@
-#ifndef ROBOTIQ_TSF_POLL_DATA_SDK_NODE_HPP
-#define ROBOTIQ_TSF_POLL_DATA_SDK_NODE_HPP
+// Copyright (c) 2026 Robotiq
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
 
 // SDK-backed ROS 2 wrapper for the Robotiq TSF tactile sensor.
 //
@@ -7,20 +34,6 @@
 // and republishes the SDK's Fingers callback onto the same topics and message
 // types as the legacy PollData.cpp node. The USB / packet / parsing logic lives
 // in the SDK — the node contains only the bridge into ROS + the AHRS fusion.
-
-#include "rclcpp/node.hpp"  // brings rclcpp::{Node, Publisher, Service}
-
-// Sensor is the aggregate message and transitively defines every per-field
-// message type the publisher members are typed on (StaticData, Dynamic, …), so
-// the individual msg headers are pulled in by the .cpp (where create_publisher
-// needs their typesupport), not here.
-#include "robotiq_tsf/msg/sensor.hpp"
-#include "robotiq_tsf/srv/tactile_sensors.hpp"
-
-#include "robotiq_tsf/MadgwickAHRS.h"  // MadgwickFilter (by-value array member)
-#include "robotiq_tsf/fusion.hpp"      // AhrsConfig (by-value member)
-
-#include "finger_data.h"  // Fingers, FINGER_COUNT
 
 #include <Eigen/Core>
 
@@ -30,6 +43,17 @@
 #include <cstdint>
 #include <memory>
 
+#include "finger_data.h" // NOLINT(build/include_subdir) - external SDK header (Fingers, FINGER_COUNT)
+#include "rclcpp/node.hpp" // brings rclcpp::{Node, Publisher, Service}
+#include "robotiq_tsf/MadgwickAHRS.h" // MadgwickFilter (by-value array member)
+#include "robotiq_tsf/fusion.hpp" // AhrsConfig (by-value member)
+// Sensor is the aggregate message and transitively defines every per-field
+// message type the publisher members are typed on (StaticData, Dynamic, …), so
+// the individual msg headers are pulled in by the .cpp (where create_publisher
+// needs their typesupport), not here.
+#include "robotiq_tsf/msg/sensor.hpp"
+#include "robotiq_tsf/srv/tactile_sensors.hpp"
+
 // Defined by the SDK (extern/tactile_sensors/sdk_cpp); forward-declared here so
 // this header doesn't pull in libserialport. The node's out-of-line destructor
 // keeps the unique_ptr happy with the incomplete type.
@@ -38,57 +62,54 @@ class RobotiqTactileSensor;
 class PollDataSdkNode : public rclcpp::Node
 {
 public:
-    PollDataSdkNode();
-    ~PollDataSdkNode() override;
+   PollDataSdkNode();
+   ~PollDataSdkNode() override;
 
-    bool startSensor();
-    bool waitForStreaming();
-    void handleFingers(const Fingers &fingers);
+   bool startSensor();
+   bool waitForStreaming();
+   void handleFingers(const Fingers& fingers);
 
 private:
-    void serviceCallback(
-        const std::shared_ptr<robotiq_tsf::srv::TactileSensors::Request> req,
-        std::shared_ptr<robotiq_tsf::srv::TactileSensors::Response> res);
+   void serviceCallback(const std::shared_ptr<robotiq_tsf::srv::TactileSensors::Request> req,
+                        std::shared_ptr<robotiq_tsf::srv::TactileSensors::Response> res);
 
-    rclcpp::Publisher<robotiq_tsf::msg::StaticData>::SharedPtr static_pub_;
-    rclcpp::Publisher<robotiq_tsf::msg::Dynamic>::SharedPtr dynamic_pub_;
-    rclcpp::Publisher<robotiq_tsf::msg::Accelerometer>::SharedPtr accel_pub_;
-    rclcpp::Publisher<robotiq_tsf::msg::Gyroscope>::SharedPtr gyro_pub_;
-    rclcpp::Publisher<robotiq_tsf::msg::EulerAngle>::SharedPtr euler_pub_;
-    rclcpp::Publisher<robotiq_tsf::msg::Quaternion>::SharedPtr quat_pub_;
-    rclcpp::Publisher<robotiq_tsf::msg::Timestamp>::SharedPtr ts_pub_;
-    rclcpp::Service<robotiq_tsf::srv::TactileSensors>::SharedPtr service_;
+   rclcpp::Publisher<robotiq_tsf::msg::StaticData>::SharedPtr static_pub_;
+   rclcpp::Publisher<robotiq_tsf::msg::Dynamic>::SharedPtr dynamic_pub_;
+   rclcpp::Publisher<robotiq_tsf::msg::Accelerometer>::SharedPtr accel_pub_;
+   rclcpp::Publisher<robotiq_tsf::msg::Gyroscope>::SharedPtr gyro_pub_;
+   rclcpp::Publisher<robotiq_tsf::msg::EulerAngle>::SharedPtr euler_pub_;
+   rclcpp::Publisher<robotiq_tsf::msg::Quaternion>::SharedPtr quat_pub_;
+   rclcpp::Publisher<robotiq_tsf::msg::Timestamp>::SharedPtr ts_pub_;
+   rclcpp::Service<robotiq_tsf::srv::TactileSensors>::SharedPtr service_;
 
-    std::unique_ptr<RobotiqTactileSensor> sensor_;
-    robotiq_tsf::msg::Sensor sensors_data_;
+   std::unique_ptr<RobotiqTactileSensor> sensor_;
+   robotiq_tsf::msg::Sensor sensors_data_;
 
-    // Publish-rate throttle: set via the publish_rate_hz parameter, from which
-    // this is derived as 1/publish_rate_hz. Default 0 = publish every packet at
-    // the sensor's native rate (~700 Hz), as poll_data_node did. A positive
-    // publish_rate_hz decimates the publishes for downstream consumers that
-    // don't need the full rate; the IMU fusion + bias calc still run on every
-    // packet regardless (fusion accuracy needs the full rate).
-    // Read/written only from the single SDK callback thread.
-    double publish_period_s_ = 0.0;
-    std::chrono::steady_clock::time_point last_pub_{};
+   // Publish-rate throttle: set via the publish_rate_hz parameter, from which
+   // this is derived as 1/publish_rate_hz. Default 0 = publish every packet at
+   // the sensor's native rate (~700 Hz), as poll_data_node did. A positive
+   // publish_rate_hz decimates the publishes for downstream consumers that
+   // don't need the full rate; the IMU fusion + bias calc still run on every
+   // packet regardless (fusion accuracy needs the full rate).
+   // Read/written only from the single SDK callback thread.
+   double publish_period_s_ = 0.0;
+   std::chrono::steady_clock::time_point last_pub_{};
 
-    // Per-finger IMU bias estimates: accumulated as sums during the startup
-    // calibration window, then converted to means. The accel "bias" is really
-    // the gravity direction and seeds the filter (see handleFingers). Zeroed
-    // in the constructor (Eigen vectors default-construct uninitialized).
-    int bias_iter_ = 0;
-    std::array<Eigen::Vector3f, FINGER_COUNT> accel_bias_;
-    std::array<Eigen::Vector3f, FINGER_COUNT> gyro_bias_;
+   // Per-finger IMU bias estimates: accumulated as sums during the startup
+   // calibration window, then converted to means. The accel "bias" is really
+   // the gravity direction and seeds the filter (see handleFingers). Zeroed
+   // in the constructor (Eigen vectors default-construct uninitialized).
+   int bias_iter_ = 0;
+   std::array<Eigen::Vector3f, FINGER_COUNT> accel_bias_;
+   std::array<Eigen::Vector3f, FINGER_COUNT> gyro_bias_;
 
-    // AHRS filter — one instance per finger; integrated on every SDK packet.
-    robotiq_tsf::AhrsConfig ahrs_cfg_;
-    std::array<MadgwickFilter, FINGER_COUNT> filter_;
-    // Per-finger MCU timestamp (ms) of the last integrated sample; 0 = not yet
-    // seeded (start of stream, or just after the bias calibration).
-    std::array<uint64_t, FINGER_COUNT> last_ts_ms_{};
+   // AHRS filter — one instance per finger; integrated on every SDK packet.
+   robotiq_tsf::AhrsConfig ahrs_cfg_;
+   std::array<MadgwickFilter, FINGER_COUNT> filter_;
+   // Per-finger MCU timestamp (ms) of the last integrated sample; 0 = not yet
+   // seeded (start of stream, or just after the bias calibration).
+   std::array<uint64_t, FINGER_COUNT> last_ts_ms_{};
 
-    std::atomic<bool> stopped_{false};
-    std::atomic<uint64_t> frames_received_{0};
+   std::atomic<bool> stopped_{false};
+   std::atomic<uint64_t> frames_received_{0};
 };
-
-#endif  // ROBOTIQ_TSF_POLL_DATA_SDK_NODE_HPP

--- a/robotiq_tsf/include/robotiq_tsf/poll_data_sdk_node.hpp
+++ b/robotiq_tsf/include/robotiq_tsf/poll_data_sdk_node.hpp
@@ -1,32 +1,5 @@
-// Copyright (c) 2026 Robotiq
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above copyright
-//      notice, this list of conditions and the following disclaimer in the
-//      documentation and/or other materials provided with the distribution.
-//
-//    * Neither the name of the copyright holder nor the names of its
-//      contributors may be used to endorse or promote products derived from
-//      this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
-
-#pragma once
+#ifndef ROBOTIQ_TSF_POLL_DATA_SDK_NODE_HPP
+#define ROBOTIQ_TSF_POLL_DATA_SDK_NODE_HPP
 
 // SDK-backed ROS 2 wrapper for the Robotiq TSF tactile sensor.
 //
@@ -35,21 +8,27 @@
 // types as the legacy PollData.cpp node. The USB / packet / parsing logic lives
 // in the SDK — the node contains only the bridge into ROS + the AHRS fusion.
 
-#include <atomic>
-#include <chrono>
-#include <cstdint>
-#include <memory>
+#include "rclcpp/node.hpp"  // brings rclcpp::{Node, Publisher, Service}
 
-#include "finger_data.h" // NOLINT(build/include_subdir) - external SDK header (Fingers, FINGER_COUNT)
-#include "rclcpp/node.hpp" // brings rclcpp::{Node, Publisher, Service}
-#include "robotiq_tsf/MadgwickAHRS.h" // MadgwickFilter (by-value array member)
-#include "robotiq_tsf/fusion.hpp" // AhrsConfig (by-value member)
 // Sensor is the aggregate message and transitively defines every per-field
 // message type the publisher members are typed on (StaticData, Dynamic, …), so
 // the individual msg headers are pulled in by the .cpp (where create_publisher
 // needs their typesupport), not here.
 #include "robotiq_tsf/msg/sensor.hpp"
 #include "robotiq_tsf/srv/tactile_sensors.hpp"
+
+#include "robotiq_tsf/MadgwickAHRS.h"  // MadgwickFilter (by-value array member)
+#include "robotiq_tsf/fusion.hpp"      // AhrsConfig (by-value member)
+
+#include "finger_data.h"  // Fingers, FINGER_COUNT
+
+#include <Eigen/Core>
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <memory>
 
 // Defined by the SDK (extern/tactile_sensors/sdk_cpp); forward-declared here so
 // this header doesn't pull in libserialport. The node's out-of-line destructor
@@ -59,52 +38,57 @@ class RobotiqTactileSensor;
 class PollDataSdkNode : public rclcpp::Node
 {
 public:
-   PollDataSdkNode();
-   ~PollDataSdkNode() override;
+    PollDataSdkNode();
+    ~PollDataSdkNode() override;
 
-   bool startSensor();
-   bool waitForStreaming();
-   void handleFingers(const Fingers& fingers);
+    bool startSensor();
+    bool waitForStreaming();
+    void handleFingers(const Fingers &fingers);
 
 private:
-   void serviceCallback(const std::shared_ptr<robotiq_tsf::srv::TactileSensors::Request> req,
-                        std::shared_ptr<robotiq_tsf::srv::TactileSensors::Response> res);
+    void serviceCallback(
+        const std::shared_ptr<robotiq_tsf::srv::TactileSensors::Request> req,
+        std::shared_ptr<robotiq_tsf::srv::TactileSensors::Response> res);
 
-   rclcpp::Publisher<robotiq_tsf::msg::StaticData>::SharedPtr static_pub_;
-   rclcpp::Publisher<robotiq_tsf::msg::Dynamic>::SharedPtr dynamic_pub_;
-   rclcpp::Publisher<robotiq_tsf::msg::Accelerometer>::SharedPtr accel_pub_;
-   rclcpp::Publisher<robotiq_tsf::msg::Gyroscope>::SharedPtr gyro_pub_;
-   rclcpp::Publisher<robotiq_tsf::msg::EulerAngle>::SharedPtr euler_pub_;
-   rclcpp::Publisher<robotiq_tsf::msg::Quaternion>::SharedPtr quat_pub_;
-   rclcpp::Publisher<robotiq_tsf::msg::Timestamp>::SharedPtr ts_pub_;
-   rclcpp::Service<robotiq_tsf::srv::TactileSensors>::SharedPtr service_;
+    rclcpp::Publisher<robotiq_tsf::msg::StaticData>::SharedPtr static_pub_;
+    rclcpp::Publisher<robotiq_tsf::msg::Dynamic>::SharedPtr dynamic_pub_;
+    rclcpp::Publisher<robotiq_tsf::msg::Accelerometer>::SharedPtr accel_pub_;
+    rclcpp::Publisher<robotiq_tsf::msg::Gyroscope>::SharedPtr gyro_pub_;
+    rclcpp::Publisher<robotiq_tsf::msg::EulerAngle>::SharedPtr euler_pub_;
+    rclcpp::Publisher<robotiq_tsf::msg::Quaternion>::SharedPtr quat_pub_;
+    rclcpp::Publisher<robotiq_tsf::msg::Timestamp>::SharedPtr ts_pub_;
+    rclcpp::Service<robotiq_tsf::srv::TactileSensors>::SharedPtr service_;
 
-   std::unique_ptr<RobotiqTactileSensor> sensor_;
-   robotiq_tsf::msg::Sensor sensors_data_;
+    std::unique_ptr<RobotiqTactileSensor> sensor_;
+    robotiq_tsf::msg::Sensor sensors_data_;
 
-   // Publish-rate throttle: set via the publish_rate_hz parameter, from which
-   // this is derived as 1/publish_rate_hz. Default 0 = publish every packet at
-   // the sensor's native rate (~700 Hz), as poll_data_node did. A positive
-   // publish_rate_hz decimates the publishes for downstream consumers that
-   // don't need the full rate; the IMU fusion + bias calc still run on every
-   // packet regardless (fusion accuracy needs the full rate).
-   // Read/written only from the single SDK callback thread.
-   double publish_period_s_ = 0.0;
-   std::chrono::steady_clock::time_point last_pub_{};
+    // Publish-rate throttle: set via the publish_rate_hz parameter, from which
+    // this is derived as 1/publish_rate_hz. Default 0 = publish every packet at
+    // the sensor's native rate (~700 Hz), as poll_data_node did. A positive
+    // publish_rate_hz decimates the publishes for downstream consumers that
+    // don't need the full rate; the IMU fusion + bias calc still run on every
+    // packet regardless (fusion accuracy needs the full rate).
+    // Read/written only from the single SDK callback thread.
+    double publish_period_s_ = 0.0;
+    std::chrono::steady_clock::time_point last_pub_{};
 
-   int bias_iter_ = 0;
-   float ax1_bias_ = 0, ay1_bias_ = 0, az1_bias_ = 0;
-   float ax2_bias_ = 0, ay2_bias_ = 0, az2_bias_ = 0;
-   float gx1_bias_ = 0, gy1_bias_ = 0, gz1_bias_ = 0;
-   float gx2_bias_ = 0, gy2_bias_ = 0, gz2_bias_ = 0;
+    // Per-finger IMU bias estimates: accumulated as sums during the startup
+    // calibration window, then converted to means. The accel "bias" is really
+    // the gravity direction and seeds the filter (see handleFingers). Zeroed
+    // in the constructor (Eigen vectors default-construct uninitialized).
+    int bias_iter_ = 0;
+    std::array<Eigen::Vector3f, FINGER_COUNT> accel_bias_;
+    std::array<Eigen::Vector3f, FINGER_COUNT> gyro_bias_;
 
-   // AHRS filter — one instance per finger; integrated on every SDK packet.
-   robotiq_tsf::AhrsConfig ahrs_cfg_;
-   MadgwickFilter filter_[FINGER_COUNT];
-   // Per-finger MCU timestamp (ms) of the last integrated sample; 0 = not yet
-   // seeded (start of stream, or just after the bias calibration).
-   uint64_t last_ts_ms_[FINGER_COUNT] = {0, 0};
+    // AHRS filter — one instance per finger; integrated on every SDK packet.
+    robotiq_tsf::AhrsConfig ahrs_cfg_;
+    std::array<MadgwickFilter, FINGER_COUNT> filter_;
+    // Per-finger MCU timestamp (ms) of the last integrated sample; 0 = not yet
+    // seeded (start of stream, or just after the bias calibration).
+    std::array<uint64_t, FINGER_COUNT> last_ts_ms_{};
 
-   std::atomic<bool> stopped_{false};
-   std::atomic<uint64_t> frames_received_{0};
+    std::atomic<bool> stopped_{false};
+    std::atomic<uint64_t> frames_received_{0};
 };
+
+#endif  // ROBOTIQ_TSF_POLL_DATA_SDK_NODE_HPP

--- a/robotiq_tsf/package.xml
+++ b/robotiq_tsf/package.xml
@@ -28,6 +28,8 @@
   <exec_depend>ament_index_cpp</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
+  <!-- Quaternion algebra in the AHRS/algorithms library (header-only). -->
+  <depend>eigen</depend>
   <depend>libopencv-dev</depend>
   <!-- SDK-backed poller (poll_data_sdk_node) links the tactile_sensors SDK,
        which uses libserialport. Installed explicitly in docker/Dockerfile. -->

--- a/robotiq_tsf/src/MadgwickAHRS.cpp
+++ b/robotiq_tsf/src/MadgwickAHRS.cpp
@@ -1,3 +1,31 @@
+// Copyright (c) 2026 Robotiq
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 // MadgwickAHRS.cpp
 //
 // Class-based Madgwick IMU AHRS filter (gyro+accel only). Derived from the
@@ -21,143 +49,161 @@
 namespace {
 constexpr float kEpsNorm = 1e-12f;
 
-inline float safeRecipSqrt(float x) {
-    if (x <= kEpsNorm) return 0.0f;
-    return 1.0f/std::sqrt(x);
+inline float safeRecipSqrt(float x)
+{
+   if(x <= kEpsNorm)
+   {
+      return 0.0f;
+   }
+   return 1.0f / std::sqrt(x);
 }
-}  // namespace
+} // namespace
 
 MadgwickFilter::MadgwickFilter(float beta)
-    : q_(Eigen::Quaternionf::Identity()),
-      beta_(beta),
-      accel_gate_lo_(0.85f),
-      accel_gate_hi_(1.15f) {}
-
-void MadgwickFilter::reset() {
-    q_ = Eigen::Quaternionf::Identity();
+   : q_(Eigen::Quaternionf::Identity())
+   , beta_(beta)
+   , accel_gate_lo_(0.85f)
+   , accel_gate_hi_(1.15f)
+{
 }
 
-void MadgwickFilter::setBeta(float beta) { beta_ = beta; }
-
-void MadgwickFilter::setAccelGate(float lo, float hi) {
-    accel_gate_lo_ = lo;
-    accel_gate_hi_ = hi;
+void MadgwickFilter::reset()
+{
+   q_ = Eigen::Quaternionf::Identity();
 }
 
-void MadgwickFilter::initFromAccel(float ax, float ay, float az) {
-    // Normalise the accelerometer reading to get the gravity direction in body
-    // frame. Build the quaternion that rotates body gravity onto world +Z, with
-    // yaw fixed at zero (no magnetometer reference available).
-    const Eigen::Vector3f a(ax, ay, az);
-    // Guard compares the norm (not squaredNorm) against kEpsNorm, matching
-    // the pre-Eigen implementation's degenerate-input threshold.
-    const float norm = a.norm();
-    if (norm <= kEpsNorm) {
-        reset();
-        return;
-    }
-    const Eigen::Vector3f g = a/norm;
-
-    // Tait-Bryan: with gravity = (-sin(pitch), sin(roll)*cos(pitch), cos(roll)*cos(pitch))
-    // in body frame for ZYX rotation from world (assuming world gravity = +Z).
-    const float roll = std::atan2(g.y(), g.z());
-    const float pitch = std::atan2(-g.x(), std::sqrt(g.y()*g.y() + g.z()*g.z()));
-
-    // ZYX composition with yaw = 0: q = qy(pitch) * qx(roll).
-    q_ = Eigen::AngleAxisf(pitch, Eigen::Vector3f::UnitY())
-       * Eigen::AngleAxisf(roll, Eigen::Vector3f::UnitX());
+void MadgwickFilter::setBeta(float beta)
+{
+   beta_ = beta;
 }
 
-void MadgwickFilter::updateIMU(float gx, float gy, float gz,
-                               float ax, float ay, float az,
-                               float dt) {
-    if (dt <= 0.0f) return;
-
-    // Rate of change of quaternion from gyroscope: qDot = 0.5 * q ⊗ (0, ω).
-    const Eigen::Quaternionf omega(0.0f, gx, gy, gz);
-    Eigen::Quaternionf qDot = q_*omega;
-    qDot.coeffs() *= 0.5f;
-
-    const Eigen::Vector3f accel(ax, ay, az);
-    const float accelNormSq = accel.squaredNorm();
-    if (accelNormSq > kEpsNorm) {
-        const float accelNorm = std::sqrt(accelNormSq);
-        // Only trust accel as a gravity reference when its magnitude is close
-        // to 1 g; outside this band the sensor is in non-gravity motion and
-        // the gradient step would corrupt the estimate.
-        if (accelNorm > accel_gate_lo_ && accelNorm < accel_gate_hi_) {
-            // Reciprocal-multiply (not division) to match the reference
-            // implementation's rounding exactly.
-            const Eigen::Vector3f an = accel*(1.0f/accelNorm);
-
-            // Madgwick gradient-descent step, kept as the reference scalar
-            // expansion (it is the algorithm itself, not generic algebra).
-            const float q0 = q_.w();
-            const float q1 = q_.x();
-            const float q2 = q_.y();
-            const float q3 = q_.z();
-            const float _2q0 = 2.0f*q0;
-            const float _2q1 = 2.0f*q1;
-            const float _2q2 = 2.0f*q2;
-            const float _2q3 = 2.0f*q3;
-            const float _4q0 = 4.0f*q0;
-            const float _4q1 = 4.0f*q1;
-            const float _4q2 = 4.0f*q2;
-            const float _8q1 = 8.0f*q1;
-            const float _8q2 = 8.0f*q2;
-            const float q0q0 = q0*q0;
-            const float q1q1 = q1*q1;
-            const float q2q2 = q2*q2;
-            const float q3q3 = q3*q3;
-
-            float s0 = _4q0*q2q2 + _2q2*an.x() + _4q0*q1q1 - _2q1*an.y();
-            float s1 = _4q1*q3q3 - _2q3*an.x() + 4.0f*q0q0*q1 - _2q0*an.y()
-                       - _4q1 + _8q1*q1q1 + _8q1*q2q2 + _4q1*an.z();
-            float s2 = 4.0f*q0q0*q2 + _2q0*an.x() + _4q2*q3q3 - _2q3*an.y()
-                       - _4q2 + _8q2*q1q1 + _8q2*q2q2 + _4q2*an.z();
-            float s3 = 4.0f*q1q1*q3 - _2q1*an.x() + 4.0f*q2q2*q3 - _2q2*an.y();
-            Eigen::Quaternionf s(s0, s1, s2, s3);
-            s.coeffs() *= safeRecipSqrt(s.squaredNorm());
-
-            qDot.coeffs() -= beta_*s.coeffs();
-        }
-    }
-
-    q_.coeffs() += qDot.coeffs()*dt;
-    q_.coeffs() *= safeRecipSqrt(q_.squaredNorm());
+void MadgwickFilter::setAccelGate(float lo, float hi)
+{
+   accel_gate_lo_ = lo;
+   accel_gate_hi_ = hi;
 }
 
-void MadgwickFilter::getQuaternion(float &q0, float &q1, float &q2, float &q3) const {
-    q0 = q_.w();
-    q1 = q_.x();
-    q2 = q_.y();
-    q3 = q_.z();
+void MadgwickFilter::initFromAccel(float ax, float ay, float az)
+{
+   // Normalise the accelerometer reading to get the gravity direction in body
+   // frame. Build the quaternion that rotates body gravity onto world +Z, with
+   // yaw fixed at zero (no magnetometer reference available).
+   const Eigen::Vector3f a(ax, ay, az);
+   // Guard compares the norm (not squaredNorm) against kEpsNorm, matching
+   // the pre-Eigen implementation's degenerate-input threshold.
+   const float norm = a.norm();
+   if(norm <= kEpsNorm)
+   {
+      reset();
+      return;
+   }
+   const Eigen::Vector3f g = a / norm;
+
+   // Tait-Bryan: with gravity = (-sin(pitch), sin(roll)*cos(pitch), cos(roll)*cos(pitch))
+   // in body frame for ZYX rotation from world (assuming world gravity = +Z).
+   const float roll = std::atan2(g.y(), g.z());
+   const float pitch = std::atan2(-g.x(), std::sqrt(g.y() * g.y() + g.z() * g.z()));
+
+   // ZYX composition with yaw = 0: q = qy(pitch) * qx(roll).
+   q_ = Eigen::AngleAxisf(pitch, Eigen::Vector3f::UnitY()) * Eigen::AngleAxisf(roll, Eigen::Vector3f::UnitX());
 }
 
-void MadgwickFilter::getEulerDeg(float &roll, float &pitch, float &yaw) const {
-    quatToEulerDeg(q_, roll, pitch, yaw);
+void MadgwickFilter::updateIMU(float gx, float gy, float gz, float ax, float ay, float az, float dt)
+{
+   if(dt <= 0.0f)
+   {
+      return;
+   }
+
+   // Rate of change of quaternion from gyroscope: qDot = 0.5 * q ⊗ (0, ω).
+   const Eigen::Quaternionf omega(0.0f, gx, gy, gz);
+   Eigen::Quaternionf qDot = q_ * omega;
+   qDot.coeffs() *= 0.5f;
+
+   const Eigen::Vector3f accel(ax, ay, az);
+   const float accelNormSq = accel.squaredNorm();
+   if(accelNormSq > kEpsNorm)
+   {
+      const float accelNorm = std::sqrt(accelNormSq);
+      // Only trust accel as a gravity reference when its magnitude is close
+      // to 1 g; outside this band the sensor is in non-gravity motion and
+      // the gradient step would corrupt the estimate.
+      if(accelNorm > accel_gate_lo_ && accelNorm < accel_gate_hi_)
+      {
+         // Reciprocal-multiply (not division) to match the reference
+         // implementation's rounding exactly.
+         const Eigen::Vector3f an = accel * (1.0f / accelNorm);
+
+         // Madgwick gradient-descent step, kept as the reference scalar
+         // expansion (it is the algorithm itself, not generic algebra).
+         const float q0 = q_.w();
+         const float q1 = q_.x();
+         const float q2 = q_.y();
+         const float q3 = q_.z();
+         const float _2q0 = 2.0f * q0;
+         const float _2q1 = 2.0f * q1;
+         const float _2q2 = 2.0f * q2;
+         const float _2q3 = 2.0f * q3;
+         const float _4q0 = 4.0f * q0;
+         const float _4q1 = 4.0f * q1;
+         const float _4q2 = 4.0f * q2;
+         const float _8q1 = 8.0f * q1;
+         const float _8q2 = 8.0f * q2;
+         const float q0q0 = q0 * q0;
+         const float q1q1 = q1 * q1;
+         const float q2q2 = q2 * q2;
+         const float q3q3 = q3 * q3;
+
+         float s0 = _4q0 * q2q2 + _2q2 * an.x() + _4q0 * q1q1 - _2q1 * an.y();
+         float s1 = _4q1 * q3q3 - _2q3 * an.x() + 4.0f * q0q0 * q1 - _2q0 * an.y() - _4q1 + _8q1 * q1q1 + _8q1 * q2q2
+                  + _4q1 * an.z();
+         float s2 = 4.0f * q0q0 * q2 + _2q0 * an.x() + _4q2 * q3q3 - _2q3 * an.y() - _4q2 + _8q2 * q1q1 + _8q2 * q2q2
+                  + _4q2 * an.z();
+         float s3 = 4.0f * q1q1 * q3 - _2q1 * an.x() + 4.0f * q2q2 * q3 - _2q2 * an.y();
+         Eigen::Quaternionf s(s0, s1, s2, s3);
+         s.coeffs() *= safeRecipSqrt(s.squaredNorm());
+
+         qDot.coeffs() -= beta_ * s.coeffs();
+      }
+   }
+
+   q_.coeffs() += qDot.coeffs() * dt;
+   q_.coeffs() *= safeRecipSqrt(q_.squaredNorm());
+}
+
+void MadgwickFilter::getQuaternion(float& q0, float& q1, float& q2, float& q3) const
+{
+   q0 = q_.w();
+   q1 = q_.x();
+   q2 = q_.y();
+   q3 = q_.z();
+}
+
+void MadgwickFilter::getEulerDeg(float& roll, float& pitch, float& yaw) const
+{
+   quatToEulerDeg(q_, roll, pitch, yaw);
 }
 
 // --- free helpers --------------------------------------------------------------
 
-void quatToEulerRad(const Eigen::Quaternionf &q, float &roll, float &pitch, float &yaw) {
-    // Matches the legacy ZYX extraction used by PollData.cpp.
-    const float q0 = q.w();
-    const float q1 = q.x();
-    const float q2 = q.y();
-    const float q3 = q.z();
-    roll  = std::atan2(2.0f*(q0*q1 + q2*q3),
-                       q0*q0 - q1*q1 - q2*q2 + q3*q3);
-    const float sinp = 2.0f*(q1*q3 - q0*q2);
-    pitch = -std::asin(sinp < -1.0f ? -1.0f : (sinp > 1.0f ? 1.0f : sinp));
-    yaw   = std::atan2(2.0f*(q1*q2 + q0*q3),
-                       q0*q0 + q1*q1 - q2*q2 - q3*q3);
+void quatToEulerRad(const Eigen::Quaternionf& q, float& roll, float& pitch, float& yaw)
+{
+   // Matches the legacy ZYX extraction used by PollData.cpp.
+   const float q0 = q.w();
+   const float q1 = q.x();
+   const float q2 = q.y();
+   const float q3 = q.z();
+   roll = std::atan2(2.0f * (q0 * q1 + q2 * q3), q0 * q0 - q1 * q1 - q2 * q2 + q3 * q3);
+   const float sinp = 2.0f * (q1 * q3 - q0 * q2);
+   pitch = -std::asin(sinp < -1.0f ? -1.0f : (sinp > 1.0f ? 1.0f : sinp));
+   yaw = std::atan2(2.0f * (q1 * q2 + q0 * q3), q0 * q0 + q1 * q1 - q2 * q2 - q3 * q3);
 }
 
-void quatToEulerDeg(const Eigen::Quaternionf &q, float &roll, float &pitch, float &yaw) {
-    quatToEulerRad(q, roll, pitch, yaw);
-    constexpr float k = 57.2957795130823f;  // 180/pi
-    roll  *= k;
-    pitch *= k;
-    yaw   *= k;
+void quatToEulerDeg(const Eigen::Quaternionf& q, float& roll, float& pitch, float& yaw)
+{
+   quatToEulerRad(q, roll, pitch, yaw);
+   constexpr float k = 57.2957795130823f; // 180/pi
+   roll *= k;
+   pitch *= k;
+   yaw *= k;
 }

--- a/robotiq_tsf/src/MadgwickAHRS.cpp
+++ b/robotiq_tsf/src/MadgwickAHRS.cpp
@@ -1,31 +1,3 @@
-// Copyright (c) 2026 Robotiq
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above copyright
-//      notice, this list of conditions and the following disclaimer in the
-//      documentation and/or other materials provided with the distribution.
-//
-//    * Neither the name of the copyright holder nor the names of its
-//      contributors may be used to endorse or promote products derived from
-//      this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
-
 // MadgwickAHRS.cpp
 //
 // Class-based Madgwick IMU AHRS filter (gyro+accel only). Derived from the
@@ -39,6 +11,8 @@
 //   - initFromAccel() seeds the quaternion from the calibration-time gravity
 //     vector instead of always starting at identity.
 //   - invSqrt bit-hack replaced with 1.0f/sqrtf (no UB, faster on modern HW).
+//   - Generic quaternion algebra (composition, integration, normalization)
+//     delegated to Eigen; only the Madgwick gradient step stays expanded.
 
 #include "robotiq_tsf/MadgwickAHRS.h"
 
@@ -47,241 +21,143 @@
 namespace {
 constexpr float kEpsNorm = 1e-12f;
 
-inline float safeRecipSqrt(float x)
-{
-   if(x <= kEpsNorm)
-   {
-      return 0.0f;
-   }
-   return 1.0f / std::sqrt(x);
+inline float safeRecipSqrt(float x) {
+    if (x <= kEpsNorm) return 0.0f;
+    return 1.0f/std::sqrt(x);
 }
-} // namespace
+}  // namespace
 
 MadgwickFilter::MadgwickFilter(float beta)
-   : q0_(1.0f)
-   , q1_(0.0f)
-   , q2_(0.0f)
-   , q3_(0.0f)
-   , beta_(beta)
-   , accel_gate_lo_(0.85f)
-   , accel_gate_hi_(1.15f)
-{
+    : q_(Eigen::Quaternionf::Identity()),
+      beta_(beta),
+      accel_gate_lo_(0.85f),
+      accel_gate_hi_(1.15f) {}
+
+void MadgwickFilter::reset() {
+    q_ = Eigen::Quaternionf::Identity();
 }
 
-void MadgwickFilter::reset()
-{
-   q0_ = 1.0f;
-   q1_ = 0.0f;
-   q2_ = 0.0f;
-   q3_ = 0.0f;
+void MadgwickFilter::setBeta(float beta) { beta_ = beta; }
+
+void MadgwickFilter::setAccelGate(float lo, float hi) {
+    accel_gate_lo_ = lo;
+    accel_gate_hi_ = hi;
 }
 
-void MadgwickFilter::setBeta(float beta)
-{
-   beta_ = beta;
+void MadgwickFilter::initFromAccel(float ax, float ay, float az) {
+    // Normalise the accelerometer reading to get the gravity direction in body
+    // frame. Build the quaternion that rotates body gravity onto world +Z, with
+    // yaw fixed at zero (no magnetometer reference available).
+    const Eigen::Vector3f a(ax, ay, az);
+    // Guard compares the norm (not squaredNorm) against kEpsNorm, matching
+    // the pre-Eigen implementation's degenerate-input threshold.
+    const float norm = a.norm();
+    if (norm <= kEpsNorm) {
+        reset();
+        return;
+    }
+    const Eigen::Vector3f g = a/norm;
+
+    // Tait-Bryan: with gravity = (-sin(pitch), sin(roll)*cos(pitch), cos(roll)*cos(pitch))
+    // in body frame for ZYX rotation from world (assuming world gravity = +Z).
+    const float roll = std::atan2(g.y(), g.z());
+    const float pitch = std::atan2(-g.x(), std::sqrt(g.y()*g.y() + g.z()*g.z()));
+
+    // ZYX composition with yaw = 0: q = qy(pitch) * qx(roll).
+    q_ = Eigen::AngleAxisf(pitch, Eigen::Vector3f::UnitY())
+       * Eigen::AngleAxisf(roll, Eigen::Vector3f::UnitX());
 }
 
-void MadgwickFilter::setAccelGate(float lo, float hi)
-{
-   accel_gate_lo_ = lo;
-   accel_gate_hi_ = hi;
+void MadgwickFilter::updateIMU(float gx, float gy, float gz,
+                               float ax, float ay, float az,
+                               float dt) {
+    if (dt <= 0.0f) return;
+
+    // Rate of change of quaternion from gyroscope: qDot = 0.5 * q ⊗ (0, ω).
+    const Eigen::Quaternionf omega(0.0f, gx, gy, gz);
+    Eigen::Quaternionf qDot = q_*omega;
+    qDot.coeffs() *= 0.5f;
+
+    const Eigen::Vector3f accel(ax, ay, az);
+    const float accelNormSq = accel.squaredNorm();
+    if (accelNormSq > kEpsNorm) {
+        const float accelNorm = std::sqrt(accelNormSq);
+        // Only trust accel as a gravity reference when its magnitude is close
+        // to 1 g; outside this band the sensor is in non-gravity motion and
+        // the gradient step would corrupt the estimate.
+        if (accelNorm > accel_gate_lo_ && accelNorm < accel_gate_hi_) {
+            // Reciprocal-multiply (not division) to match the reference
+            // implementation's rounding exactly.
+            const Eigen::Vector3f an = accel*(1.0f/accelNorm);
+
+            // Madgwick gradient-descent step, kept as the reference scalar
+            // expansion (it is the algorithm itself, not generic algebra).
+            const float q0 = q_.w();
+            const float q1 = q_.x();
+            const float q2 = q_.y();
+            const float q3 = q_.z();
+            const float _2q0 = 2.0f*q0;
+            const float _2q1 = 2.0f*q1;
+            const float _2q2 = 2.0f*q2;
+            const float _2q3 = 2.0f*q3;
+            const float _4q0 = 4.0f*q0;
+            const float _4q1 = 4.0f*q1;
+            const float _4q2 = 4.0f*q2;
+            const float _8q1 = 8.0f*q1;
+            const float _8q2 = 8.0f*q2;
+            const float q0q0 = q0*q0;
+            const float q1q1 = q1*q1;
+            const float q2q2 = q2*q2;
+            const float q3q3 = q3*q3;
+
+            float s0 = _4q0*q2q2 + _2q2*an.x() + _4q0*q1q1 - _2q1*an.y();
+            float s1 = _4q1*q3q3 - _2q3*an.x() + 4.0f*q0q0*q1 - _2q0*an.y()
+                       - _4q1 + _8q1*q1q1 + _8q1*q2q2 + _4q1*an.z();
+            float s2 = 4.0f*q0q0*q2 + _2q0*an.x() + _4q2*q3q3 - _2q3*an.y()
+                       - _4q2 + _8q2*q1q1 + _8q2*q2q2 + _4q2*an.z();
+            float s3 = 4.0f*q1q1*q3 - _2q1*an.x() + 4.0f*q2q2*q3 - _2q2*an.y();
+            Eigen::Quaternionf s(s0, s1, s2, s3);
+            s.coeffs() *= safeRecipSqrt(s.squaredNorm());
+
+            qDot.coeffs() -= beta_*s.coeffs();
+        }
+    }
+
+    q_.coeffs() += qDot.coeffs()*dt;
+    q_.coeffs() *= safeRecipSqrt(q_.squaredNorm());
 }
 
-void MadgwickFilter::initFromAccel(float ax, float ay, float az)
-{
-   // Normalise the accelerometer reading to get the gravity direction in body
-   // frame. Build the quaternion that rotates body gravity onto world +Z, with
-   // yaw fixed at zero (no magnetometer reference available).
-   const float norm = std::sqrt(ax * ax + ay * ay + az * az);
-   if(norm <= kEpsNorm)
-   {
-      reset();
-      return;
-   }
-   const float gx = ax / norm;
-   const float gy = ay / norm;
-   const float gz = az / norm;
-
-   // Tait-Bryan: with gravity = (-sin(pitch), sin(roll)*cos(pitch), cos(roll)*cos(pitch))
-   // in body frame for ZYX rotation from world (assuming world gravity = +Z).
-   const float roll = std::atan2(gy, gz);
-   const float pitch = std::atan2(-gx, std::sqrt(gy * gy + gz * gz));
-   const float yaw = 0.0f;
-
-   const float cr = std::cos(roll * 0.5f);
-   const float sr = std::sin(roll * 0.5f);
-   const float cp = std::cos(pitch * 0.5f);
-   const float sp = std::sin(pitch * 0.5f);
-   const float cy = std::cos(yaw * 0.5f);
-   const float sy = std::sin(yaw * 0.5f);
-
-   // ZYX composition: q = qz * qy * qx
-   q0_ = cr * cp * cy + sr * sp * sy;
-   q1_ = sr * cp * cy - cr * sp * sy;
-   q2_ = cr * sp * cy + sr * cp * sy;
-   q3_ = cr * cp * sy - sr * sp * cy;
+void MadgwickFilter::getQuaternion(float &q0, float &q1, float &q2, float &q3) const {
+    q0 = q_.w();
+    q1 = q_.x();
+    q2 = q_.y();
+    q3 = q_.z();
 }
 
-void MadgwickFilter::updateIMU(float gx, float gy, float gz, float ax, float ay, float az, float dt)
-{
-   if(dt <= 0.0f)
-   {
-      return;
-   }
-
-   // Rate of change of quaternion from gyroscope.
-   float qDot1 = 0.5f * (-q1_ * gx - q2_ * gy - q3_ * gz);
-   float qDot2 = 0.5f * (q0_ * gx + q2_ * gz - q3_ * gy);
-   float qDot3 = 0.5f * (q0_ * gy - q1_ * gz + q3_ * gx);
-   float qDot4 = 0.5f * (q0_ * gz + q1_ * gy - q2_ * gx);
-
-   const float accelNormSq = ax * ax + ay * ay + az * az;
-   if(accelNormSq > kEpsNorm)
-   {
-      const float accelNorm = std::sqrt(accelNormSq);
-      // Only trust accel as a gravity reference when its magnitude is close
-      // to 1 g; outside this band the sensor is in non-gravity motion and
-      // the gradient step would corrupt the estimate.
-      if(accelNorm > accel_gate_lo_ && accelNorm < accel_gate_hi_)
-      {
-         const float recipNorm = 1.0f / accelNorm;
-         ax *= recipNorm;
-         ay *= recipNorm;
-         az *= recipNorm;
-
-         const float _2q0 = 2.0f * q0_;
-         const float _2q1 = 2.0f * q1_;
-         const float _2q2 = 2.0f * q2_;
-         const float _2q3 = 2.0f * q3_;
-         const float _4q0 = 4.0f * q0_;
-         const float _4q1 = 4.0f * q1_;
-         const float _4q2 = 4.0f * q2_;
-         const float _8q1 = 8.0f * q1_;
-         const float _8q2 = 8.0f * q2_;
-         const float q0q0 = q0_ * q0_;
-         const float q1q1 = q1_ * q1_;
-         const float q2q2 = q2_ * q2_;
-         const float q3q3 = q3_ * q3_;
-
-         float s0 = _4q0 * q2q2 + _2q2 * ax + _4q0 * q1q1 - _2q1 * ay;
-         float s1 =
-            _4q1 * q3q3 - _2q3 * ax + 4.0f * q0q0 * q1_ - _2q0 * ay - _4q1 + _8q1 * q1q1 + _8q1 * q2q2 + _4q1 * az;
-         float s2 =
-            4.0f * q0q0 * q2_ + _2q0 * ax + _4q2 * q3q3 - _2q3 * ay - _4q2 + _8q2 * q1q1 + _8q2 * q2q2 + _4q2 * az;
-         float s3 = 4.0f * q1q1 * q3_ - _2q1 * ax + 4.0f * q2q2 * q3_ - _2q2 * ay;
-         const float recipStep = safeRecipSqrt(s0 * s0 + s1 * s1 + s2 * s2 + s3 * s3);
-         s0 *= recipStep;
-         s1 *= recipStep;
-         s2 *= recipStep;
-         s3 *= recipStep;
-
-         qDot1 -= beta_ * s0;
-         qDot2 -= beta_ * s1;
-         qDot3 -= beta_ * s2;
-         qDot4 -= beta_ * s3;
-      }
-   }
-
-   q0_ += qDot1 * dt;
-   q1_ += qDot2 * dt;
-   q2_ += qDot3 * dt;
-   q3_ += qDot4 * dt;
-
-   const float recipQ = safeRecipSqrt(q0_ * q0_ + q1_ * q1_ + q2_ * q2_ + q3_ * q3_);
-   q0_ *= recipQ;
-   q1_ *= recipQ;
-   q2_ *= recipQ;
-   q3_ *= recipQ;
-}
-
-void MadgwickFilter::getQuaternion(float& q0, float& q1, float& q2, float& q3) const
-{
-   q0 = q0_;
-   q1 = q1_;
-   q2 = q2_;
-   q3 = q3_;
-}
-
-void MadgwickFilter::getEulerDeg(float& roll, float& pitch, float& yaw) const
-{
-   const float q[4] = {q0_, q1_, q2_, q3_};
-   quatToEulerDeg(q, roll, pitch, yaw);
+void MadgwickFilter::getEulerDeg(float &roll, float &pitch, float &yaw) const {
+    quatToEulerDeg(q_, roll, pitch, yaw);
 }
 
 // --- free helpers --------------------------------------------------------------
 
-void quatMul(const float a[4], const float b[4], float out[4])
-{
-   // Hamilton product. out = a ⊗ b. Local temporaries so out may alias a or b.
-   const float w = a[0] * b[0] - a[1] * b[1] - a[2] * b[2] - a[3] * b[3];
-   const float x = a[0] * b[1] + a[1] * b[0] + a[2] * b[3] - a[3] * b[2];
-   const float y = a[0] * b[2] - a[1] * b[3] + a[2] * b[0] + a[3] * b[1];
-   const float z = a[0] * b[3] + a[1] * b[2] - a[2] * b[1] + a[3] * b[0];
-   out[0] = w;
-   out[1] = x;
-   out[2] = y;
-   out[3] = z;
+void quatToEulerRad(const Eigen::Quaternionf &q, float &roll, float &pitch, float &yaw) {
+    // Matches the legacy ZYX extraction used by PollData.cpp.
+    const float q0 = q.w();
+    const float q1 = q.x();
+    const float q2 = q.y();
+    const float q3 = q.z();
+    roll  = std::atan2(2.0f*(q0*q1 + q2*q3),
+                       q0*q0 - q1*q1 - q2*q2 + q3*q3);
+    const float sinp = 2.0f*(q1*q3 - q0*q2);
+    pitch = -std::asin(sinp < -1.0f ? -1.0f : (sinp > 1.0f ? 1.0f : sinp));
+    yaw   = std::atan2(2.0f*(q1*q2 + q0*q3),
+                       q0*q0 + q1*q1 - q2*q2 - q3*q3);
 }
 
-void quatConj(const float q[4], float out[4])
-{
-   out[0] = q[0];
-   out[1] = -q[1];
-   out[2] = -q[2];
-   out[3] = -q[3];
-}
-
-void quatNormalize(float q[4])
-{
-   const float n = q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3];
-   const float r = safeRecipSqrt(n);
-   q[0] *= r;
-   q[1] *= r;
-   q[2] *= r;
-   q[3] *= r;
-}
-
-void quatFromAxisX(float angle_rad, float out[4])
-{
-   const float h = 0.5f * angle_rad;
-   out[0] = std::cos(h);
-   out[1] = std::sin(h);
-   out[2] = 0.0f;
-   out[3] = 0.0f;
-}
-
-void quatFromAxisY(float angle_rad, float out[4])
-{
-   const float h = 0.5f * angle_rad;
-   out[0] = std::cos(h);
-   out[1] = 0.0f;
-   out[2] = std::sin(h);
-   out[3] = 0.0f;
-}
-
-void quatFromAxisZ(float angle_rad, float out[4])
-{
-   const float h = 0.5f * angle_rad;
-   out[0] = std::cos(h);
-   out[1] = 0.0f;
-   out[2] = 0.0f;
-   out[3] = std::sin(h);
-}
-
-void quatToEulerRad(const float q[4], float& roll, float& pitch, float& yaw)
-{
-   // Matches the legacy ZYX extraction used by PollData.cpp.
-   roll = std::atan2(2.0f * (q[0] * q[1] + q[2] * q[3]), q[0] * q[0] - q[1] * q[1] - q[2] * q[2] + q[3] * q[3]);
-   const float sinp = 2.0f * (q[1] * q[3] - q[0] * q[2]);
-   pitch = -std::asin(sinp < -1.0f ? -1.0f : (sinp > 1.0f ? 1.0f : sinp));
-   yaw = std::atan2(2.0f * (q[1] * q[2] + q[0] * q[3]), q[0] * q[0] + q[1] * q[1] - q[2] * q[2] - q[3] * q[3]);
-}
-
-void quatToEulerDeg(const float q[4], float& roll, float& pitch, float& yaw)
-{
-   quatToEulerRad(q, roll, pitch, yaw);
-   constexpr float k = 57.2957795130823f; // 180/pi
-   roll *= k;
-   pitch *= k;
-   yaw *= k;
+void quatToEulerDeg(const Eigen::Quaternionf &q, float &roll, float &pitch, float &yaw) {
+    quatToEulerRad(q, roll, pitch, yaw);
+    constexpr float k = 57.2957795130823f;  // 180/pi
+    roll  *= k;
+    pitch *= k;
+    yaw   *= k;
 }

--- a/robotiq_tsf/src/poll_data_sdk.cpp
+++ b/robotiq_tsf/src/poll_data_sdk.cpp
@@ -1,46 +1,15 @@
-// Copyright (c) 2026 Robotiq
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above copyright
-//      notice, this list of conditions and the following disclaimer in the
-//      documentation and/or other materials provided with the distribution.
-//
-//    * Neither the name of the copyright holder nor the names of its
-//      contributors may be used to endorse or promote products derived from
-//      this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
-
 // Implementation of PollDataSdkNode (declared in poll_data_sdk_node.hpp).
 // The USB / packet / parsing logic lives in the SDK; this file is the bridge
 // into ROS plus the AHRS fusion. main() is in poll_data_sdk_main.cpp so the
 // class can be constructed by unit tests without a hardware sensor.
 
-#include <strings.h>
+#include "robotiq_tsf/poll_data_sdk_node.hpp"
 
-#include <cmath>
-#include <cstdint>
-#include <string>
-#include <thread>
-
-#include "RobotiqTactileSensor.h"
-#include "rclcpp/rclcpp.hpp"
 #include "robotiq_tsf/device_autodetect.hpp"
+#include "robotiq_tsf/sdk_bridge.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+
 // Full per-field message headers: create_publisher<T> needs each type's
 // typesupport (the header only needs their struct definitions, via sensor.hpp).
 #include "robotiq_tsf/msg/accelerometer.hpp"
@@ -50,17 +19,33 @@
 #include "robotiq_tsf/msg/quaternion.hpp"
 #include "robotiq_tsf/msg/static_data.hpp"
 #include "robotiq_tsf/msg/timestamp.hpp"
-#include "robotiq_tsf/poll_data_sdk_node.hpp"
-#include "robotiq_tsf/sdk_bridge.hpp"
+
+#include "RobotiqTactileSensor.h"
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <cmath>
+#include <string>
+#include <strings.h>
+#include <thread>
 
 namespace msg = robotiq_tsf::msg;
 namespace srv = robotiq_tsf::srv;
 
-namespace {
+namespace
+{
 constexpr int kBiasCalculationIterations = 5000;
-constexpr const char* kDefaultDevice = robotiq_tsf::kDefaultSensorDevice;
+constexpr const char *kDefaultDevice = robotiq_tsf::kDefaultSensorDevice;
 constexpr float kAccelRes = 2.0f / 32768.0f;
 constexpr float kGyroRes = 250.0f / 32768.0f;
+
+// Raw IMU triple (int16 counts) -> float vector, before resolution scaling.
+Eigen::Vector3f toVector3f(const int16_t (&v)[3])
+{
+    return {static_cast<float>(v[0]), static_cast<float>(v[1]),
+            static_cast<float>(v[2])};
+}
 // SDK sampling period: 1 ms (~1 kHz request rate).
 constexpr unsigned int kSamplePeriodMs = 1;
 
@@ -69,16 +54,16 @@ constexpr unsigned int kSamplePeriodMs = 1;
 // to `this` at the end of construction (before startSensor() creates the SDK
 // reader thread) and clears it in the destructor; atomic because the reader
 // thread reads it concurrently with those writes.
-std::atomic<PollDataSdkNode*> g_node_for_callback{nullptr};
+std::atomic<PollDataSdkNode *> g_node_for_callback{nullptr};
 
-void onSensorData(const Fingers& fingers)
+void onSensorData(const Fingers &fingers)
 {
-   if(auto* node = g_node_for_callback.load(std::memory_order_acquire))
-   {
-      node->handleFingers(fingers);
-   }
+    if (auto *node = g_node_for_callback.load(std::memory_order_acquire))
+    {
+        node->handleFingers(fingers);
+    }
 }
-} // namespace
+}  // namespace
 
 // Stop dispatching to this node, then join the SDK reader thread (in sensor_'s
 // destructor) while every member it touches is still alive. Doing this here
@@ -86,110 +71,119 @@ void onSensorData(const Fingers& fingers)
 // reader thread outlives the node otherwise.
 PollDataSdkNode::~PollDataSdkNode()
 {
-   g_node_for_callback.store(nullptr, std::memory_order_release);
-   sensor_.reset();
+    g_node_for_callback.store(nullptr, std::memory_order_release);
+    sensor_.reset();
 }
 
 PollDataSdkNode::PollDataSdkNode()
-   : rclcpp::Node("poll_data_sdk")
+    : rclcpp::Node("poll_data_sdk")
 {
-   declare_parameter<std::string>("device", kDefaultDevice);
+    declare_parameter<std::string>("device", kDefaultDevice);
 
-   // Cap the published topic rate (Hz). Default 0 = unthrottled: publish on
-   // every sensor packet, matching the legacy poll_data_node. Set a positive
-   // rate to decimate (fusion still runs at the full packet rate).
-   const double publish_rate_hz = declare_parameter<double>("publish_rate_hz", 0.0);
-   publish_period_s_ = publish_rate_hz > 0.0 ? 1.0 / publish_rate_hz : 0.0;
+    // Cap the published topic rate (Hz). Default 0 = unthrottled: publish on
+    // every sensor packet, matching the legacy poll_data_node. Set a positive
+    // rate to decimate (fusion still runs at the full packet rate).
+    const double publish_rate_hz =
+        declare_parameter<double>("publish_rate_hz", 0.0);
+    publish_period_s_ = publish_rate_hz > 0.0 ? 1.0 / publish_rate_hz : 0.0;
 
-   // AHRS tunables (madgwick.*), matching the legacy poll_data_node so existing
-   // launch files / configs that set them keep working.
-   ahrs_cfg_.beta = static_cast<float>(declare_parameter<double>("madgwick.beta", ahrs_cfg_.beta));
-   ahrs_cfg_.accel_gate_lo =
-      static_cast<float>(declare_parameter<double>("madgwick.accel_gate_lo", ahrs_cfg_.accel_gate_lo));
-   ahrs_cfg_.accel_gate_hi =
-      static_cast<float>(declare_parameter<double>("madgwick.accel_gate_hi", ahrs_cfg_.accel_gate_hi));
-   ahrs_cfg_.bias_learn_rate =
-      static_cast<float>(declare_parameter<double>("madgwick.bias_learn_rate", ahrs_cfg_.bias_learn_rate));
-   ahrs_cfg_.still_gyro_eps_deg_s =
-      static_cast<float>(declare_parameter<double>("madgwick.still_gyro_eps_deg_s", ahrs_cfg_.still_gyro_eps_deg_s));
-   ahrs_cfg_.still_accel_eps_g =
-      static_cast<float>(declare_parameter<double>("madgwick.still_accel_eps_g", ahrs_cfg_.still_accel_eps_g));
-   ahrs_cfg_.dt_clamp_lo = static_cast<float>(declare_parameter<double>("madgwick.dt_clamp_lo", ahrs_cfg_.dt_clamp_lo));
-   ahrs_cfg_.dt_clamp_hi = static_cast<float>(declare_parameter<double>("madgwick.dt_clamp_hi", ahrs_cfg_.dt_clamp_hi));
+    // AHRS tunables (madgwick.*), matching the legacy poll_data_node so existing
+    // launch files / configs that set them keep working.
+    ahrs_cfg_.beta = static_cast<float>(
+        declare_parameter<double>("madgwick.beta", ahrs_cfg_.beta));
+    ahrs_cfg_.accel_gate_lo = static_cast<float>(
+        declare_parameter<double>("madgwick.accel_gate_lo", ahrs_cfg_.accel_gate_lo));
+    ahrs_cfg_.accel_gate_hi = static_cast<float>(
+        declare_parameter<double>("madgwick.accel_gate_hi", ahrs_cfg_.accel_gate_hi));
+    ahrs_cfg_.bias_learn_rate = static_cast<float>(
+        declare_parameter<double>("madgwick.bias_learn_rate", ahrs_cfg_.bias_learn_rate));
+    ahrs_cfg_.still_gyro_eps_deg_s = static_cast<float>(
+        declare_parameter<double>("madgwick.still_gyro_eps_deg_s", ahrs_cfg_.still_gyro_eps_deg_s));
+    ahrs_cfg_.still_accel_eps_g = static_cast<float>(
+        declare_parameter<double>("madgwick.still_accel_eps_g", ahrs_cfg_.still_accel_eps_g));
+    ahrs_cfg_.dt_clamp_lo = static_cast<float>(
+        declare_parameter<double>("madgwick.dt_clamp_lo", ahrs_cfg_.dt_clamp_lo));
+    ahrs_cfg_.dt_clamp_hi = static_cast<float>(
+        declare_parameter<double>("madgwick.dt_clamp_hi", ahrs_cfg_.dt_clamp_hi));
 
-   for(int f = 0; f < FINGER_COUNT; ++f)
-   {
-      filter_[f].setBeta(ahrs_cfg_.beta);
-      filter_[f].setAccelGate(ahrs_cfg_.accel_gate_lo, ahrs_cfg_.accel_gate_hi);
-   }
+    for (int f = 0; f < FINGER_COUNT; ++f)
+    {
+        filter_[f].setBeta(ahrs_cfg_.beta);
+        filter_[f].setAccelGate(ahrs_cfg_.accel_gate_lo, ahrs_cfg_.accel_gate_hi);
+        accel_bias_[f].setZero();
+        gyro_bias_[f].setZero();
+    }
 
-   auto qos = rclcpp::SensorDataQoS();
-   static_pub_ = create_publisher<msg::StaticData>("TactileSensor/StaticData", qos);
-   dynamic_pub_ = create_publisher<msg::Dynamic>("TactileSensor/Dynamic", qos);
-   accel_pub_ = create_publisher<msg::Accelerometer>("TactileSensor/Accelerometer", qos);
-   gyro_pub_ = create_publisher<msg::Gyroscope>("TactileSensor/Gyroscope", qos);
-   euler_pub_ = create_publisher<msg::EulerAngle>("TactileSensor/EulerAngle", qos);
-   quat_pub_ = create_publisher<msg::Quaternion>("TactileSensor/Quaternion", qos);
-   ts_pub_ = create_publisher<msg::Timestamp>("TactileSensor/Timestamp", qos);
+    auto qos = rclcpp::SensorDataQoS();
+    static_pub_ = create_publisher<msg::StaticData>("TactileSensor/StaticData", qos);
+    dynamic_pub_ = create_publisher<msg::Dynamic>("TactileSensor/Dynamic", qos);
+    accel_pub_ = create_publisher<msg::Accelerometer>("TactileSensor/Accelerometer", qos);
+    gyro_pub_ = create_publisher<msg::Gyroscope>("TactileSensor/Gyroscope", qos);
+    euler_pub_ = create_publisher<msg::EulerAngle>("TactileSensor/EulerAngle", qos);
+    quat_pub_ = create_publisher<msg::Quaternion>("TactileSensor/Quaternion", qos);
+    ts_pub_ = create_publisher<msg::Timestamp>("TactileSensor/Timestamp", qos);
 
-   service_ = create_service<srv::TactileSensors>(
-      "tactile_sensors_service",
-      [this](const std::shared_ptr<srv::TactileSensors::Request> req,
-             std::shared_ptr<srv::TactileSensors::Response> res) { serviceCallback(req, res); });
+    service_ = create_service<srv::TactileSensors>(
+        "tactile_sensors_service",
+        [this](const std::shared_ptr<srv::TactileSensors::Request> req,
+               std::shared_ptr<srv::TactileSensors::Response> res)
+        { serviceCallback(req, res); });
 
-   // Register for the SDK C callback last: everything it touches now exists,
-   // and the reader thread that invokes it isn't created until startSensor().
-   g_node_for_callback.store(this, std::memory_order_release);
+    // Register for the SDK C callback last: everything it touches now exists,
+    // and the reader thread that invokes it isn't created until startSensor().
+    g_node_for_callback.store(this, std::memory_order_release);
 }
 
 bool PollDataSdkNode::startSensor()
 {
-   std::string device = get_parameter("device").as_string();
+    std::string device = get_parameter("device").as_string();
 
-   // If the user left the default device and it isn't present, fall back to
-   // the shared autodetect (rq_tsf85_*, then ttyACM*/ttyUSB* by USB
-   // descriptor string).
-   if(device == kDefaultDevice && !robotiq_tsf::deviceExists(device))
-   {
-      const std::string detected = robotiq_tsf::autoDetectSensorDevice();
-      if(!detected.empty())
-      {
-         RCLCPP_INFO(get_logger(),
-                     "Auto-detected tactile sensor on %s (default %s not present)",
-                     detected.c_str(),
-                     device.c_str());
-         device = detected;
-         set_parameter(rclcpp::Parameter("device", device));
-      }
-      else
-      {
-         RCLCPP_WARN(get_logger(), "Could not auto-detect tactile sensor; falling back to %s", device.c_str());
-      }
-   }
+    // If the user left the default device and it isn't present, fall back to
+    // the shared autodetect (rq_tsf85_*, then ttyACM*/ttyUSB* by USB
+    // descriptor string).
+    if (device == kDefaultDevice && !robotiq_tsf::deviceExists(device))
+    {
+        const std::string detected = robotiq_tsf::autoDetectSensorDevice();
+        if (!detected.empty())
+        {
+            RCLCPP_INFO(get_logger(),
+                        "Auto-detected tactile sensor on %s (default %s not present)",
+                        detected.c_str(), device.c_str());
+            device = detected;
+            set_parameter(rclcpp::Parameter("device", device));
+        }
+        else
+        {
+            RCLCPP_WARN(get_logger(),
+                        "Could not auto-detect tactile sensor; falling back to %s",
+                        device.c_str());
+        }
+    }
 
-   RCLCPP_INFO(get_logger(), "Opening tactile sensor at %s via SDK", device.c_str());
+    RCLCPP_INFO(get_logger(), "Opening tactile sensor at %s via SDK", device.c_str());
 
-   // The SDK (libserialport) opens the port in raw mode. That is load-bearing,
-   // not incidental: the sensor stream is binary, and a freshly re-enumerated
-   // CDC-ACM tty defaults to cooked line discipline (ICRNL rewrites 0x0D, IXON
-   // eats 0x11/0x13), which mangles the stream and makes the taxels read as
-   // rail-to-rail garbage ("flashing red"). This is exactly the bug the old
-   // hand-rolled poll_data_node hit (it never forced raw mode); the SDK path is
-   // immune only because libserialport sets raw mode for us. If this ever moves
-   // off libserialport, the replacement MUST put the tty in raw mode.
-   sensor_ = std::make_unique<RobotiqTactileSensor>(device.c_str(), &onSensorData, kSamplePeriodMs);
-   if(!sensor_->isConnected())
-   {
-      RCLCPP_FATAL(get_logger(), "SDK failed to open sensor: %s", sensor_->getLastError());
-      sensor_.reset();
-      return false;
-   }
+    // The SDK (libserialport) opens the port in raw mode. That is load-bearing,
+    // not incidental: the sensor stream is binary, and a freshly re-enumerated
+    // CDC-ACM tty defaults to cooked line discipline (ICRNL rewrites 0x0D, IXON
+    // eats 0x11/0x13), which mangles the stream and makes the taxels read as
+    // rail-to-rail garbage ("flashing red"). This is exactly the bug the old
+    // hand-rolled poll_data_node hit (it never forced raw mode); the SDK path is
+    // immune only because libserialport sets raw mode for us. If this ever moves
+    // off libserialport, the replacement MUST put the tty in raw mode.
+    sensor_ = std::make_unique<RobotiqTactileSensor>(device.c_str(), &onSensorData, kSamplePeriodMs);
+    if (!sensor_->isConnected())
+    {
+        RCLCPP_FATAL(get_logger(), "SDK failed to open sensor: %s",
+                     sensor_->getLastError());
+        sensor_.reset();
+        return false;
+    }
 
-   // NOTE: the firmware version is purely informational and nothing here
-   // uses it, and this sensor/firmware doesn't reliably reply to GET_VERSION
-   // (it consistently times out). So we don't query it at all — no point
-   // delaying startup for a value we don't need.
-   return true;
+    // NOTE: the firmware version is purely informational and nothing here
+    // uses it, and this sensor/firmware doesn't reliably reply to GET_VERSION
+    // (it consistently times out). So we don't query it at all — no point
+    // delaying startup for a value we don't need.
+    return true;
 }
 
 // The sensor can come up opened-but-silent (seen after an unclean shutdown of
@@ -198,240 +192,178 @@ bool PollDataSdkNode::startSensor()
 // stop/start to re-trigger streaming before giving up.
 bool PollDataSdkNode::waitForStreaming()
 {
-   using namespace std::chrono; // NOLINT(build/namespaces)
-   constexpr int kAttempts = 3;
-   constexpr auto kFirstDataTimeout = seconds(2);
+    using namespace std::chrono;
+    constexpr int kAttempts = 3;
+    constexpr auto kFirstDataTimeout = seconds(2);
 
-   for(int attempt = 1; attempt <= kAttempts; ++attempt)
-   {
-      const uint64_t before = frames_received_.load();
-      const auto deadline = steady_clock::now() + kFirstDataTimeout;
-      while(steady_clock::now() < deadline)
-      {
-         if(frames_received_.load() > before)
-         {
-            return true;
-         }
-         std::this_thread::sleep_for(milliseconds(50));
-      }
-      if(attempt < kAttempts)
-      {
-         RCLCPP_WARN(get_logger(),
-                     "No data from sensor after %lds; cycling the stream "
-                     "(attempt %d/%d)",
-                     static_cast<int64_t>(kFirstDataTimeout.count()),
-                     attempt,
-                     kAttempts);
-         sensor_->stop();
-         std::this_thread::sleep_for(milliseconds(200));
-         sensor_->start();
-      }
-   }
-   RCLCPP_FATAL(get_logger(),
-                "Sensor opened but never streamed data; replug the sensor "
-                "(or USB-reset it) and relaunch.");
-   return false;
+    for (int attempt = 1; attempt <= kAttempts; ++attempt)
+    {
+        const uint64_t before = frames_received_.load();
+        const auto deadline = steady_clock::now() + kFirstDataTimeout;
+        while (steady_clock::now() < deadline)
+        {
+            if (frames_received_.load() > before)
+                return true;
+            std::this_thread::sleep_for(milliseconds(50));
+        }
+        if (attempt < kAttempts)
+        {
+            RCLCPP_WARN(get_logger(),
+                        "No data from sensor after %lds; cycling the stream "
+                        "(attempt %d/%d)",
+                        static_cast<long>(kFirstDataTimeout.count()),
+                        attempt, kAttempts);
+            sensor_->stop();
+            std::this_thread::sleep_for(milliseconds(200));
+            sensor_->start();
+        }
+    }
+    RCLCPP_FATAL(get_logger(),
+                 "Sensor opened but never streamed data; replug the sensor "
+                 "(or USB-reset it) and relaunch.");
+    return false;
 }
 
-void PollDataSdkNode::serviceCallback(const std::shared_ptr<srv::TactileSensors::Request> req,
-                                      std::shared_ptr<srv::TactileSensors::Response> res)
+void PollDataSdkNode::serviceCallback(
+    const std::shared_ptr<srv::TactileSensors::Request> req,
+    std::shared_ptr<srv::TactileSensors::Response> res)
 {
-   RCLCPP_INFO(get_logger(), "TactileSensors service request: [%s]", req->request.c_str());
-   if(strcasecmp(req->request.c_str(), "start") == 0)
-   {
-      stopped_ = false;
-      if(sensor_)
-      {
-         sensor_->start();
-      }
-      res->response = true;
-      return;
-   }
-   if(strcasecmp(req->request.c_str(), "stop") == 0)
-   {
-      stopped_ = true;
-      if(sensor_)
-      {
-         sensor_->stop();
-      }
-      res->response = true;
-      return;
-   }
-   RCLCPP_WARN(get_logger(), "Invalid TactileSensors request");
-   res->response = false;
+    RCLCPP_INFO(get_logger(), "TactileSensors service request: [%s]", req->request.c_str());
+    if (strcasecmp(req->request.c_str(), "start") == 0)
+    {
+        stopped_ = false;
+        if (sensor_) sensor_->start();
+        res->response = true;
+        return;
+    }
+    if (strcasecmp(req->request.c_str(), "stop") == 0)
+    {
+        stopped_ = true;
+        if (sensor_) sensor_->stop();
+        res->response = true;
+        return;
+    }
+    RCLCPP_WARN(get_logger(), "Invalid TactileSensors request");
+    res->response = false;
 }
 
-void PollDataSdkNode::handleFingers(const Fingers& fingers)
+void PollDataSdkNode::handleFingers(const Fingers &fingers)
 {
-   frames_received_.fetch_add(1, std::memory_order_relaxed);
-   if(stopped_.load())
-   {
-      return;
-   }
+    frames_received_.fetch_add(1, std::memory_order_relaxed);
+    if (stopped_.load())
+        return;
 
-   robotiq_tsf::fillSensorMessages(fingers, sensors_data_);
+    robotiq_tsf::fillSensorMessages(fingers, sensors_data_);
 
-   if(bias_iter_ > kBiasCalculationIterations)
-   {
-      // Bias-corrected IMU: accel in g, gyro in deg/s.
-      const float ax1 = fingers.finger[0].accelerometer[0] * kAccelRes - ax1_bias_;
-      const float ay1 = fingers.finger[0].accelerometer[1] * kAccelRes - ay1_bias_;
-      const float az1 = fingers.finger[0].accelerometer[2] * kAccelRes - az1_bias_;
-      const float ax2 = fingers.finger[1].accelerometer[0] * kAccelRes - ax2_bias_;
-      const float ay2 = fingers.finger[1].accelerometer[1] * kAccelRes - ay2_bias_;
-      const float az2 = fingers.finger[1].accelerometer[2] * kAccelRes - az2_bias_;
-      const float gx1 = fingers.finger[0].gyroscope[0] * kGyroRes - gx1_bias_;
-      const float gy1 = fingers.finger[0].gyroscope[1] * kGyroRes - gy1_bias_;
-      const float gz1 = fingers.finger[0].gyroscope[2] * kGyroRes - gz1_bias_;
-      const float gx2 = fingers.finger[1].gyroscope[0] * kGyroRes - gx2_bias_;
-      const float gy2 = fingers.finger[1].gyroscope[1] * kGyroRes - gy2_bias_;
-      const float gz2 = fingers.finger[1].gyroscope[2] * kGyroRes - gz2_bias_;
+    if (bias_iter_ > kBiasCalculationIterations)
+    {
+        constexpr float deg_to_rad = static_cast<float>(M_PI / 180.0);
+        for (int f = 0; f < FINGER_COUNT; ++f)
+        {
+            const auto &finger = fingers.finger[f];
+            // Bias-corrected IMU: accel in g, gyro in deg/s. Explicit Vector3f
+            // on the left (not auto): the right side is a lazy Eigen expression
+            // referencing temporaries, and only the assignment evaluates it.
+            const Eigen::Vector3f accel =
+                toVector3f(finger.accelerometer)*kAccelRes - accel_bias_[f];
+            const Eigen::Vector3f gyro =
+                toVector3f(finger.gyroscope)*kGyroRes - gyro_bias_[f];
 
-      // Integration step from each finger's MCU timestamp (immune to host
-      // jitter, and to the stall a stop()->start() cycle would inject). 0 = not
-      // usable (first sample after calibration, or a duplicate/backwards
-      // timestamp) -> skip integration for that finger this frame.
-      const float dt1 = robotiq_tsf::deriveDt(last_ts_ms_[0],
-                                              fingers.finger[0].timestamp,
-                                              ahrs_cfg_.dt_clamp_lo,
-                                              ahrs_cfg_.dt_clamp_hi);
-      const float dt2 = robotiq_tsf::deriveDt(last_ts_ms_[1],
-                                              fingers.finger[1].timestamp,
-                                              ahrs_cfg_.dt_clamp_lo,
-                                              ahrs_cfg_.dt_clamp_hi);
-      last_ts_ms_[0] = fingers.finger[0].timestamp;
-      last_ts_ms_[1] = fingers.finger[1].timestamp;
+            // Integration step from the finger's MCU timestamp (immune to host
+            // jitter, and to the stall a stop()->start() cycle would inject).
+            // 0 = not usable (first sample after calibration, or a duplicate/
+            // backwards timestamp) -> skip integration for this finger.
+            const float dt = robotiq_tsf::deriveDt(last_ts_ms_[f], finger.timestamp,
+                                                   ahrs_cfg_.dt_clamp_lo, ahrs_cfg_.dt_clamp_hi);
+            last_ts_ms_[f] = finger.timestamp;
 
-      constexpr float deg_to_rad = static_cast<float>(M_PI / 180.0);
-      if(dt1 > 0.0f)
-      {
-         filter_[0].updateIMU(gx1 * deg_to_rad, gy1 * deg_to_rad, gz1 * deg_to_rad, ax1, ay1, az1, dt1);
-      }
-      if(dt2 > 0.0f)
-      {
-         filter_[1].updateIMU(gx2 * deg_to_rad, gy2 * deg_to_rad, gz2 * deg_to_rad, ax2, ay2, az2, dt2);
-      }
+            if (dt > 0.0f)
+            {
+                const Eigen::Vector3f gyro_rad = gyro*deg_to_rad;
+                filter_[f].updateIMU(gyro_rad.x(), gyro_rad.y(), gyro_rad.z(),
+                                     accel.x(), accel.y(), accel.z(), dt);
 
-      // Online gyro-bias trim while stationary: drift the stored bias slowly
-      // toward the residual, so a frozen bias can't leak thermal drift into yaw.
-      const float alpha = ahrs_cfg_.bias_learn_rate;
-      if(dt1 > 0.0f
-         && robotiq_tsf::sampleIsStill(gx1,
-                                       gy1,
-                                       gz1,
-                                       ax1,
-                                       ay1,
-                                       az1,
-                                       ahrs_cfg_.still_gyro_eps_deg_s,
-                                       ahrs_cfg_.still_accel_eps_g))
-      {
-         gx1_bias_ = robotiq_tsf::trimBias(gx1_bias_, gx1, alpha);
-         gy1_bias_ = robotiq_tsf::trimBias(gy1_bias_, gy1, alpha);
-         gz1_bias_ = robotiq_tsf::trimBias(gz1_bias_, gz1, alpha);
-      }
-      if(dt2 > 0.0f
-         && robotiq_tsf::sampleIsStill(gx2,
-                                       gy2,
-                                       gz2,
-                                       ax2,
-                                       ay2,
-                                       az2,
-                                       ahrs_cfg_.still_gyro_eps_deg_s,
-                                       ahrs_cfg_.still_accel_eps_g))
-      {
-         gx2_bias_ = robotiq_tsf::trimBias(gx2_bias_, gx2, alpha);
-         gy2_bias_ = robotiq_tsf::trimBias(gy2_bias_, gy2, alpha);
-         gz2_bias_ = robotiq_tsf::trimBias(gz2_bias_, gz2, alpha);
-      }
+                // Online gyro-bias trim while stationary: drift the stored bias
+                // slowly toward the residual, so a frozen bias can't leak
+                // thermal drift into yaw.
+                if (robotiq_tsf::sampleIsStill(gyro, accel,
+                                               ahrs_cfg_.still_gyro_eps_deg_s,
+                                               ahrs_cfg_.still_accel_eps_g))
+                {
+                    gyro_bias_[f] = robotiq_tsf::trimBias(gyro_bias_[f], gyro,
+                                                          ahrs_cfg_.bias_learn_rate);
+                }
+            }
 
-      // One absolute filter quaternion sources both orientation topics; Euler
-      // wraps at ±180°, so continuous-orientation consumers use Quaternion.
-      float q1[4], q2[4];
-      filter_[0].getQuaternion(q1[0], q1[1], q1[2], q1[3]);
-      filter_[1].getQuaternion(q2[0], q2[1], q2[2], q2[3]);
-      for(int i = 0; i < 4; ++i)
-      {
-         sensors_data_.quaternion.data[0].values[i] = q1[i];
-         sensors_data_.quaternion.data[1].values[i] = q2[i];
-      }
+            // One absolute filter quaternion sources both orientation topics;
+            // Euler wraps at ±180°, so continuous-orientation consumers use
+            // Quaternion.
+            const Eigen::Quaternionf q = filter_[f].quaternion();
+            sensors_data_.quaternion.data[f].values[0] = q.w();
+            sensors_data_.quaternion.data[f].values[1] = q.x();
+            sensors_data_.quaternion.data[f].values[2] = q.y();
+            sensors_data_.quaternion.data[f].values[3] = q.z();
 
-      filter_[0].getEulerDeg(sensors_data_.eulerangle.data[0].values[0],
-                             sensors_data_.eulerangle.data[0].values[1],
-                             sensors_data_.eulerangle.data[0].values[2]);
-      filter_[1].getEulerDeg(sensors_data_.eulerangle.data[1].values[0],
-                             sensors_data_.eulerangle.data[1].values[1],
-                             sensors_data_.eulerangle.data[1].values[2]);
-   }
-   else if(bias_iter_ == kBiasCalculationIterations)
-   {
-      gx1_bias_ /= kBiasCalculationIterations;
-      gy1_bias_ /= kBiasCalculationIterations;
-      gz1_bias_ /= kBiasCalculationIterations;
-      gx2_bias_ /= kBiasCalculationIterations;
-      gy2_bias_ /= kBiasCalculationIterations;
-      gz2_bias_ /= kBiasCalculationIterations;
-      ax1_bias_ /= kBiasCalculationIterations;
-      ay1_bias_ /= kBiasCalculationIterations;
-      az1_bias_ /= kBiasCalculationIterations;
-      ax2_bias_ /= kBiasCalculationIterations;
-      ay2_bias_ /= kBiasCalculationIterations;
-      az2_bias_ /= kBiasCalculationIterations;
+            filter_[f].getEulerDeg(sensors_data_.eulerangle.data[f].values[0],
+                                   sensors_data_.eulerangle.data[f].values[1],
+                                   sensors_data_.eulerangle.data[f].values[2]);
+        }
+    }
+    else if (bias_iter_ == kBiasCalculationIterations)
+    {
+        for (int f = 0; f < FINGER_COUNT; ++f)
+        {
+            gyro_bias_[f] /= kBiasCalculationIterations;
+            accel_bias_[f] /= kBiasCalculationIterations;
 
-      // Gravity in the body frame at rest is the signal, not a bias: seed
-      // each filter's quaternion from the accel mean, then stop subtracting
-      // the accel offset. Mirrors PollData.cpp's new MadgwickFilter path.
-      filter_[0].initFromAccel(ax1_bias_, ay1_bias_, az1_bias_);
-      filter_[1].initFromAccel(ax2_bias_, ay2_bias_, az2_bias_);
-      ax1_bias_ = ay1_bias_ = az1_bias_ = 0.0f;
-      ax2_bias_ = ay2_bias_ = az2_bias_ = 0.0f;
+            // Gravity in the body frame at rest is the signal, not a bias: seed
+            // each filter's quaternion from the accel mean, then stop subtracting
+            // the accel offset. Mirrors PollData.cpp's new MadgwickFilter path.
+            filter_[f].initFromAccel(accel_bias_[f].x(), accel_bias_[f].y(),
+                                     accel_bias_[f].z());
+            accel_bias_[f].setZero();
 
-      // Reseed the per-finger dt so the first post-calibration sample skips
-      // integration instead of using a stale delta spanning the calibration.
-      last_ts_ms_[0] = last_ts_ms_[1] = 0;
-      ++bias_iter_;
-   }
-   else
-   {
-      gx1_bias_ += fingers.finger[0].gyroscope[0] * kGyroRes;
-      gy1_bias_ += fingers.finger[0].gyroscope[1] * kGyroRes;
-      gz1_bias_ += fingers.finger[0].gyroscope[2] * kGyroRes;
-      gx2_bias_ += fingers.finger[1].gyroscope[0] * kGyroRes;
-      gy2_bias_ += fingers.finger[1].gyroscope[1] * kGyroRes;
-      gz2_bias_ += fingers.finger[1].gyroscope[2] * kGyroRes;
-      ax1_bias_ += fingers.finger[0].accelerometer[0] * kAccelRes;
-      ay1_bias_ += fingers.finger[0].accelerometer[1] * kAccelRes;
-      az1_bias_ += fingers.finger[0].accelerometer[2] * kAccelRes;
-      ax2_bias_ += fingers.finger[1].accelerometer[0] * kAccelRes;
-      ay2_bias_ += fingers.finger[1].accelerometer[1] * kAccelRes;
-      az2_bias_ += fingers.finger[1].accelerometer[2] * kAccelRes;
-      ++bias_iter_;
-   }
+            // Reseed the per-finger dt so the first post-calibration sample skips
+            // integration instead of using a stale delta spanning the calibration.
+            last_ts_ms_[f] = 0;
+        }
+        ++bias_iter_;
+    }
+    else
+    {
+        for (int f = 0; f < FINGER_COUNT; ++f)
+        {
+            const auto &finger = fingers.finger[f];
+            gyro_bias_[f] += toVector3f(finger.gyroscope)*kGyroRes;
+            accel_bias_[f] += toVector3f(finger.accelerometer)*kAccelRes;
+        }
+        ++bias_iter_;
+    }
 
-   // Decimate publishing to publish_period_s_ (fusion above already ran at
-   // full rate). Skip the very first packet's elapsed check by seeding
-   // last_pub_ on first use.
-   if(publish_period_s_ > 0.0)
-   {
-      const auto now = std::chrono::steady_clock::now();
-      if(last_pub_.time_since_epoch().count() != 0)
-      {
-         const double elapsed = std::chrono::duration<double>(now - last_pub_).count();
-         if(elapsed < publish_period_s_)
-         {
-            return;
-         }
-      }
-      last_pub_ = now;
-   }
+    // Decimate publishing to publish_period_s_ (fusion above already ran at
+    // full rate). Skip the very first packet's elapsed check by seeding
+    // last_pub_ on first use.
+    if (publish_period_s_ > 0.0)
+    {
+        const auto now = std::chrono::steady_clock::now();
+        if (last_pub_.time_since_epoch().count() != 0)
+        {
+            const double elapsed =
+                std::chrono::duration<double>(now - last_pub_).count();
+            if (elapsed < publish_period_s_)
+                return;
+        }
+        last_pub_ = now;
+    }
 
-   static_pub_->publish(sensors_data_.staticdata);
-   dynamic_pub_->publish(sensors_data_.dynamic);
-   accel_pub_->publish(sensors_data_.accelerometer);
-   gyro_pub_->publish(sensors_data_.gyroscope);
-   ts_pub_->publish(sensors_data_.timestamp);
-   if(bias_iter_ > kBiasCalculationIterations)
-   {
-      euler_pub_->publish(sensors_data_.eulerangle);
-      quat_pub_->publish(sensors_data_.quaternion);
-   }
+    static_pub_->publish(sensors_data_.staticdata);
+    dynamic_pub_->publish(sensors_data_.dynamic);
+    accel_pub_->publish(sensors_data_.accelerometer);
+    gyro_pub_->publish(sensors_data_.gyroscope);
+    ts_pub_->publish(sensors_data_.timestamp);
+    if (bias_iter_ > kBiasCalculationIterations)
+    {
+        euler_pub_->publish(sensors_data_.eulerangle);
+        quat_pub_->publish(sensors_data_.quaternion);
+    }
 }

--- a/robotiq_tsf/src/poll_data_sdk.cpp
+++ b/robotiq_tsf/src/poll_data_sdk.cpp
@@ -1,15 +1,48 @@
+// Copyright (c) 2026 Robotiq
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 // Implementation of PollDataSdkNode (declared in poll_data_sdk_node.hpp).
 // The USB / packet / parsing logic lives in the SDK; this file is the bridge
 // into ROS plus the AHRS fusion. main() is in poll_data_sdk_main.cpp so the
 // class can be constructed by unit tests without a hardware sensor.
 
-#include "robotiq_tsf/poll_data_sdk_node.hpp"
+#include <strings.h>
 
-#include "robotiq_tsf/device_autodetect.hpp"
-#include "robotiq_tsf/sdk_bridge.hpp"
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <thread>
 
+#include "RobotiqTactileSensor.h"
 #include "rclcpp/rclcpp.hpp"
-
+#include "robotiq_tsf/device_autodetect.hpp"
 // Full per-field message headers: create_publisher<T> needs each type's
 // typesupport (the header only needs their struct definitions, via sensor.hpp).
 #include "robotiq_tsf/msg/accelerometer.hpp"
@@ -19,32 +52,22 @@
 #include "robotiq_tsf/msg/quaternion.hpp"
 #include "robotiq_tsf/msg/static_data.hpp"
 #include "robotiq_tsf/msg/timestamp.hpp"
-
-#include "RobotiqTactileSensor.h"
-
-#include <Eigen/Core>
-#include <Eigen/Geometry>
-
-#include <cmath>
-#include <string>
-#include <strings.h>
-#include <thread>
+#include "robotiq_tsf/poll_data_sdk_node.hpp"
+#include "robotiq_tsf/sdk_bridge.hpp"
 
 namespace msg = robotiq_tsf::msg;
 namespace srv = robotiq_tsf::srv;
 
-namespace
-{
+namespace {
 constexpr int kBiasCalculationIterations = 5000;
-constexpr const char *kDefaultDevice = robotiq_tsf::kDefaultSensorDevice;
+constexpr const char* kDefaultDevice = robotiq_tsf::kDefaultSensorDevice;
 constexpr float kAccelRes = 2.0f / 32768.0f;
 constexpr float kGyroRes = 250.0f / 32768.0f;
 
 // Raw IMU triple (int16 counts) -> float vector, before resolution scaling.
 Eigen::Vector3f toVector3f(const int16_t (&v)[3])
 {
-    return {static_cast<float>(v[0]), static_cast<float>(v[1]),
-            static_cast<float>(v[2])};
+   return {static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2])};
 }
 // SDK sampling period: 1 ms (~1 kHz request rate).
 constexpr unsigned int kSamplePeriodMs = 1;
@@ -54,16 +77,16 @@ constexpr unsigned int kSamplePeriodMs = 1;
 // to `this` at the end of construction (before startSensor() creates the SDK
 // reader thread) and clears it in the destructor; atomic because the reader
 // thread reads it concurrently with those writes.
-std::atomic<PollDataSdkNode *> g_node_for_callback{nullptr};
+std::atomic<PollDataSdkNode*> g_node_for_callback{nullptr};
 
-void onSensorData(const Fingers &fingers)
+void onSensorData(const Fingers& fingers)
 {
-    if (auto *node = g_node_for_callback.load(std::memory_order_acquire))
-    {
-        node->handleFingers(fingers);
-    }
+   if(auto* node = g_node_for_callback.load(std::memory_order_acquire))
+   {
+      node->handleFingers(fingers);
+   }
 }
-}  // namespace
+} // namespace
 
 // Stop dispatching to this node, then join the SDK reader thread (in sensor_'s
 // destructor) while every member it touches is still alive. Doing this here
@@ -71,119 +94,112 @@ void onSensorData(const Fingers &fingers)
 // reader thread outlives the node otherwise.
 PollDataSdkNode::~PollDataSdkNode()
 {
-    g_node_for_callback.store(nullptr, std::memory_order_release);
-    sensor_.reset();
+   g_node_for_callback.store(nullptr, std::memory_order_release);
+   sensor_.reset();
 }
 
 PollDataSdkNode::PollDataSdkNode()
-    : rclcpp::Node("poll_data_sdk")
+   : rclcpp::Node("poll_data_sdk")
 {
-    declare_parameter<std::string>("device", kDefaultDevice);
+   declare_parameter<std::string>("device", kDefaultDevice);
 
-    // Cap the published topic rate (Hz). Default 0 = unthrottled: publish on
-    // every sensor packet, matching the legacy poll_data_node. Set a positive
-    // rate to decimate (fusion still runs at the full packet rate).
-    const double publish_rate_hz =
-        declare_parameter<double>("publish_rate_hz", 0.0);
-    publish_period_s_ = publish_rate_hz > 0.0 ? 1.0 / publish_rate_hz : 0.0;
+   // Cap the published topic rate (Hz). Default 0 = unthrottled: publish on
+   // every sensor packet, matching the legacy poll_data_node. Set a positive
+   // rate to decimate (fusion still runs at the full packet rate).
+   const double publish_rate_hz = declare_parameter<double>("publish_rate_hz", 0.0);
+   publish_period_s_ = publish_rate_hz > 0.0 ? 1.0 / publish_rate_hz : 0.0;
 
-    // AHRS tunables (madgwick.*), matching the legacy poll_data_node so existing
-    // launch files / configs that set them keep working.
-    ahrs_cfg_.beta = static_cast<float>(
-        declare_parameter<double>("madgwick.beta", ahrs_cfg_.beta));
-    ahrs_cfg_.accel_gate_lo = static_cast<float>(
-        declare_parameter<double>("madgwick.accel_gate_lo", ahrs_cfg_.accel_gate_lo));
-    ahrs_cfg_.accel_gate_hi = static_cast<float>(
-        declare_parameter<double>("madgwick.accel_gate_hi", ahrs_cfg_.accel_gate_hi));
-    ahrs_cfg_.bias_learn_rate = static_cast<float>(
-        declare_parameter<double>("madgwick.bias_learn_rate", ahrs_cfg_.bias_learn_rate));
-    ahrs_cfg_.still_gyro_eps_deg_s = static_cast<float>(
-        declare_parameter<double>("madgwick.still_gyro_eps_deg_s", ahrs_cfg_.still_gyro_eps_deg_s));
-    ahrs_cfg_.still_accel_eps_g = static_cast<float>(
-        declare_parameter<double>("madgwick.still_accel_eps_g", ahrs_cfg_.still_accel_eps_g));
-    ahrs_cfg_.dt_clamp_lo = static_cast<float>(
-        declare_parameter<double>("madgwick.dt_clamp_lo", ahrs_cfg_.dt_clamp_lo));
-    ahrs_cfg_.dt_clamp_hi = static_cast<float>(
-        declare_parameter<double>("madgwick.dt_clamp_hi", ahrs_cfg_.dt_clamp_hi));
+   // AHRS tunables (madgwick.*), matching the legacy poll_data_node so existing
+   // launch files / configs that set them keep working.
+   ahrs_cfg_.beta = static_cast<float>(declare_parameter<double>("madgwick.beta", ahrs_cfg_.beta));
+   ahrs_cfg_.accel_gate_lo =
+      static_cast<float>(declare_parameter<double>("madgwick.accel_gate_lo", ahrs_cfg_.accel_gate_lo));
+   ahrs_cfg_.accel_gate_hi =
+      static_cast<float>(declare_parameter<double>("madgwick.accel_gate_hi", ahrs_cfg_.accel_gate_hi));
+   ahrs_cfg_.bias_learn_rate =
+      static_cast<float>(declare_parameter<double>("madgwick.bias_learn_rate", ahrs_cfg_.bias_learn_rate));
+   ahrs_cfg_.still_gyro_eps_deg_s =
+      static_cast<float>(declare_parameter<double>("madgwick.still_gyro_eps_deg_s", ahrs_cfg_.still_gyro_eps_deg_s));
+   ahrs_cfg_.still_accel_eps_g =
+      static_cast<float>(declare_parameter<double>("madgwick.still_accel_eps_g", ahrs_cfg_.still_accel_eps_g));
+   ahrs_cfg_.dt_clamp_lo = static_cast<float>(declare_parameter<double>("madgwick.dt_clamp_lo", ahrs_cfg_.dt_clamp_lo));
+   ahrs_cfg_.dt_clamp_hi = static_cast<float>(declare_parameter<double>("madgwick.dt_clamp_hi", ahrs_cfg_.dt_clamp_hi));
 
-    for (int f = 0; f < FINGER_COUNT; ++f)
-    {
-        filter_[f].setBeta(ahrs_cfg_.beta);
-        filter_[f].setAccelGate(ahrs_cfg_.accel_gate_lo, ahrs_cfg_.accel_gate_hi);
-        accel_bias_[f].setZero();
-        gyro_bias_[f].setZero();
-    }
+   for(int f = 0; f < FINGER_COUNT; ++f)
+   {
+      filter_[f].setBeta(ahrs_cfg_.beta);
+      filter_[f].setAccelGate(ahrs_cfg_.accel_gate_lo, ahrs_cfg_.accel_gate_hi);
+      accel_bias_[f].setZero();
+      gyro_bias_[f].setZero();
+   }
 
-    auto qos = rclcpp::SensorDataQoS();
-    static_pub_ = create_publisher<msg::StaticData>("TactileSensor/StaticData", qos);
-    dynamic_pub_ = create_publisher<msg::Dynamic>("TactileSensor/Dynamic", qos);
-    accel_pub_ = create_publisher<msg::Accelerometer>("TactileSensor/Accelerometer", qos);
-    gyro_pub_ = create_publisher<msg::Gyroscope>("TactileSensor/Gyroscope", qos);
-    euler_pub_ = create_publisher<msg::EulerAngle>("TactileSensor/EulerAngle", qos);
-    quat_pub_ = create_publisher<msg::Quaternion>("TactileSensor/Quaternion", qos);
-    ts_pub_ = create_publisher<msg::Timestamp>("TactileSensor/Timestamp", qos);
+   auto qos = rclcpp::SensorDataQoS();
+   static_pub_ = create_publisher<msg::StaticData>("TactileSensor/StaticData", qos);
+   dynamic_pub_ = create_publisher<msg::Dynamic>("TactileSensor/Dynamic", qos);
+   accel_pub_ = create_publisher<msg::Accelerometer>("TactileSensor/Accelerometer", qos);
+   gyro_pub_ = create_publisher<msg::Gyroscope>("TactileSensor/Gyroscope", qos);
+   euler_pub_ = create_publisher<msg::EulerAngle>("TactileSensor/EulerAngle", qos);
+   quat_pub_ = create_publisher<msg::Quaternion>("TactileSensor/Quaternion", qos);
+   ts_pub_ = create_publisher<msg::Timestamp>("TactileSensor/Timestamp", qos);
 
-    service_ = create_service<srv::TactileSensors>(
-        "tactile_sensors_service",
-        [this](const std::shared_ptr<srv::TactileSensors::Request> req,
-               std::shared_ptr<srv::TactileSensors::Response> res)
-        { serviceCallback(req, res); });
+   service_ = create_service<srv::TactileSensors>(
+      "tactile_sensors_service",
+      [this](const std::shared_ptr<srv::TactileSensors::Request> req,
+             std::shared_ptr<srv::TactileSensors::Response> res) { serviceCallback(req, res); });
 
-    // Register for the SDK C callback last: everything it touches now exists,
-    // and the reader thread that invokes it isn't created until startSensor().
-    g_node_for_callback.store(this, std::memory_order_release);
+   // Register for the SDK C callback last: everything it touches now exists,
+   // and the reader thread that invokes it isn't created until startSensor().
+   g_node_for_callback.store(this, std::memory_order_release);
 }
 
 bool PollDataSdkNode::startSensor()
 {
-    std::string device = get_parameter("device").as_string();
+   std::string device = get_parameter("device").as_string();
 
-    // If the user left the default device and it isn't present, fall back to
-    // the shared autodetect (rq_tsf85_*, then ttyACM*/ttyUSB* by USB
-    // descriptor string).
-    if (device == kDefaultDevice && !robotiq_tsf::deviceExists(device))
-    {
-        const std::string detected = robotiq_tsf::autoDetectSensorDevice();
-        if (!detected.empty())
-        {
-            RCLCPP_INFO(get_logger(),
-                        "Auto-detected tactile sensor on %s (default %s not present)",
-                        detected.c_str(), device.c_str());
-            device = detected;
-            set_parameter(rclcpp::Parameter("device", device));
-        }
-        else
-        {
-            RCLCPP_WARN(get_logger(),
-                        "Could not auto-detect tactile sensor; falling back to %s",
-                        device.c_str());
-        }
-    }
+   // If the user left the default device and it isn't present, fall back to
+   // the shared autodetect (rq_tsf85_*, then ttyACM*/ttyUSB* by USB
+   // descriptor string).
+   if(device == kDefaultDevice && !robotiq_tsf::deviceExists(device))
+   {
+      const std::string detected = robotiq_tsf::autoDetectSensorDevice();
+      if(!detected.empty())
+      {
+         RCLCPP_INFO(get_logger(),
+                     "Auto-detected tactile sensor on %s (default %s not present)",
+                     detected.c_str(),
+                     device.c_str());
+         device = detected;
+         set_parameter(rclcpp::Parameter("device", device));
+      }
+      else
+      {
+         RCLCPP_WARN(get_logger(), "Could not auto-detect tactile sensor; falling back to %s", device.c_str());
+      }
+   }
 
-    RCLCPP_INFO(get_logger(), "Opening tactile sensor at %s via SDK", device.c_str());
+   RCLCPP_INFO(get_logger(), "Opening tactile sensor at %s via SDK", device.c_str());
 
-    // The SDK (libserialport) opens the port in raw mode. That is load-bearing,
-    // not incidental: the sensor stream is binary, and a freshly re-enumerated
-    // CDC-ACM tty defaults to cooked line discipline (ICRNL rewrites 0x0D, IXON
-    // eats 0x11/0x13), which mangles the stream and makes the taxels read as
-    // rail-to-rail garbage ("flashing red"). This is exactly the bug the old
-    // hand-rolled poll_data_node hit (it never forced raw mode); the SDK path is
-    // immune only because libserialport sets raw mode for us. If this ever moves
-    // off libserialport, the replacement MUST put the tty in raw mode.
-    sensor_ = std::make_unique<RobotiqTactileSensor>(device.c_str(), &onSensorData, kSamplePeriodMs);
-    if (!sensor_->isConnected())
-    {
-        RCLCPP_FATAL(get_logger(), "SDK failed to open sensor: %s",
-                     sensor_->getLastError());
-        sensor_.reset();
-        return false;
-    }
+   // The SDK (libserialport) opens the port in raw mode. That is load-bearing,
+   // not incidental: the sensor stream is binary, and a freshly re-enumerated
+   // CDC-ACM tty defaults to cooked line discipline (ICRNL rewrites 0x0D, IXON
+   // eats 0x11/0x13), which mangles the stream and makes the taxels read as
+   // rail-to-rail garbage ("flashing red"). This is exactly the bug the old
+   // hand-rolled poll_data_node hit (it never forced raw mode); the SDK path is
+   // immune only because libserialport sets raw mode for us. If this ever moves
+   // off libserialport, the replacement MUST put the tty in raw mode.
+   sensor_ = std::make_unique<RobotiqTactileSensor>(device.c_str(), &onSensorData, kSamplePeriodMs);
+   if(!sensor_->isConnected())
+   {
+      RCLCPP_FATAL(get_logger(), "SDK failed to open sensor: %s", sensor_->getLastError());
+      sensor_.reset();
+      return false;
+   }
 
-    // NOTE: the firmware version is purely informational and nothing here
-    // uses it, and this sensor/firmware doesn't reliably reply to GET_VERSION
-    // (it consistently times out). So we don't query it at all — no point
-    // delaying startup for a value we don't need.
-    return true;
+   // NOTE: the firmware version is purely informational and nothing here
+   // uses it, and this sensor/firmware doesn't reliably reply to GET_VERSION
+   // (it consistently times out). So we don't query it at all — no point
+   // delaying startup for a value we don't need.
+   return true;
 }
 
 // The sensor can come up opened-but-silent (seen after an unclean shutdown of
@@ -192,178 +208,182 @@ bool PollDataSdkNode::startSensor()
 // stop/start to re-trigger streaming before giving up.
 bool PollDataSdkNode::waitForStreaming()
 {
-    using namespace std::chrono;
-    constexpr int kAttempts = 3;
-    constexpr auto kFirstDataTimeout = seconds(2);
+   using namespace std::chrono; // NOLINT(build/namespaces)
+   constexpr int kAttempts = 3;
+   constexpr auto kFirstDataTimeout = seconds(2);
 
-    for (int attempt = 1; attempt <= kAttempts; ++attempt)
-    {
-        const uint64_t before = frames_received_.load();
-        const auto deadline = steady_clock::now() + kFirstDataTimeout;
-        while (steady_clock::now() < deadline)
-        {
-            if (frames_received_.load() > before)
-                return true;
-            std::this_thread::sleep_for(milliseconds(50));
-        }
-        if (attempt < kAttempts)
-        {
-            RCLCPP_WARN(get_logger(),
-                        "No data from sensor after %lds; cycling the stream "
-                        "(attempt %d/%d)",
-                        static_cast<long>(kFirstDataTimeout.count()),
-                        attempt, kAttempts);
-            sensor_->stop();
-            std::this_thread::sleep_for(milliseconds(200));
-            sensor_->start();
-        }
-    }
-    RCLCPP_FATAL(get_logger(),
-                 "Sensor opened but never streamed data; replug the sensor "
-                 "(or USB-reset it) and relaunch.");
-    return false;
+   for(int attempt = 1; attempt <= kAttempts; ++attempt)
+   {
+      const uint64_t before = frames_received_.load();
+      const auto deadline = steady_clock::now() + kFirstDataTimeout;
+      while(steady_clock::now() < deadline)
+      {
+         if(frames_received_.load() > before)
+         {
+            return true;
+         }
+         std::this_thread::sleep_for(milliseconds(50));
+      }
+      if(attempt < kAttempts)
+      {
+         RCLCPP_WARN(get_logger(),
+                     "No data from sensor after %lds; cycling the stream "
+                     "(attempt %d/%d)",
+                     static_cast<int64_t>(kFirstDataTimeout.count()),
+                     attempt,
+                     kAttempts);
+         sensor_->stop();
+         std::this_thread::sleep_for(milliseconds(200));
+         sensor_->start();
+      }
+   }
+   RCLCPP_FATAL(get_logger(),
+                "Sensor opened but never streamed data; replug the sensor "
+                "(or USB-reset it) and relaunch.");
+   return false;
 }
 
-void PollDataSdkNode::serviceCallback(
-    const std::shared_ptr<srv::TactileSensors::Request> req,
-    std::shared_ptr<srv::TactileSensors::Response> res)
+void PollDataSdkNode::serviceCallback(const std::shared_ptr<srv::TactileSensors::Request> req,
+                                      std::shared_ptr<srv::TactileSensors::Response> res)
 {
-    RCLCPP_INFO(get_logger(), "TactileSensors service request: [%s]", req->request.c_str());
-    if (strcasecmp(req->request.c_str(), "start") == 0)
-    {
-        stopped_ = false;
-        if (sensor_) sensor_->start();
-        res->response = true;
-        return;
-    }
-    if (strcasecmp(req->request.c_str(), "stop") == 0)
-    {
-        stopped_ = true;
-        if (sensor_) sensor_->stop();
-        res->response = true;
-        return;
-    }
-    RCLCPP_WARN(get_logger(), "Invalid TactileSensors request");
-    res->response = false;
+   RCLCPP_INFO(get_logger(), "TactileSensors service request: [%s]", req->request.c_str());
+   if(strcasecmp(req->request.c_str(), "start") == 0)
+   {
+      stopped_ = false;
+      if(sensor_)
+      {
+         sensor_->start();
+      }
+      res->response = true;
+      return;
+   }
+   if(strcasecmp(req->request.c_str(), "stop") == 0)
+   {
+      stopped_ = true;
+      if(sensor_)
+      {
+         sensor_->stop();
+      }
+      res->response = true;
+      return;
+   }
+   RCLCPP_WARN(get_logger(), "Invalid TactileSensors request");
+   res->response = false;
 }
 
-void PollDataSdkNode::handleFingers(const Fingers &fingers)
+void PollDataSdkNode::handleFingers(const Fingers& fingers)
 {
-    frames_received_.fetch_add(1, std::memory_order_relaxed);
-    if (stopped_.load())
-        return;
+   frames_received_.fetch_add(1, std::memory_order_relaxed);
+   if(stopped_.load())
+   {
+      return;
+   }
 
-    robotiq_tsf::fillSensorMessages(fingers, sensors_data_);
+   robotiq_tsf::fillSensorMessages(fingers, sensors_data_);
 
-    if (bias_iter_ > kBiasCalculationIterations)
-    {
-        constexpr float deg_to_rad = static_cast<float>(M_PI / 180.0);
-        for (int f = 0; f < FINGER_COUNT; ++f)
-        {
-            const auto &finger = fingers.finger[f];
-            // Bias-corrected IMU: accel in g, gyro in deg/s. Explicit Vector3f
-            // on the left (not auto): the right side is a lazy Eigen expression
-            // referencing temporaries, and only the assignment evaluates it.
-            const Eigen::Vector3f accel =
-                toVector3f(finger.accelerometer)*kAccelRes - accel_bias_[f];
-            const Eigen::Vector3f gyro =
-                toVector3f(finger.gyroscope)*kGyroRes - gyro_bias_[f];
+   if(bias_iter_ > kBiasCalculationIterations)
+   {
+      constexpr float deg_to_rad = static_cast<float>(M_PI / 180.0);
+      for(int f = 0; f < FINGER_COUNT; ++f)
+      {
+         const auto& finger = fingers.finger[f];
+         // Bias-corrected IMU: accel in g, gyro in deg/s. Explicit Vector3f
+         // on the left (not auto): the right side is a lazy Eigen expression
+         // referencing temporaries, and only the assignment evaluates it.
+         const Eigen::Vector3f accel = toVector3f(finger.accelerometer) * kAccelRes - accel_bias_[f];
+         const Eigen::Vector3f gyro = toVector3f(finger.gyroscope) * kGyroRes - gyro_bias_[f];
 
-            // Integration step from the finger's MCU timestamp (immune to host
-            // jitter, and to the stall a stop()->start() cycle would inject).
-            // 0 = not usable (first sample after calibration, or a duplicate/
-            // backwards timestamp) -> skip integration for this finger.
-            const float dt = robotiq_tsf::deriveDt(last_ts_ms_[f], finger.timestamp,
-                                                   ahrs_cfg_.dt_clamp_lo, ahrs_cfg_.dt_clamp_hi);
-            last_ts_ms_[f] = finger.timestamp;
+         // Integration step from the finger's MCU timestamp (immune to host
+         // jitter, and to the stall a stop()->start() cycle would inject).
+         // 0 = not usable (first sample after calibration, or a duplicate/
+         // backwards timestamp) -> skip integration for this finger.
+         const float dt =
+            robotiq_tsf::deriveDt(last_ts_ms_[f], finger.timestamp, ahrs_cfg_.dt_clamp_lo, ahrs_cfg_.dt_clamp_hi);
+         last_ts_ms_[f] = finger.timestamp;
 
-            if (dt > 0.0f)
+         if(dt > 0.0f)
+         {
+            const Eigen::Vector3f gyro_rad = gyro * deg_to_rad;
+            filter_[f].updateIMU(gyro_rad.x(), gyro_rad.y(), gyro_rad.z(), accel.x(), accel.y(), accel.z(), dt);
+
+            // Online gyro-bias trim while stationary: drift the stored bias
+            // slowly toward the residual, so a frozen bias can't leak
+            // thermal drift into yaw.
+            if(robotiq_tsf::sampleIsStill(gyro, accel, ahrs_cfg_.still_gyro_eps_deg_s, ahrs_cfg_.still_accel_eps_g))
             {
-                const Eigen::Vector3f gyro_rad = gyro*deg_to_rad;
-                filter_[f].updateIMU(gyro_rad.x(), gyro_rad.y(), gyro_rad.z(),
-                                     accel.x(), accel.y(), accel.z(), dt);
-
-                // Online gyro-bias trim while stationary: drift the stored bias
-                // slowly toward the residual, so a frozen bias can't leak
-                // thermal drift into yaw.
-                if (robotiq_tsf::sampleIsStill(gyro, accel,
-                                               ahrs_cfg_.still_gyro_eps_deg_s,
-                                               ahrs_cfg_.still_accel_eps_g))
-                {
-                    gyro_bias_[f] = robotiq_tsf::trimBias(gyro_bias_[f], gyro,
-                                                          ahrs_cfg_.bias_learn_rate);
-                }
+               gyro_bias_[f] = robotiq_tsf::trimBias(gyro_bias_[f], gyro, ahrs_cfg_.bias_learn_rate);
             }
+         }
 
-            // One absolute filter quaternion sources both orientation topics;
-            // Euler wraps at ±180°, so continuous-orientation consumers use
-            // Quaternion.
-            const Eigen::Quaternionf q = filter_[f].quaternion();
-            sensors_data_.quaternion.data[f].values[0] = q.w();
-            sensors_data_.quaternion.data[f].values[1] = q.x();
-            sensors_data_.quaternion.data[f].values[2] = q.y();
-            sensors_data_.quaternion.data[f].values[3] = q.z();
+         // One absolute filter quaternion sources both orientation topics;
+         // Euler wraps at ±180°, so continuous-orientation consumers use
+         // Quaternion.
+         const Eigen::Quaternionf q = filter_[f].quaternion();
+         sensors_data_.quaternion.data[f].values[0] = q.w();
+         sensors_data_.quaternion.data[f].values[1] = q.x();
+         sensors_data_.quaternion.data[f].values[2] = q.y();
+         sensors_data_.quaternion.data[f].values[3] = q.z();
 
-            filter_[f].getEulerDeg(sensors_data_.eulerangle.data[f].values[0],
-                                   sensors_data_.eulerangle.data[f].values[1],
-                                   sensors_data_.eulerangle.data[f].values[2]);
-        }
-    }
-    else if (bias_iter_ == kBiasCalculationIterations)
-    {
-        for (int f = 0; f < FINGER_COUNT; ++f)
-        {
-            gyro_bias_[f] /= kBiasCalculationIterations;
-            accel_bias_[f] /= kBiasCalculationIterations;
+         filter_[f].getEulerDeg(sensors_data_.eulerangle.data[f].values[0],
+                                sensors_data_.eulerangle.data[f].values[1],
+                                sensors_data_.eulerangle.data[f].values[2]);
+      }
+   }
+   else if(bias_iter_ == kBiasCalculationIterations)
+   {
+      for(int f = 0; f < FINGER_COUNT; ++f)
+      {
+         gyro_bias_[f] /= kBiasCalculationIterations;
+         accel_bias_[f] /= kBiasCalculationIterations;
 
-            // Gravity in the body frame at rest is the signal, not a bias: seed
-            // each filter's quaternion from the accel mean, then stop subtracting
-            // the accel offset. Mirrors PollData.cpp's new MadgwickFilter path.
-            filter_[f].initFromAccel(accel_bias_[f].x(), accel_bias_[f].y(),
-                                     accel_bias_[f].z());
-            accel_bias_[f].setZero();
+         // Gravity in the body frame at rest is the signal, not a bias: seed
+         // each filter's quaternion from the accel mean, then stop subtracting
+         // the accel offset. Mirrors PollData.cpp's new MadgwickFilter path.
+         filter_[f].initFromAccel(accel_bias_[f].x(), accel_bias_[f].y(), accel_bias_[f].z());
+         accel_bias_[f].setZero();
 
-            // Reseed the per-finger dt so the first post-calibration sample skips
-            // integration instead of using a stale delta spanning the calibration.
-            last_ts_ms_[f] = 0;
-        }
-        ++bias_iter_;
-    }
-    else
-    {
-        for (int f = 0; f < FINGER_COUNT; ++f)
-        {
-            const auto &finger = fingers.finger[f];
-            gyro_bias_[f] += toVector3f(finger.gyroscope)*kGyroRes;
-            accel_bias_[f] += toVector3f(finger.accelerometer)*kAccelRes;
-        }
-        ++bias_iter_;
-    }
+         // Reseed the per-finger dt so the first post-calibration sample skips
+         // integration instead of using a stale delta spanning the calibration.
+         last_ts_ms_[f] = 0;
+      }
+      ++bias_iter_;
+   }
+   else
+   {
+      for(int f = 0; f < FINGER_COUNT; ++f)
+      {
+         const auto& finger = fingers.finger[f];
+         gyro_bias_[f] += toVector3f(finger.gyroscope) * kGyroRes;
+         accel_bias_[f] += toVector3f(finger.accelerometer) * kAccelRes;
+      }
+      ++bias_iter_;
+   }
 
-    // Decimate publishing to publish_period_s_ (fusion above already ran at
-    // full rate). Skip the very first packet's elapsed check by seeding
-    // last_pub_ on first use.
-    if (publish_period_s_ > 0.0)
-    {
-        const auto now = std::chrono::steady_clock::now();
-        if (last_pub_.time_since_epoch().count() != 0)
-        {
-            const double elapsed =
-                std::chrono::duration<double>(now - last_pub_).count();
-            if (elapsed < publish_period_s_)
-                return;
-        }
-        last_pub_ = now;
-    }
+   // Decimate publishing to publish_period_s_ (fusion above already ran at
+   // full rate). Skip the very first packet's elapsed check by seeding
+   // last_pub_ on first use.
+   if(publish_period_s_ > 0.0)
+   {
+      const auto now = std::chrono::steady_clock::now();
+      if(last_pub_.time_since_epoch().count() != 0)
+      {
+         const double elapsed = std::chrono::duration<double>(now - last_pub_).count();
+         if(elapsed < publish_period_s_)
+         {
+            return;
+         }
+      }
+      last_pub_ = now;
+   }
 
-    static_pub_->publish(sensors_data_.staticdata);
-    dynamic_pub_->publish(sensors_data_.dynamic);
-    accel_pub_->publish(sensors_data_.accelerometer);
-    gyro_pub_->publish(sensors_data_.gyroscope);
-    ts_pub_->publish(sensors_data_.timestamp);
-    if (bias_iter_ > kBiasCalculationIterations)
-    {
-        euler_pub_->publish(sensors_data_.eulerangle);
-        quat_pub_->publish(sensors_data_.quaternion);
-    }
+   static_pub_->publish(sensors_data_.staticdata);
+   dynamic_pub_->publish(sensors_data_.dynamic);
+   accel_pub_->publish(sensors_data_.accelerometer);
+   gyro_pub_->publish(sensors_data_.gyroscope);
+   ts_pub_->publish(sensors_data_.timestamp);
+   if(bias_iter_ > kBiasCalculationIterations)
+   {
+      euler_pub_->publish(sensors_data_.eulerangle);
+      quat_pub_->publish(sensors_data_.quaternion);
+   }
 }

--- a/robotiq_tsf/test/eigen_test_utils.hpp
+++ b/robotiq_tsf/test/eigen_test_utils.hpp
@@ -1,0 +1,37 @@
+#ifndef ROBOTIQ_TSF_TEST_EIGEN_TEST_UTILS_HPP
+#define ROBOTIQ_TSF_TEST_EIGEN_TEST_UTILS_HPP
+
+// gtest helpers for comparing Eigen dense objects coefficient-wise.
+//
+//   expectEigenFloatEq(actual, Eigen::Vector3f(0.2f, 0.0f, 0.0f));
+//
+// Each coefficient is compared with EXPECT_FLOAT_EQ; a failure names the
+// offending coefficient. Failures are reported at this header's line — wrap
+// the call in SCOPED_TRACE if a test has several calls to tell apart.
+
+#include <Eigen/Core>
+#include <gtest/gtest.h>
+
+namespace robotiq_tsf::test
+{
+
+template <typename DerivedA, typename DerivedB>
+void expectEigenFloatEq(const Eigen::DenseBase<DerivedA> &actual,
+                        const Eigen::DenseBase<DerivedB> &expected)
+{
+    ASSERT_EQ(actual.rows(), expected.rows());
+    ASSERT_EQ(actual.cols(), expected.cols());
+    for (Eigen::Index r = 0; r < actual.rows(); ++r)
+    {
+        for (Eigen::Index c = 0; c < actual.cols(); ++c)
+        {
+            EXPECT_FLOAT_EQ(actual.derived().coeff(r, c), expected.derived().coeff(r, c))
+                << "coefficient (" << r << ", " << c << ") of\n"
+                << actual.derived() << "\nvs expected\n" << expected.derived();
+        }
+    }
+}
+
+}  // namespace robotiq_tsf::test
+
+#endif  // ROBOTIQ_TSF_TEST_EIGEN_TEST_UTILS_HPP

--- a/robotiq_tsf/test/eigen_test_utils.hpp
+++ b/robotiq_tsf/test/eigen_test_utils.hpp
@@ -1,5 +1,32 @@
-#ifndef ROBOTIQ_TSF_TEST_EIGEN_TEST_UTILS_HPP
-#define ROBOTIQ_TSF_TEST_EIGEN_TEST_UTILS_HPP
+// Copyright (c) 2026 Robotiq
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
 
 // gtest helpers for comparing Eigen dense objects coefficient-wise.
 //
@@ -12,26 +39,23 @@
 #include <Eigen/Core>
 #include <gtest/gtest.h>
 
-namespace robotiq_tsf::test
-{
+namespace robotiq_tsf::test {
 
 template <typename DerivedA, typename DerivedB>
-void expectEigenFloatEq(const Eigen::DenseBase<DerivedA> &actual,
-                        const Eigen::DenseBase<DerivedB> &expected)
+void expectEigenFloatEq(const Eigen::DenseBase<DerivedA>& actual, const Eigen::DenseBase<DerivedB>& expected)
 {
-    ASSERT_EQ(actual.rows(), expected.rows());
-    ASSERT_EQ(actual.cols(), expected.cols());
-    for (Eigen::Index r = 0; r < actual.rows(); ++r)
-    {
-        for (Eigen::Index c = 0; c < actual.cols(); ++c)
-        {
-            EXPECT_FLOAT_EQ(actual.derived().coeff(r, c), expected.derived().coeff(r, c))
-                << "coefficient (" << r << ", " << c << ") of\n"
-                << actual.derived() << "\nvs expected\n" << expected.derived();
-        }
-    }
+   ASSERT_EQ(actual.rows(), expected.rows());
+   ASSERT_EQ(actual.cols(), expected.cols());
+   for(Eigen::Index r = 0; r < actual.rows(); ++r)
+   {
+      for(Eigen::Index c = 0; c < actual.cols(); ++c)
+      {
+         EXPECT_FLOAT_EQ(actual.derived().coeff(r, c), expected.derived().coeff(r, c))
+            << "coefficient (" << r << ", " << c << ") of\n"
+            << actual.derived() << "\nvs expected\n"
+            << expected.derived();
+      }
+   }
 }
 
-}  // namespace robotiq_tsf::test
-
-#endif  // ROBOTIQ_TSF_TEST_EIGEN_TEST_UTILS_HPP
+} // namespace robotiq_tsf::test

--- a/robotiq_tsf/test/test_fusion.cpp
+++ b/robotiq_tsf/test/test_fusion.cpp
@@ -1,101 +1,85 @@
-// Copyright (c) 2026 Robotiq
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above copyright
-//      notice, this list of conditions and the following disclaimer in the
-//      documentation and/or other materials provided with the distribution.
-//
-//    * Neither the name of the copyright holder nor the names of its
-//      contributors may be used to endorse or promote products derived from
-//      this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
-
 // Unit tests for the AHRS fusion helpers (robotiq_tsf/fusion.hpp): per-finger
 // MCU-timestamp dt derivation (with its [lo, hi] clamp), still-detection and
 // bias-EMA trim. These regressed silently once (the SDK node integrated on an
 // unbounded host-clock dt with a frozen gyro bias), so they're pinned here.
 
-#include <gtest/gtest.h>
-
 #include "robotiq_tsf/fusion.hpp"
 
+#include "eigen_test_utils.hpp"
+
+#include <Eigen/Core>
+#include <gtest/gtest.h>
+
+using Eigen::Vector3f;
 using robotiq_tsf::deriveDt;
 using robotiq_tsf::sampleIsStill;
 using robotiq_tsf::trimBias;
 
-namespace {
-constexpr float kLo = 1e-4f; // 0.1 ms
-constexpr float kHi = 0.1f; // 100 ms
-} // namespace
+namespace
+{
+constexpr float kLo = 1e-4f;   // 0.1 ms
+constexpr float kHi = 0.1f;    // 100 ms
+}
 
 TEST(DeriveDt, NormalDeltaIsMsToSeconds)
 {
-   // 10 ms apart -> 0.01 s, within [lo, hi].
-   EXPECT_FLOAT_EQ(deriveDt(1000, 1010, kLo, kHi), 0.010f);
+    // 10 ms apart -> 0.01 s, within [lo, hi].
+    EXPECT_FLOAT_EQ(deriveDt(1000, 1010, kLo, kHi), 0.010f);
 }
 
 TEST(DeriveDt, FirstSampleAfterSeedReturnsZero)
 {
-   // prev == 0 means "not yet seeded" -> skip integration.
-   EXPECT_FLOAT_EQ(deriveDt(0, 1234, kLo, kHi), 0.0f);
+    // prev == 0 means "not yet seeded" -> skip integration.
+    EXPECT_FLOAT_EQ(deriveDt(0, 1234, kLo, kHi), 0.0f);
 }
 
 TEST(DeriveDt, DuplicateTimestampReturnsZero)
 {
-   EXPECT_FLOAT_EQ(deriveDt(1000, 1000, kLo, kHi), 0.0f);
+    EXPECT_FLOAT_EQ(deriveDt(1000, 1000, kLo, kHi), 0.0f);
 }
 
 TEST(DeriveDt, BackwardsTimestampReturnsZero)
 {
-   EXPECT_FLOAT_EQ(deriveDt(2000, 1000, kLo, kHi), 0.0f);
+    EXPECT_FLOAT_EQ(deriveDt(2000, 1000, kLo, kHi), 0.0f);
 }
 
 TEST(DeriveDt, StalledDeltaIsClampedToHi)
 {
-   // 500 ms stall -> capped at 100 ms so a delayed sample can't inject an
-   // outsized integration step.
-   EXPECT_FLOAT_EQ(deriveDt(1000, 1500, kLo, kHi), kHi);
+    // 500 ms stall -> capped at 100 ms so a delayed sample can't inject an
+    // outsized integration step.
+    EXPECT_FLOAT_EQ(deriveDt(1000, 1500, kLo, kHi), kHi);
 }
 
 TEST(SampleIsStill, TrueWhenGyroSmallAndAccelNearOneG)
 {
-   EXPECT_TRUE(sampleIsStill(0.1f, -0.1f, 0.05f, 0.0f, 0.0f, 1.0f, 0.8f, 0.05f));
+    EXPECT_TRUE(sampleIsStill({0.1f, -0.1f, 0.05f},
+                              {0.0f, 0.0f, 1.0f}, 0.8f, 0.05f));
 }
 
 TEST(SampleIsStill, FalseWhenRotating)
 {
-   EXPECT_FALSE(sampleIsStill(5.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.8f, 0.05f));
+    EXPECT_FALSE(sampleIsStill({5.0f, 0.0f, 0.0f},
+                               {0.0f, 0.0f, 1.0f}, 0.8f, 0.05f));
 }
 
 TEST(SampleIsStill, FalseUnderLinearAcceleration)
 {
-   // |a| well away from 1 g -> not stationary even with zero angular rate.
-   EXPECT_FALSE(sampleIsStill(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.5f, 0.8f, 0.05f));
+    // |a| well away from 1 g -> not stationary even with zero angular rate.
+    EXPECT_FALSE(sampleIsStill({0.0f, 0.0f, 0.0f},
+                               {0.0f, 0.0f, 1.5f}, 0.8f, 0.05f));
 }
 
 TEST(TrimBias, NudgesTowardResidualByAlpha)
 {
-   // bias 0.10, residual 0.20, alpha 0.5 -> 0.10 + 0.5 * 0.20 = 0.20.
-   EXPECT_FLOAT_EQ(trimBias(0.10f, 0.20f, 0.5f), 0.20f);
+    // bias 0.10, residual 0.20, alpha 0.5 -> 0.10 + 0.5 * 0.20 = 0.20,
+    // independently per axis.
+    const Vector3f out = trimBias({0.10f, 0.0f, -0.10f},
+                                  {0.20f, 0.0f, 0.20f}, 0.5f);
+    robotiq_tsf::test::expectEigenFloatEq(out, Vector3f(0.20f, 0.0f, 0.0f));
 }
 
 TEST(TrimBias, ZeroResidualLeavesBiasUnchanged)
 {
-   EXPECT_FLOAT_EQ(trimBias(0.42f, 0.0f, 0.0005f), 0.42f);
+    const Vector3f bias(0.42f, -0.17f, 0.03f);
+    robotiq_tsf::test::expectEigenFloatEq(trimBias(bias, Vector3f::Zero(), 0.0005f), bias);
 }

--- a/robotiq_tsf/test/test_fusion.cpp
+++ b/robotiq_tsf/test/test_fusion.cpp
@@ -1,85 +1,108 @@
+// Copyright (c) 2026 Robotiq
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 // Unit tests for the AHRS fusion helpers (robotiq_tsf/fusion.hpp): per-finger
 // MCU-timestamp dt derivation (with its [lo, hi] clamp), still-detection and
 // bias-EMA trim. These regressed silently once (the SDK node integrated on an
 // unbounded host-clock dt with a frozen gyro bias), so they're pinned here.
 
-#include "robotiq_tsf/fusion.hpp"
-
-#include "eigen_test_utils.hpp"
+#include <gtest/gtest.h>
 
 #include <Eigen/Core>
-#include <gtest/gtest.h>
+
+#include "eigen_test_utils.hpp"
+#include "robotiq_tsf/fusion.hpp"
 
 using Eigen::Vector3f;
 using robotiq_tsf::deriveDt;
 using robotiq_tsf::sampleIsStill;
 using robotiq_tsf::trimBias;
 
-namespace
-{
-constexpr float kLo = 1e-4f;   // 0.1 ms
-constexpr float kHi = 0.1f;    // 100 ms
-}
+namespace {
+constexpr float kLo = 1e-4f; // 0.1 ms
+constexpr float kHi = 0.1f; // 100 ms
+} // namespace
 
 TEST(DeriveDt, NormalDeltaIsMsToSeconds)
 {
-    // 10 ms apart -> 0.01 s, within [lo, hi].
-    EXPECT_FLOAT_EQ(deriveDt(1000, 1010, kLo, kHi), 0.010f);
+   // 10 ms apart -> 0.01 s, within [lo, hi].
+   EXPECT_FLOAT_EQ(deriveDt(1000, 1010, kLo, kHi), 0.010f);
 }
 
 TEST(DeriveDt, FirstSampleAfterSeedReturnsZero)
 {
-    // prev == 0 means "not yet seeded" -> skip integration.
-    EXPECT_FLOAT_EQ(deriveDt(0, 1234, kLo, kHi), 0.0f);
+   // prev == 0 means "not yet seeded" -> skip integration.
+   EXPECT_FLOAT_EQ(deriveDt(0, 1234, kLo, kHi), 0.0f);
 }
 
 TEST(DeriveDt, DuplicateTimestampReturnsZero)
 {
-    EXPECT_FLOAT_EQ(deriveDt(1000, 1000, kLo, kHi), 0.0f);
+   EXPECT_FLOAT_EQ(deriveDt(1000, 1000, kLo, kHi), 0.0f);
 }
 
 TEST(DeriveDt, BackwardsTimestampReturnsZero)
 {
-    EXPECT_FLOAT_EQ(deriveDt(2000, 1000, kLo, kHi), 0.0f);
+   EXPECT_FLOAT_EQ(deriveDt(2000, 1000, kLo, kHi), 0.0f);
 }
 
 TEST(DeriveDt, StalledDeltaIsClampedToHi)
 {
-    // 500 ms stall -> capped at 100 ms so a delayed sample can't inject an
-    // outsized integration step.
-    EXPECT_FLOAT_EQ(deriveDt(1000, 1500, kLo, kHi), kHi);
+   // 500 ms stall -> capped at 100 ms so a delayed sample can't inject an
+   // outsized integration step.
+   EXPECT_FLOAT_EQ(deriveDt(1000, 1500, kLo, kHi), kHi);
 }
 
 TEST(SampleIsStill, TrueWhenGyroSmallAndAccelNearOneG)
 {
-    EXPECT_TRUE(sampleIsStill({0.1f, -0.1f, 0.05f},
-                              {0.0f, 0.0f, 1.0f}, 0.8f, 0.05f));
+   EXPECT_TRUE(sampleIsStill({0.1f, -0.1f, 0.05f}, {0.0f, 0.0f, 1.0f}, 0.8f, 0.05f));
 }
 
 TEST(SampleIsStill, FalseWhenRotating)
 {
-    EXPECT_FALSE(sampleIsStill({5.0f, 0.0f, 0.0f},
-                               {0.0f, 0.0f, 1.0f}, 0.8f, 0.05f));
+   EXPECT_FALSE(sampleIsStill({5.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 1.0f}, 0.8f, 0.05f));
 }
 
 TEST(SampleIsStill, FalseUnderLinearAcceleration)
 {
-    // |a| well away from 1 g -> not stationary even with zero angular rate.
-    EXPECT_FALSE(sampleIsStill({0.0f, 0.0f, 0.0f},
-                               {0.0f, 0.0f, 1.5f}, 0.8f, 0.05f));
+   // |a| well away from 1 g -> not stationary even with zero angular rate.
+   EXPECT_FALSE(sampleIsStill({0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 1.5f}, 0.8f, 0.05f));
 }
 
 TEST(TrimBias, NudgesTowardResidualByAlpha)
 {
-    // bias 0.10, residual 0.20, alpha 0.5 -> 0.10 + 0.5 * 0.20 = 0.20,
-    // independently per axis.
-    const Vector3f out = trimBias({0.10f, 0.0f, -0.10f},
-                                  {0.20f, 0.0f, 0.20f}, 0.5f);
-    robotiq_tsf::test::expectEigenFloatEq(out, Vector3f(0.20f, 0.0f, 0.0f));
+   // bias 0.10, residual 0.20, alpha 0.5 -> 0.10 + 0.5 * 0.20 = 0.20,
+   // independently per axis.
+   const Vector3f out = trimBias({0.10f, 0.0f, -0.10f}, {0.20f, 0.0f, 0.20f}, 0.5f);
+   robotiq_tsf::test::expectEigenFloatEq(out, Vector3f(0.20f, 0.0f, 0.0f));
 }
 
 TEST(TrimBias, ZeroResidualLeavesBiasUnchanged)
 {
-    const Vector3f bias(0.42f, -0.17f, 0.03f);
-    robotiq_tsf::test::expectEigenFloatEq(trimBias(bias, Vector3f::Zero(), 0.0005f), bias);
+   const Vector3f bias(0.42f, -0.17f, 0.03f);
+   robotiq_tsf::test::expectEigenFloatEq(trimBias(bias, Vector3f::Zero(), 0.0005f), bias);
 }

--- a/robotiq_tsf/test/test_madgwick_ahrs.cpp
+++ b/robotiq_tsf/test/test_madgwick_ahrs.cpp
@@ -1,15 +1,43 @@
+// Copyright (c) 2026 Robotiq
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 // All math is done in float, matching the filter under test: the Madgwick
 // reference implementation is float32 (embedded origin), and the IMU samples
 // are 16-bit (±2 g / ±250 deg/s), so sensor noise and bias sit far above
 // float32 rounding — double would add no accuracy. The quaternion is
 // renormalized every update, so float error does not accumulate either.
 
-#include "robotiq_tsf/MadgwickAHRS.h"
-
-#include <Eigen/Geometry>
 #include <gtest/gtest.h>
 
+#include <Eigen/Geometry>
 #include <cmath>
+
+#include "robotiq_tsf/MadgwickAHRS.h"
 
 using Eigen::AngleAxisf;
 using Eigen::Quaternionf;
@@ -37,281 +65,305 @@ constexpr float kTrackingTolDeg = 3.0f;
 // a no-op, so anything beyond float dust is a gating failure.
 constexpr float kGateLeakTolDeg = 0.1f;
 
-struct EulerAngles {
-    float roll;
-    float pitch;
-    float yaw;
+struct EulerAngles
+{
+   float roll;
+   float pitch;
+   float yaw;
 };
 
-EulerAngles eulerDegOf(const Quaternionf &q) {
-    EulerAngles e;
-    quatToEulerDeg(q, e.roll, e.pitch, e.yaw);
-    return e;
+EulerAngles eulerDegOf(const Quaternionf& q)
+{
+   EulerAngles e;
+   quatToEulerDeg(q, e.roll, e.pitch, e.yaw);
+   return e;
 }
 
-EulerAngles eulerDegOf(const MadgwickFilter &f) {
-    EulerAngles e;
-    f.getEulerDeg(e.roll, e.pitch, e.yaw);
-    return e;
+EulerAngles eulerDegOf(const MadgwickFilter& f)
+{
+   EulerAngles e;
+   f.getEulerDeg(e.roll, e.pitch, e.yaw);
+   return e;
 }
 
-float maxAbsDeg(const EulerAngles &e) {
-    return std::max(std::fabs(e.roll), std::max(std::fabs(e.pitch), std::fabs(e.yaw)));
+float maxAbsDeg(const EulerAngles& e)
+{
+   return std::max(std::fabs(e.roll), std::max(std::fabs(e.pitch), std::fabs(e.yaw)));
 }
 
-::testing::AssertionResult eulerNear(const EulerAngles &actual,
-                                     const EulerAngles &expected,
-                                     float tol_deg) {
-    if (std::fabs(actual.roll - expected.roll) <= tol_deg &&
-        std::fabs(actual.pitch - expected.pitch) <= tol_deg &&
-        std::fabs(actual.yaw - expected.yaw) <= tol_deg) {
-        return ::testing::AssertionSuccess();
-    }
-    return ::testing::AssertionFailure()
-           << "(roll, pitch, yaw) = (" << actual.roll << ", " << actual.pitch
-           << ", " << actual.yaw << ") deg, expected (" << expected.roll << ", "
-           << expected.pitch << ", " << expected.yaw << ") deg +/- " << tol_deg;
+::testing::AssertionResult eulerNear(const EulerAngles& actual, const EulerAngles& expected, float tol_deg)
+{
+   if(std::fabs(actual.roll - expected.roll) <= tol_deg && std::fabs(actual.pitch - expected.pitch) <= tol_deg
+      && std::fabs(actual.yaw - expected.yaw) <= tol_deg)
+   {
+      return ::testing::AssertionSuccess();
+   }
+   return ::testing::AssertionFailure() << "(roll, pitch, yaw) = (" << actual.roll << ", " << actual.pitch << ", "
+                                        << actual.yaw << ") deg, expected (" << expected.roll << ", " << expected.pitch
+                                        << ", " << expected.yaw << ") deg +/- " << tol_deg;
 }
 
-TEST(QuatHelpers, EulerFromSingleAxisQuaternions) {
-    constexpr float kRollDeg = 30.0f;
-    constexpr float kPitchDeg = 45.0f;
-    constexpr float kYawDeg = -60.0f;
+TEST(QuatHelpers, EulerFromSingleAxisQuaternions)
+{
+   constexpr float kRollDeg = 30.0f;
+   constexpr float kPitchDeg = 45.0f;
+   constexpr float kYawDeg = -60.0f;
 
-    Quaternionf q(AngleAxisf(kRollDeg*kDegToRad, Vector3f::UnitX()));
-    EXPECT_TRUE(eulerNear(eulerDegOf(q), {kRollDeg, 0.0f, 0.0f}, kExactTolDeg));
+   Quaternionf q(AngleAxisf(kRollDeg * kDegToRad, Vector3f::UnitX()));
+   EXPECT_TRUE(eulerNear(eulerDegOf(q), {kRollDeg, 0.0f, 0.0f}, kExactTolDeg));
 
-    q = AngleAxisf(kPitchDeg*kDegToRad, Vector3f::UnitY());
-    EXPECT_TRUE(eulerNear(eulerDegOf(q), {0.0f, kPitchDeg, 0.0f}, kExactTolDeg));
+   q = AngleAxisf(kPitchDeg * kDegToRad, Vector3f::UnitY());
+   EXPECT_TRUE(eulerNear(eulerDegOf(q), {0.0f, kPitchDeg, 0.0f}, kExactTolDeg));
 
-    q = AngleAxisf(kYawDeg*kDegToRad, Vector3f::UnitZ());
-    EXPECT_TRUE(eulerNear(eulerDegOf(q), {0.0f, 0.0f, kYawDeg}, kExactTolDeg));
+   q = AngleAxisf(kYawDeg * kDegToRad, Vector3f::UnitZ());
+   EXPECT_TRUE(eulerNear(eulerDegOf(q), {0.0f, 0.0f, kYawDeg}, kExactTolDeg));
 }
 
-TEST(QuatHelpers, EulerFromComposedZyxRotation) {
-    // ZYX Tait-Bryan: q = qz(yaw) * qy(pitch) * qx(roll) must decompose back
-    // into the same three angles.
-    constexpr float kRollDeg = 10.0f;
-    constexpr float kPitchDeg = 20.0f;
-    constexpr float kYawDeg = 30.0f;
+TEST(QuatHelpers, EulerFromComposedZyxRotation)
+{
+   // ZYX Tait-Bryan: q = qz(yaw) * qy(pitch) * qx(roll) must decompose back
+   // into the same three angles.
+   constexpr float kRollDeg = 10.0f;
+   constexpr float kPitchDeg = 20.0f;
+   constexpr float kYawDeg = 30.0f;
 
-    const Quaternionf q = AngleAxisf(kYawDeg*kDegToRad, Vector3f::UnitZ())
-                        * AngleAxisf(kPitchDeg*kDegToRad, Vector3f::UnitY())
-                        * AngleAxisf(kRollDeg*kDegToRad, Vector3f::UnitX());
+   const Quaternionf q = AngleAxisf(kYawDeg * kDegToRad, Vector3f::UnitZ())
+                       * AngleAxisf(kPitchDeg * kDegToRad, Vector3f::UnitY())
+                       * AngleAxisf(kRollDeg * kDegToRad, Vector3f::UnitX());
 
-    EXPECT_TRUE(eulerNear(eulerDegOf(q), {kRollDeg, kPitchDeg, kYawDeg}, kExactTolDeg));
+   EXPECT_TRUE(eulerNear(eulerDegOf(q), {kRollDeg, kPitchDeg, kYawDeg}, kExactTolDeg));
 }
 
-TEST(QuatHelpers, MulByConjugateGivesRelativeRotation) {
-    // Zeroing as done for relative orientation: q_rel = conj(q_ref) * q.
-    constexpr float kRefRollDeg = 30.0f;
-    constexpr float kCurRollDeg = 50.0f;
-    constexpr float kRelRollDeg = kCurRollDeg - kRefRollDeg;
+TEST(QuatHelpers, MulByConjugateGivesRelativeRotation)
+{
+   // Zeroing as done for relative orientation: q_rel = conj(q_ref) * q.
+   constexpr float kRefRollDeg = 30.0f;
+   constexpr float kCurRollDeg = 50.0f;
+   constexpr float kRelRollDeg = kCurRollDeg - kRefRollDeg;
 
-    const Quaternionf q_ref(AngleAxisf(kRefRollDeg*kDegToRad, Vector3f::UnitX()));
-    const Quaternionf q_cur(AngleAxisf(kCurRollDeg*kDegToRad, Vector3f::UnitX()));
-    Quaternionf q_rel = q_ref.conjugate()*q_cur;
+   const Quaternionf q_ref(AngleAxisf(kRefRollDeg * kDegToRad, Vector3f::UnitX()));
+   const Quaternionf q_cur(AngleAxisf(kCurRollDeg * kDegToRad, Vector3f::UnitX()));
+   Quaternionf q_rel = q_ref.conjugate() * q_cur;
 
-    EXPECT_TRUE(eulerNear(eulerDegOf(q_rel), {kRelRollDeg, 0.0f, 0.0f}, kExactTolDeg));
+   EXPECT_TRUE(eulerNear(eulerDegOf(q_rel), {kRelRollDeg, 0.0f, 0.0f}, kExactTolDeg));
 
-    // Self-relative must be identity.
-    q_rel = q_cur.conjugate()*q_cur;
-    EXPECT_NEAR(q_rel.w(), 1.0f, kQuatTol);
-    EXPECT_NEAR(q_rel.x(), 0.0f, kQuatTol);
-    EXPECT_NEAR(q_rel.y(), 0.0f, kQuatTol);
-    EXPECT_NEAR(q_rel.z(), 0.0f, kQuatTol);
+   // Self-relative must be identity.
+   q_rel = q_cur.conjugate() * q_cur;
+   EXPECT_NEAR(q_rel.w(), 1.0f, kQuatTol);
+   EXPECT_NEAR(q_rel.x(), 0.0f, kQuatTol);
+   EXPECT_NEAR(q_rel.y(), 0.0f, kQuatTol);
+   EXPECT_NEAR(q_rel.z(), 0.0f, kQuatTol);
 }
 
-TEST(QuatHelpers, HamiltonConventionGoldenComponents) {
-    // Pins the Hamilton product order and right-handed rotation signs of the
-    // Eigen types the filter is built on, with exact component values, so a
-    // convention regression cannot slip in silently.
-    constexpr float kHalfSqrt2 = 0.70710678f;
+TEST(QuatHelpers, HamiltonConventionGoldenComponents)
+{
+   // Pins the Hamilton product order and right-handed rotation signs of the
+   // Eigen types the filter is built on, with exact component values, so a
+   // convention regression cannot slip in silently.
+   constexpr float kHalfSqrt2 = 0.70710678f;
 
-    const Quaternionf qx(AngleAxisf(0.5f*kPi, Vector3f::UnitX()));
-    EXPECT_NEAR(qx.w(), kHalfSqrt2, kQuatTol);
-    EXPECT_NEAR(qx.x(), kHalfSqrt2, kQuatTol);
-    EXPECT_NEAR(qx.y(), 0.0f, kQuatTol);
-    EXPECT_NEAR(qx.z(), 0.0f, kQuatTol);
+   const Quaternionf qx(AngleAxisf(0.5f * kPi, Vector3f::UnitX()));
+   EXPECT_NEAR(qx.w(), kHalfSqrt2, kQuatTol);
+   EXPECT_NEAR(qx.x(), kHalfSqrt2, kQuatTol);
+   EXPECT_NEAR(qx.y(), 0.0f, kQuatTol);
+   EXPECT_NEAR(qx.z(), 0.0f, kQuatTol);
 
-    const Quaternionf qy(AngleAxisf(0.5f*kPi, Vector3f::UnitY()));
-    EXPECT_NEAR(qy.w(), kHalfSqrt2, kQuatTol);
-    EXPECT_NEAR(qy.y(), kHalfSqrt2, kQuatTol);
+   const Quaternionf qy(AngleAxisf(0.5f * kPi, Vector3f::UnitY()));
+   EXPECT_NEAR(qy.w(), kHalfSqrt2, kQuatTol);
+   EXPECT_NEAR(qy.y(), kHalfSqrt2, kQuatTol);
 
-    const Quaternionf qz(AngleAxisf(0.5f*kPi, Vector3f::UnitZ()));
-    EXPECT_NEAR(qz.w(), kHalfSqrt2, kQuatTol);
-    EXPECT_NEAR(qz.z(), kHalfSqrt2, kQuatTol);
+   const Quaternionf qz(AngleAxisf(0.5f * kPi, Vector3f::UnitZ()));
+   EXPECT_NEAR(qz.w(), kHalfSqrt2, kQuatTol);
+   EXPECT_NEAR(qz.z(), kHalfSqrt2, kQuatTol);
 
-    // Hamilton product: qx(90) * qy(90) = (0.5, 0.5, 0.5, 0.5) exactly.
-    const Quaternionf q = qx*qy;
-    EXPECT_NEAR(q.w(), 0.5f, kQuatTol);
-    EXPECT_NEAR(q.x(), 0.5f, kQuatTol);
-    EXPECT_NEAR(q.y(), 0.5f, kQuatTol);
-    EXPECT_NEAR(q.z(), 0.5f, kQuatTol);
+   // Hamilton product: qx(90) * qy(90) = (0.5, 0.5, 0.5, 0.5) exactly.
+   const Quaternionf q = qx * qy;
+   EXPECT_NEAR(q.w(), 0.5f, kQuatTol);
+   EXPECT_NEAR(q.x(), 0.5f, kQuatTol);
+   EXPECT_NEAR(q.y(), 0.5f, kQuatTol);
+   EXPECT_NEAR(q.z(), 0.5f, kQuatTol);
 }
 
-TEST(QuatHelpers, EulerExtractionClampsAtGimbalLock) {
-    // A slightly super-unit quaternion pushes |sin(pitch)| past 1; the
-    // extraction must clamp to exactly +/-90 deg and stay finite (no NaN from
-    // asin out of domain).
-    float roll, pitch, yaw;
+TEST(QuatHelpers, EulerExtractionClampsAtGimbalLock)
+{
+   // A slightly super-unit quaternion pushes |sin(pitch)| past 1; the
+   // extraction must clamp to exactly +/-90 deg and stay finite (no NaN from
+   // asin out of domain).
+   float roll, pitch, yaw;
 
-    const Quaternionf q_up(0.7071f, 0.0f, 0.7080f, 0.0f);  // sinp < -1 -> +90
-    quatToEulerDeg(q_up, roll, pitch, yaw);
-    EXPECT_NEAR(pitch, 90.0f, kExactTolDeg);
-    EXPECT_TRUE(std::isfinite(roll) && std::isfinite(yaw));
+   const Quaternionf q_up(0.7071f, 0.0f, 0.7080f, 0.0f); // sinp < -1 -> +90
+   quatToEulerDeg(q_up, roll, pitch, yaw);
+   EXPECT_NEAR(pitch, 90.0f, kExactTolDeg);
+   EXPECT_TRUE(std::isfinite(roll) && std::isfinite(yaw));
 
-    const Quaternionf q_down(0.7071f, 0.0f, -0.7080f, 0.0f);  // sinp > 1 -> -90
-    quatToEulerDeg(q_down, roll, pitch, yaw);
-    EXPECT_NEAR(pitch, -90.0f, kExactTolDeg);
-    EXPECT_TRUE(std::isfinite(roll) && std::isfinite(yaw));
+   const Quaternionf q_down(0.7071f, 0.0f, -0.7080f, 0.0f); // sinp > 1 -> -90
+   quatToEulerDeg(q_down, roll, pitch, yaw);
+   EXPECT_NEAR(pitch, -90.0f, kExactTolDeg);
+   EXPECT_TRUE(std::isfinite(roll) && std::isfinite(yaw));
 }
 
-TEST(MadgwickFilter, InitFromAccelMatchesTilt) {
-    constexpr float kRollDeg = 30.0f;
-    constexpr float kPitchDeg = 20.0f;
-    constexpr float g = 9.81f;  // m/s^2
+TEST(MadgwickFilter, InitFromAccelMatchesTilt)
+{
+   constexpr float kRollDeg = 30.0f;
+   constexpr float kPitchDeg = 20.0f;
+   constexpr float g = 9.81f; // m/s^2
 
-    MadgwickFilter f;
+   MadgwickFilter f;
 
-    // Flat: gravity along body +Z.
-    f.initFromAccel(0.0f, 0.0f, 1.0f);
-    EXPECT_TRUE(eulerNear(eulerDegOf(f), {0.0f, 0.0f, 0.0f}, kExactTolDeg));
+   // Flat: gravity along body +Z.
+   f.initFromAccel(0.0f, 0.0f, 1.0f);
+   EXPECT_TRUE(eulerNear(eulerDegOf(f), {0.0f, 0.0f, 0.0f}, kExactTolDeg));
 
-    // Pure roll: gravity_body = (0, sin r, cos r). Units must not matter,
-    // so feed m/s^2 rather than g.
-    f.initFromAccel(0.0f, g * std::sin(kRollDeg * kDegToRad),
-                    g * std::cos(kRollDeg * kDegToRad));
-    EXPECT_TRUE(eulerNear(eulerDegOf(f), {kRollDeg, 0.0f, 0.0f}, kExactTolDeg));
+   // Pure roll: gravity_body = (0, sin r, cos r). Units must not matter,
+   // so feed m/s^2 rather than g.
+   f.initFromAccel(0.0f, g * std::sin(kRollDeg * kDegToRad), g * std::cos(kRollDeg * kDegToRad));
+   EXPECT_TRUE(eulerNear(eulerDegOf(f), {kRollDeg, 0.0f, 0.0f}, kExactTolDeg));
 
-    // Pure pitch: gravity_body = (-sin p, 0, cos p).
-    f.initFromAccel(-std::sin(kPitchDeg * kDegToRad), 0.0f,
-                    std::cos(kPitchDeg * kDegToRad));
-    EXPECT_TRUE(eulerNear(eulerDegOf(f), {0.0f, kPitchDeg, 0.0f}, kExactTolDeg));
+   // Pure pitch: gravity_body = (-sin p, 0, cos p).
+   f.initFromAccel(-std::sin(kPitchDeg * kDegToRad), 0.0f, std::cos(kPitchDeg * kDegToRad));
+   EXPECT_TRUE(eulerNear(eulerDegOf(f), {0.0f, kPitchDeg, 0.0f}, kExactTolDeg));
 }
 
-TEST(MadgwickFilter, InitFromAccelCombinedRollPitch) {
-    // Gravity in body frame for roll r, pitch p (ZYX, yaw-free):
-    // g_body = (-sin p, sin r * cos p, cos r * cos p).
-    constexpr float kRollDeg = 30.0f;
-    constexpr float kPitchDeg = 20.0f;
-    const float sr = std::sin(kRollDeg*kDegToRad);
-    const float cr = std::cos(kRollDeg*kDegToRad);
-    const float sp = std::sin(kPitchDeg*kDegToRad);
-    const float cp = std::cos(kPitchDeg*kDegToRad);
+TEST(MadgwickFilter, InitFromAccelCombinedRollPitch)
+{
+   // Gravity in body frame for roll r, pitch p (ZYX, yaw-free):
+   // g_body = (-sin p, sin r * cos p, cos r * cos p).
+   constexpr float kRollDeg = 30.0f;
+   constexpr float kPitchDeg = 20.0f;
+   const float sr = std::sin(kRollDeg * kDegToRad);
+   const float cr = std::cos(kRollDeg * kDegToRad);
+   const float sp = std::sin(kPitchDeg * kDegToRad);
+   const float cp = std::cos(kPitchDeg * kDegToRad);
 
-    MadgwickFilter f;
-    f.initFromAccel(-sp, sr*cp, cr*cp);
-    EXPECT_TRUE(eulerNear(eulerDegOf(f), {kRollDeg, kPitchDeg, 0.0f}, kExactTolDeg));
+   MadgwickFilter f;
+   f.initFromAccel(-sp, sr * cp, cr * cp);
+   EXPECT_TRUE(eulerNear(eulerDegOf(f), {kRollDeg, kPitchDeg, 0.0f}, kExactTolDeg));
 }
 
-TEST(MadgwickFilter, InitFromZeroAccelResetsToIdentity) {
-    MadgwickFilter f;
-    f.initFromAccel(0.0f, 1.0f, 0.0f);  // some non-identity state first
-    f.initFromAccel(0.0f, 0.0f, 0.0f);
-    float q0, q1, q2, q3;
-    f.getQuaternion(q0, q1, q2, q3);
-    EXPECT_NEAR(q0, 1.0f, kQuatTol);
-    EXPECT_NEAR(q1, 0.0f, kQuatTol);
-    EXPECT_NEAR(q2, 0.0f, kQuatTol);
-    EXPECT_NEAR(q3, 0.0f, kQuatTol);
+TEST(MadgwickFilter, InitFromZeroAccelResetsToIdentity)
+{
+   MadgwickFilter f;
+   f.initFromAccel(0.0f, 1.0f, 0.0f); // some non-identity state first
+   f.initFromAccel(0.0f, 0.0f, 0.0f);
+   float q0, q1, q2, q3;
+   f.getQuaternion(q0, q1, q2, q3);
+   EXPECT_NEAR(q0, 1.0f, kQuatTol);
+   EXPECT_NEAR(q1, 0.0f, kQuatTol);
+   EXPECT_NEAR(q2, 0.0f, kQuatTol);
+   EXPECT_NEAR(q3, 0.0f, kQuatTol);
 }
 
-TEST(MadgwickFilter, NonPositiveDtIsIgnored) {
-    MadgwickFilter f;
-    f.initFromAccel(0.0f, 0.0f, 1.0f);
-    float before[4], after[4];
-    f.getQuaternion(before[0], before[1], before[2], before[3]);
-    f.updateIMU(1.0f, 2.0f, 3.0f, 0.0f, 0.0f, 1.0f, 0.0f);
-    f.updateIMU(1.0f, 2.0f, 3.0f, 0.0f, 0.0f, 1.0f, -0.01f);
-    f.getQuaternion(after[0], after[1], after[2], after[3]);
-    for (int i = 0; i < 4; ++i) EXPECT_EQ(before[i], after[i]);
+TEST(MadgwickFilter, NonPositiveDtIsIgnored)
+{
+   MadgwickFilter f;
+   f.initFromAccel(0.0f, 0.0f, 1.0f);
+   float before[4], after[4];
+   f.getQuaternion(before[0], before[1], before[2], before[3]);
+   f.updateIMU(1.0f, 2.0f, 3.0f, 0.0f, 0.0f, 1.0f, 0.0f);
+   f.updateIMU(1.0f, 2.0f, 3.0f, 0.0f, 0.0f, 1.0f, -0.01f);
+   f.getQuaternion(after[0], after[1], after[2], after[3]);
+   for(int i = 0; i < 4; ++i)
+   {
+      EXPECT_EQ(before[i], after[i]);
+   }
 }
 
-TEST(MadgwickFilter, TracksRotationWithMeasuredDt) {
-    // 90 deg/s roll for 1 s, sampled at 200 Hz. Accel stays consistent with
-    // the true attitude (pure tilt, |a| = 1 g), gyro is exact. The legacy
-    // filter integrated every sample as 1/1000 s regardless of the real rate,
-    // so it tracked this rotation ~5x too slow — the "drift" in PR #5.
-    constexpr float kRateDegS = 90.0f;
-    constexpr float kDt = 0.005f;
-    constexpr int kSteps = 200;
-    constexpr float kExpectedRollDeg = kRateDegS * kDt * kSteps;
+TEST(MadgwickFilter, TracksRotationWithMeasuredDt)
+{
+   // 90 deg/s roll for 1 s, sampled at 200 Hz. Accel stays consistent with
+   // the true attitude (pure tilt, |a| = 1 g), gyro is exact. The legacy
+   // filter integrated every sample as 1/1000 s regardless of the real rate,
+   // so it tracked this rotation ~5x too slow — the "drift" in PR #5.
+   constexpr float kRateDegS = 90.0f;
+   constexpr float kDt = 0.005f;
+   constexpr int kSteps = 200;
+   constexpr float kExpectedRollDeg = kRateDegS * kDt * kSteps;
 
-    MadgwickFilter f;
-    f.initFromAccel(0.0f, 0.0f, 1.0f);
-    for (int i = 0; i < kSteps; ++i) {
-        const float rollTrue = kRateDegS * kDt * static_cast<float>(i) * kDegToRad;
-        f.updateIMU(kRateDegS * kDegToRad, 0.0f, 0.0f,
-                    0.0f, std::sin(rollTrue), std::cos(rollTrue), kDt);
-    }
-    EXPECT_TRUE(eulerNear(eulerDegOf(f), {kExpectedRollDeg, 0.0f, 0.0f}, kTrackingTolDeg));
+   MadgwickFilter f;
+   f.initFromAccel(0.0f, 0.0f, 1.0f);
+   for(int i = 0; i < kSteps; ++i)
+   {
+      const float rollTrue = kRateDegS * kDt * static_cast<float>(i) * kDegToRad;
+      f.updateIMU(kRateDegS * kDegToRad, 0.0f, 0.0f, 0.0f, std::sin(rollTrue), std::cos(rollTrue), kDt);
+   }
+   EXPECT_TRUE(eulerNear(eulerDegOf(f), {kExpectedRollDeg, 0.0f, 0.0f}, kTrackingTolDeg));
 }
 
-TEST(MadgwickFilter, AccelGateRejectsMotionBursts) {
-    // Stationary sensor, zero rotation, but a sustained linear-acceleration
-    // burst (|a| ~ 1.35 g). The legacy filter treated the burst as a tilted
-    // gravity vector and walked the attitude away — the "noisy in transition"
-    // in PR #5. Accel feedback outside [0.85, 1.15] g must be gated, so the
-    // attitude must not move at all.
-    constexpr float kDt = 0.005f;
-    constexpr int kBurstSteps = 1000;  // 5 s of burst at 200 Hz
-    // gravity (1 g on Z) + 0.9 g lateral -> |a| ~ 1.35 g, outside the accel gate
-    constexpr float kBurstLateralG = 0.9f;
+TEST(MadgwickFilter, AccelGateRejectsMotionBursts)
+{
+   // Stationary sensor, zero rotation, but a sustained linear-acceleration
+   // burst (|a| ~ 1.35 g). The legacy filter treated the burst as a tilted
+   // gravity vector and walked the attitude away — the "noisy in transition"
+   // in PR #5. Accel feedback outside [0.85, 1.15] g must be gated, so the
+   // attitude must not move at all.
+   constexpr float kDt = 0.005f;
+   constexpr int kBurstSteps = 1000; // 5 s of burst at 200 Hz
+   // gravity (1 g on Z) + 0.9 g lateral -> |a| ~ 1.35 g, outside the accel gate
+   constexpr float kBurstLateralG = 0.9f;
 
-    MadgwickFilter f;
-    f.initFromAccel(0.0f, 0.0f, 1.0f);
+   MadgwickFilter f;
+   f.initFromAccel(0.0f, 0.0f, 1.0f);
 
-    float peakDeg = 0.0f;
-    for (int i = 0; i < kBurstSteps; ++i) {
-        f.updateIMU(0.0f, 0.0f, 0.0f, kBurstLateralG, 0.0f, 1.0f, kDt);
-        peakDeg = std::max(peakDeg, maxAbsDeg(eulerDegOf(f)));
-    }
+   float peakDeg = 0.0f;
+   for(int i = 0; i < kBurstSteps; ++i)
+   {
+      f.updateIMU(0.0f, 0.0f, 0.0f, kBurstLateralG, 0.0f, 1.0f, kDt);
+      peakDeg = std::max(peakDeg, maxAbsDeg(eulerDegOf(f)));
+   }
 
-    EXPECT_LT(peakDeg, kGateLeakTolDeg);
+   EXPECT_LT(peakDeg, kGateLeakTolDeg);
 }
 
-TEST(MadgwickFilter, GoldenTrajectoryCheckpoints) {
-    // End-to-end numeric regression: a fixed synthetic IMU stream must keep
-    // reproducing the quaternion checkpoints recorded from the pre-Eigen
-    // implementation. Guards the library migration against any behavior
-    // change beyond float-op reordering: 1e-5 (~80 float32 ulps at unit
-    // scale) absorbs reordering drift accumulated over the 350 updates while
-    // staying orders of magnitude below a real algorithmic change.
-    constexpr float kGoldenTol = 1e-5f;
-    constexpr float kDt = 0.005f;
-    struct Checkpoint { const char* tag; float q[4]; };
+TEST(MadgwickFilter, GoldenTrajectoryCheckpoints)
+{
+   // End-to-end numeric regression: a fixed synthetic IMU stream must keep
+   // reproducing the quaternion checkpoints recorded from the pre-Eigen
+   // implementation. Guards the library migration against any behavior
+   // change beyond float-op reordering: 1e-5 (~80 float32 ulps at unit
+   // scale) absorbs reordering drift accumulated over the 350 updates while
+   // staying orders of magnitude below a real algorithmic change.
+   constexpr float kGoldenTol = 1e-5f;
+   constexpr float kDt = 0.005f;
+   struct Checkpoint
+   {
+      const char* tag;
+      float q[4];
+   };
 
-    MadgwickFilter f;
-    f.initFromAccel(0.0f, 0.0f, 1.0f);
+   MadgwickFilter f;
+   f.initFromAccel(0.0f, 0.0f, 1.0f);
 
-    auto expectCheckpoint = [&f](const Checkpoint &c) {
-        float q[4];
-        f.getQuaternion(q[0], q[1], q[2], q[3]);
-        for (int i = 0; i < 4; ++i) {
-            EXPECT_NEAR(q[i], c.q[i], kGoldenTol)
-                << "checkpoint " << c.tag << " component " << i;
-        }
-    };
+   auto expectCheckpoint = [&f](const Checkpoint& c) {
+      float q[4];
+      f.getQuaternion(q[0], q[1], q[2], q[3]);
+      for(int i = 0; i < 4; ++i)
+      {
+         EXPECT_NEAR(q[i], c.q[i], kGoldenTol) << "checkpoint " << c.tag << " component " << i;
+      }
+   };
 
-    // Segment A: 100 steps stationary (accel gate open, gradient active).
-    for (int i = 0; i < 100; ++i)
-        f.updateIMU(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, kDt);
-    expectCheckpoint({"A", {1.00000000f, 0.00000000f, 0.00000000f, 0.00000000f}});
+   // Segment A: 100 steps stationary (accel gate open, gradient active).
+   for(int i = 0; i < 100; ++i)
+   {
+      f.updateIMU(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, kDt);
+   }
+   expectCheckpoint({"A", {1.00000000f, 0.00000000f, 0.00000000f, 0.00000000f}});
 
-    // Segment B: 150 steps rolling at 60 deg/s with attitude-consistent accel.
-    for (int i = 0; i < 150; ++i) {
-        const float roll = 60.0f*kDt*static_cast<float>(i)*kDegToRad;
-        f.updateIMU(60.0f*kDegToRad, 0.0f, 0.0f,
-                    0.0f, std::sin(roll), std::cos(roll), kDt);
-    }
-    expectCheckpoint({"B", {0.92394269f, 0.38253102f, 0.00000000f, 0.00000000f}});
+   // Segment B: 150 steps rolling at 60 deg/s with attitude-consistent accel.
+   for(int i = 0; i < 150; ++i)
+   {
+      const float roll = 60.0f * kDt * static_cast<float>(i) * kDegToRad;
+      f.updateIMU(60.0f * kDegToRad, 0.0f, 0.0f, 0.0f, std::sin(roll), std::cos(roll), kDt);
+   }
+   expectCheckpoint({"B", {0.92394269f, 0.38253102f, 0.00000000f, 0.00000000f}});
 
-    // Segment C: 100 steps yawing at 45 deg/s while accel is gated
-    // (|a| = 1.4 g): pure gyro integration path.
-    for (int i = 0; i < 100; ++i)
-        f.updateIMU(0.0f, 0.0f, 45.0f*kDegToRad, 0.98f, 0.0f, 1.0f, kDt);
-    expectCheckpoint({"C", {0.90618920f, 0.37518126f, -0.07462808f, 0.18025191f}});
+   // Segment C: 100 steps yawing at 45 deg/s while accel is gated
+   // (|a| = 1.4 g): pure gyro integration path.
+   for(int i = 0; i < 100; ++i)
+   {
+      f.updateIMU(0.0f, 0.0f, 45.0f * kDegToRad, 0.98f, 0.0f, 1.0f, kDt);
+   }
+   expectCheckpoint({"C", {0.90618920f, 0.37518126f, -0.07462808f, 0.18025191f}});
 }
 
-}  // namespace
+} // namespace

--- a/robotiq_tsf/test/test_madgwick_ahrs.cpp
+++ b/robotiq_tsf/test/test_madgwick_ahrs.cpp
@@ -6,9 +6,14 @@
 
 #include "robotiq_tsf/MadgwickAHRS.h"
 
+#include <Eigen/Geometry>
 #include <gtest/gtest.h>
 
 #include <cmath>
+
+using Eigen::AngleAxisf;
+using Eigen::Quaternionf;
+using Eigen::Vector3f;
 
 namespace {
 
@@ -38,7 +43,7 @@ struct EulerAngles {
     float yaw;
 };
 
-EulerAngles eulerDegOf(const float q[4]) {
+EulerAngles eulerDegOf(const Quaternionf &q) {
     EulerAngles e;
     quatToEulerDeg(q, e.roll, e.pitch, e.yaw);
     return e;
@@ -73,15 +78,13 @@ TEST(QuatHelpers, EulerFromSingleAxisQuaternions) {
     constexpr float kPitchDeg = 45.0f;
     constexpr float kYawDeg = -60.0f;
 
-    float q[4];
-
-    quatFromAxisX(kRollDeg * kDegToRad, q);
+    Quaternionf q(AngleAxisf(kRollDeg*kDegToRad, Vector3f::UnitX()));
     EXPECT_TRUE(eulerNear(eulerDegOf(q), {kRollDeg, 0.0f, 0.0f}, kExactTolDeg));
 
-    quatFromAxisY(kPitchDeg * kDegToRad, q);
+    q = AngleAxisf(kPitchDeg*kDegToRad, Vector3f::UnitY());
     EXPECT_TRUE(eulerNear(eulerDegOf(q), {0.0f, kPitchDeg, 0.0f}, kExactTolDeg));
 
-    quatFromAxisZ(kYawDeg * kDegToRad, q);
+    q = AngleAxisf(kYawDeg*kDegToRad, Vector3f::UnitZ());
     EXPECT_TRUE(eulerNear(eulerDegOf(q), {0.0f, 0.0f, kYawDeg}, kExactTolDeg));
 }
 
@@ -92,12 +95,9 @@ TEST(QuatHelpers, EulerFromComposedZyxRotation) {
     constexpr float kPitchDeg = 20.0f;
     constexpr float kYawDeg = 30.0f;
 
-    float qx[4], qy[4], qz[4], tmp[4], q[4];
-    quatFromAxisX(kRollDeg * kDegToRad, qx);
-    quatFromAxisY(kPitchDeg * kDegToRad, qy);
-    quatFromAxisZ(kYawDeg * kDegToRad, qz);
-    quatMul(qz, qy, tmp);
-    quatMul(tmp, qx, q);
+    const Quaternionf q = AngleAxisf(kYawDeg*kDegToRad, Vector3f::UnitZ())
+                        * AngleAxisf(kPitchDeg*kDegToRad, Vector3f::UnitY())
+                        * AngleAxisf(kRollDeg*kDegToRad, Vector3f::UnitX());
 
     EXPECT_TRUE(eulerNear(eulerDegOf(q), {kRollDeg, kPitchDeg, kYawDeg}, kExactTolDeg));
 }
@@ -108,62 +108,46 @@ TEST(QuatHelpers, MulByConjugateGivesRelativeRotation) {
     constexpr float kCurRollDeg = 50.0f;
     constexpr float kRelRollDeg = kCurRollDeg - kRefRollDeg;
 
-    float q_ref[4], q_cur[4], q_ref_conj[4], q_rel[4];
-    quatFromAxisX(kRefRollDeg * kDegToRad, q_ref);
-    quatFromAxisX(kCurRollDeg * kDegToRad, q_cur);
-    quatConj(q_ref, q_ref_conj);
-    quatMul(q_ref_conj, q_cur, q_rel);
+    const Quaternionf q_ref(AngleAxisf(kRefRollDeg*kDegToRad, Vector3f::UnitX()));
+    const Quaternionf q_cur(AngleAxisf(kCurRollDeg*kDegToRad, Vector3f::UnitX()));
+    Quaternionf q_rel = q_ref.conjugate()*q_cur;
 
     EXPECT_TRUE(eulerNear(eulerDegOf(q_rel), {kRelRollDeg, 0.0f, 0.0f}, kExactTolDeg));
 
     // Self-relative must be identity.
-    quatConj(q_cur, q_ref_conj);
-    quatMul(q_ref_conj, q_cur, q_rel);
-    EXPECT_NEAR(q_rel[0], 1.0f, kQuatTol);
-    EXPECT_NEAR(q_rel[1], 0.0f, kQuatTol);
-    EXPECT_NEAR(q_rel[2], 0.0f, kQuatTol);
-    EXPECT_NEAR(q_rel[3], 0.0f, kQuatTol);
+    q_rel = q_cur.conjugate()*q_cur;
+    EXPECT_NEAR(q_rel.w(), 1.0f, kQuatTol);
+    EXPECT_NEAR(q_rel.x(), 0.0f, kQuatTol);
+    EXPECT_NEAR(q_rel.y(), 0.0f, kQuatTol);
+    EXPECT_NEAR(q_rel.z(), 0.0f, kQuatTol);
 }
 
 TEST(QuatHelpers, HamiltonConventionGoldenComponents) {
-    // Pins the [w, x, y, z] layout, Hamilton product order, and right-handed
-    // rotation signs with exact component values, so a linalg-library swap
-    // cannot silently flip handedness or component order.
+    // Pins the Hamilton product order and right-handed rotation signs of the
+    // Eigen types the filter is built on, with exact component values, so a
+    // convention regression cannot slip in silently.
     constexpr float kHalfSqrt2 = 0.70710678f;
-    float qx[4], qy[4], qz[4], q[4];
 
-    quatFromAxisX(0.5f*kPi, qx);
-    EXPECT_NEAR(qx[0], kHalfSqrt2, kQuatTol);
-    EXPECT_NEAR(qx[1], kHalfSqrt2, kQuatTol);
-    EXPECT_NEAR(qx[2], 0.0f, kQuatTol);
-    EXPECT_NEAR(qx[3], 0.0f, kQuatTol);
+    const Quaternionf qx(AngleAxisf(0.5f*kPi, Vector3f::UnitX()));
+    EXPECT_NEAR(qx.w(), kHalfSqrt2, kQuatTol);
+    EXPECT_NEAR(qx.x(), kHalfSqrt2, kQuatTol);
+    EXPECT_NEAR(qx.y(), 0.0f, kQuatTol);
+    EXPECT_NEAR(qx.z(), 0.0f, kQuatTol);
 
-    quatFromAxisY(0.5f*kPi, qy);
-    EXPECT_NEAR(qy[0], kHalfSqrt2, kQuatTol);
-    EXPECT_NEAR(qy[2], kHalfSqrt2, kQuatTol);
+    const Quaternionf qy(AngleAxisf(0.5f*kPi, Vector3f::UnitY()));
+    EXPECT_NEAR(qy.w(), kHalfSqrt2, kQuatTol);
+    EXPECT_NEAR(qy.y(), kHalfSqrt2, kQuatTol);
 
-    quatFromAxisZ(0.5f*kPi, qz);
-    EXPECT_NEAR(qz[0], kHalfSqrt2, kQuatTol);
-    EXPECT_NEAR(qz[3], kHalfSqrt2, kQuatTol);
+    const Quaternionf qz(AngleAxisf(0.5f*kPi, Vector3f::UnitZ()));
+    EXPECT_NEAR(qz.w(), kHalfSqrt2, kQuatTol);
+    EXPECT_NEAR(qz.z(), kHalfSqrt2, kQuatTol);
 
     // Hamilton product: qx(90) * qy(90) = (0.5, 0.5, 0.5, 0.5) exactly.
-    quatMul(qx, qy, q);
-    EXPECT_NEAR(q[0], 0.5f, kQuatTol);
-    EXPECT_NEAR(q[1], 0.5f, kQuatTol);
-    EXPECT_NEAR(q[2], 0.5f, kQuatTol);
-    EXPECT_NEAR(q[3], 0.5f, kQuatTol);
-}
-
-TEST(QuatHelpers, MulSupportsAliasedOutput) {
-    // quatMul documents that out may alias a or b: q ⊗ q in place must equal
-    // the rotation of twice the angle.
-    constexpr float kAngleDeg = 30.0f;
-    float q[4], expected[4];
-    quatFromAxisX(kAngleDeg*kDegToRad, q);
-    quatFromAxisX(2.0f*kAngleDeg*kDegToRad, expected);
-
-    quatMul(q, q, q);
-    for (int i = 0; i < 4; ++i) EXPECT_NEAR(q[i], expected[i], kQuatTol);
+    const Quaternionf q = qx*qy;
+    EXPECT_NEAR(q.w(), 0.5f, kQuatTol);
+    EXPECT_NEAR(q.x(), 0.5f, kQuatTol);
+    EXPECT_NEAR(q.y(), 0.5f, kQuatTol);
+    EXPECT_NEAR(q.z(), 0.5f, kQuatTol);
 }
 
 TEST(QuatHelpers, EulerExtractionClampsAtGimbalLock) {
@@ -172,26 +156,15 @@ TEST(QuatHelpers, EulerExtractionClampsAtGimbalLock) {
     // asin out of domain).
     float roll, pitch, yaw;
 
-    const float q_up[4] = {0.7071f, 0.0f, 0.7080f, 0.0f};  // sinp < -1 -> +90
+    const Quaternionf q_up(0.7071f, 0.0f, 0.7080f, 0.0f);  // sinp < -1 -> +90
     quatToEulerDeg(q_up, roll, pitch, yaw);
     EXPECT_NEAR(pitch, 90.0f, kExactTolDeg);
     EXPECT_TRUE(std::isfinite(roll) && std::isfinite(yaw));
 
-    const float q_down[4] = {0.7071f, 0.0f, -0.7080f, 0.0f};  // sinp > 1 -> -90
+    const Quaternionf q_down(0.7071f, 0.0f, -0.7080f, 0.0f);  // sinp > 1 -> -90
     quatToEulerDeg(q_down, roll, pitch, yaw);
     EXPECT_NEAR(pitch, -90.0f, kExactTolDeg);
     EXPECT_TRUE(std::isfinite(roll) && std::isfinite(yaw));
-}
-
-TEST(QuatHelpers, NormalizeScalesToUnitAndHandlesZero) {
-    float q[4] = {2.0f, 0.0f, 0.0f, 0.0f};
-    quatNormalize(q);
-    EXPECT_NEAR(q[0], 1.0f, kQuatTol);
-
-    float z[4] = {0.0f, 0.0f, 0.0f, 0.0f};
-    quatNormalize(z);  // must not produce NaN/inf
-    EXPECT_TRUE(std::isfinite(z[0]) && std::isfinite(z[1]) &&
-                std::isfinite(z[2]) && std::isfinite(z[3]));
 }
 
 TEST(MadgwickFilter, InitFromAccelMatchesTilt) {

--- a/robotiq_tsf/test/test_madgwick_ahrs.cpp
+++ b/robotiq_tsf/test/test_madgwick_ahrs.cpp
@@ -1,42 +1,14 @@
-// Copyright (c) 2026 Robotiq
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above copyright
-//      notice, this list of conditions and the following disclaimer in the
-//      documentation and/or other materials provided with the distribution.
-//
-//    * Neither the name of the copyright holder nor the names of its
-//      contributors may be used to endorse or promote products derived from
-//      this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
-
 // All math is done in float, matching the filter under test: the Madgwick
 // reference implementation is float32 (embedded origin), and the IMU samples
 // are 16-bit (±2 g / ±250 deg/s), so sensor noise and bias sit far above
 // float32 rounding — double would add no accuracy. The quaternion is
 // renormalized every update, so float error does not accumulate either.
 
+#include "robotiq_tsf/MadgwickAHRS.h"
+
 #include <gtest/gtest.h>
 
 #include <cmath>
-
-#include "robotiq_tsf/MadgwickAHRS.h"
 
 namespace {
 
@@ -60,209 +32,313 @@ constexpr float kTrackingTolDeg = 3.0f;
 // a no-op, so anything beyond float dust is a gating failure.
 constexpr float kGateLeakTolDeg = 0.1f;
 
-struct EulerAngles
-{
-   float roll;
-   float pitch;
-   float yaw;
+struct EulerAngles {
+    float roll;
+    float pitch;
+    float yaw;
 };
 
-EulerAngles eulerDegOf(const float q[4])
-{
-   EulerAngles e;
-   quatToEulerDeg(q, e.roll, e.pitch, e.yaw);
-   return e;
+EulerAngles eulerDegOf(const float q[4]) {
+    EulerAngles e;
+    quatToEulerDeg(q, e.roll, e.pitch, e.yaw);
+    return e;
 }
 
-EulerAngles eulerDegOf(const MadgwickFilter& f)
-{
-   EulerAngles e;
-   f.getEulerDeg(e.roll, e.pitch, e.yaw);
-   return e;
+EulerAngles eulerDegOf(const MadgwickFilter &f) {
+    EulerAngles e;
+    f.getEulerDeg(e.roll, e.pitch, e.yaw);
+    return e;
 }
 
-float maxAbsDeg(const EulerAngles& e)
-{
-   return std::max(std::fabs(e.roll), std::max(std::fabs(e.pitch), std::fabs(e.yaw)));
+float maxAbsDeg(const EulerAngles &e) {
+    return std::max(std::fabs(e.roll), std::max(std::fabs(e.pitch), std::fabs(e.yaw)));
 }
 
-::testing::AssertionResult eulerNear(const EulerAngles& actual, const EulerAngles& expected, float tol_deg)
-{
-   if(std::fabs(actual.roll - expected.roll) <= tol_deg && std::fabs(actual.pitch - expected.pitch) <= tol_deg
-      && std::fabs(actual.yaw - expected.yaw) <= tol_deg)
-   {
-      return ::testing::AssertionSuccess();
-   }
-   return ::testing::AssertionFailure() << "(roll, pitch, yaw) = (" << actual.roll << ", " << actual.pitch << ", "
-                                        << actual.yaw << ") deg, expected (" << expected.roll << ", " << expected.pitch
-                                        << ", " << expected.yaw << ") deg +/- " << tol_deg;
+::testing::AssertionResult eulerNear(const EulerAngles &actual,
+                                     const EulerAngles &expected,
+                                     float tol_deg) {
+    if (std::fabs(actual.roll - expected.roll) <= tol_deg &&
+        std::fabs(actual.pitch - expected.pitch) <= tol_deg &&
+        std::fabs(actual.yaw - expected.yaw) <= tol_deg) {
+        return ::testing::AssertionSuccess();
+    }
+    return ::testing::AssertionFailure()
+           << "(roll, pitch, yaw) = (" << actual.roll << ", " << actual.pitch
+           << ", " << actual.yaw << ") deg, expected (" << expected.roll << ", "
+           << expected.pitch << ", " << expected.yaw << ") deg +/- " << tol_deg;
 }
 
-TEST(QuatHelpers, EulerFromSingleAxisQuaternions)
-{
-   constexpr float kRollDeg = 30.0f;
-   constexpr float kPitchDeg = 45.0f;
-   constexpr float kYawDeg = -60.0f;
+TEST(QuatHelpers, EulerFromSingleAxisQuaternions) {
+    constexpr float kRollDeg = 30.0f;
+    constexpr float kPitchDeg = 45.0f;
+    constexpr float kYawDeg = -60.0f;
 
-   float q[4];
+    float q[4];
 
-   quatFromAxisX(kRollDeg * kDegToRad, q);
-   EXPECT_TRUE(eulerNear(eulerDegOf(q), {kRollDeg, 0.0f, 0.0f}, kExactTolDeg));
+    quatFromAxisX(kRollDeg * kDegToRad, q);
+    EXPECT_TRUE(eulerNear(eulerDegOf(q), {kRollDeg, 0.0f, 0.0f}, kExactTolDeg));
 
-   quatFromAxisY(kPitchDeg * kDegToRad, q);
-   EXPECT_TRUE(eulerNear(eulerDegOf(q), {0.0f, kPitchDeg, 0.0f}, kExactTolDeg));
+    quatFromAxisY(kPitchDeg * kDegToRad, q);
+    EXPECT_TRUE(eulerNear(eulerDegOf(q), {0.0f, kPitchDeg, 0.0f}, kExactTolDeg));
 
-   quatFromAxisZ(kYawDeg * kDegToRad, q);
-   EXPECT_TRUE(eulerNear(eulerDegOf(q), {0.0f, 0.0f, kYawDeg}, kExactTolDeg));
+    quatFromAxisZ(kYawDeg * kDegToRad, q);
+    EXPECT_TRUE(eulerNear(eulerDegOf(q), {0.0f, 0.0f, kYawDeg}, kExactTolDeg));
 }
 
-TEST(QuatHelpers, EulerFromComposedZyxRotation)
-{
-   // ZYX Tait-Bryan: q = qz(yaw) * qy(pitch) * qx(roll) must decompose back
-   // into the same three angles.
-   constexpr float kRollDeg = 10.0f;
-   constexpr float kPitchDeg = 20.0f;
-   constexpr float kYawDeg = 30.0f;
+TEST(QuatHelpers, EulerFromComposedZyxRotation) {
+    // ZYX Tait-Bryan: q = qz(yaw) * qy(pitch) * qx(roll) must decompose back
+    // into the same three angles.
+    constexpr float kRollDeg = 10.0f;
+    constexpr float kPitchDeg = 20.0f;
+    constexpr float kYawDeg = 30.0f;
 
-   float qx[4], qy[4], qz[4], tmp[4], q[4];
-   quatFromAxisX(kRollDeg * kDegToRad, qx);
-   quatFromAxisY(kPitchDeg * kDegToRad, qy);
-   quatFromAxisZ(kYawDeg * kDegToRad, qz);
-   quatMul(qz, qy, tmp);
-   quatMul(tmp, qx, q);
+    float qx[4], qy[4], qz[4], tmp[4], q[4];
+    quatFromAxisX(kRollDeg * kDegToRad, qx);
+    quatFromAxisY(kPitchDeg * kDegToRad, qy);
+    quatFromAxisZ(kYawDeg * kDegToRad, qz);
+    quatMul(qz, qy, tmp);
+    quatMul(tmp, qx, q);
 
-   EXPECT_TRUE(eulerNear(eulerDegOf(q), {kRollDeg, kPitchDeg, kYawDeg}, kExactTolDeg));
+    EXPECT_TRUE(eulerNear(eulerDegOf(q), {kRollDeg, kPitchDeg, kYawDeg}, kExactTolDeg));
 }
 
-TEST(QuatHelpers, MulByConjugateGivesRelativeRotation)
-{
-   // Zeroing as done for relative orientation: q_rel = conj(q_ref) * q.
-   constexpr float kRefRollDeg = 30.0f;
-   constexpr float kCurRollDeg = 50.0f;
-   constexpr float kRelRollDeg = kCurRollDeg - kRefRollDeg;
+TEST(QuatHelpers, MulByConjugateGivesRelativeRotation) {
+    // Zeroing as done for relative orientation: q_rel = conj(q_ref) * q.
+    constexpr float kRefRollDeg = 30.0f;
+    constexpr float kCurRollDeg = 50.0f;
+    constexpr float kRelRollDeg = kCurRollDeg - kRefRollDeg;
 
-   float q_ref[4], q_cur[4], q_ref_conj[4], q_rel[4];
-   quatFromAxisX(kRefRollDeg * kDegToRad, q_ref);
-   quatFromAxisX(kCurRollDeg * kDegToRad, q_cur);
-   quatConj(q_ref, q_ref_conj);
-   quatMul(q_ref_conj, q_cur, q_rel);
+    float q_ref[4], q_cur[4], q_ref_conj[4], q_rel[4];
+    quatFromAxisX(kRefRollDeg * kDegToRad, q_ref);
+    quatFromAxisX(kCurRollDeg * kDegToRad, q_cur);
+    quatConj(q_ref, q_ref_conj);
+    quatMul(q_ref_conj, q_cur, q_rel);
 
-   EXPECT_TRUE(eulerNear(eulerDegOf(q_rel), {kRelRollDeg, 0.0f, 0.0f}, kExactTolDeg));
+    EXPECT_TRUE(eulerNear(eulerDegOf(q_rel), {kRelRollDeg, 0.0f, 0.0f}, kExactTolDeg));
 
-   // Self-relative must be identity.
-   quatConj(q_cur, q_ref_conj);
-   quatMul(q_ref_conj, q_cur, q_rel);
-   EXPECT_NEAR(q_rel[0], 1.0f, kQuatTol);
-   EXPECT_NEAR(q_rel[1], 0.0f, kQuatTol);
-   EXPECT_NEAR(q_rel[2], 0.0f, kQuatTol);
-   EXPECT_NEAR(q_rel[3], 0.0f, kQuatTol);
+    // Self-relative must be identity.
+    quatConj(q_cur, q_ref_conj);
+    quatMul(q_ref_conj, q_cur, q_rel);
+    EXPECT_NEAR(q_rel[0], 1.0f, kQuatTol);
+    EXPECT_NEAR(q_rel[1], 0.0f, kQuatTol);
+    EXPECT_NEAR(q_rel[2], 0.0f, kQuatTol);
+    EXPECT_NEAR(q_rel[3], 0.0f, kQuatTol);
 }
 
-TEST(QuatHelpers, NormalizeScalesToUnitAndHandlesZero)
-{
-   float q[4] = {2.0f, 0.0f, 0.0f, 0.0f};
-   quatNormalize(q);
-   EXPECT_NEAR(q[0], 1.0f, kQuatTol);
+TEST(QuatHelpers, HamiltonConventionGoldenComponents) {
+    // Pins the [w, x, y, z] layout, Hamilton product order, and right-handed
+    // rotation signs with exact component values, so a linalg-library swap
+    // cannot silently flip handedness or component order.
+    constexpr float kHalfSqrt2 = 0.70710678f;
+    float qx[4], qy[4], qz[4], q[4];
 
-   float z[4] = {0.0f, 0.0f, 0.0f, 0.0f};
-   quatNormalize(z); // must not produce NaN/inf
-   EXPECT_TRUE(std::isfinite(z[0]) && std::isfinite(z[1]) && std::isfinite(z[2]) && std::isfinite(z[3]));
+    quatFromAxisX(0.5f*kPi, qx);
+    EXPECT_NEAR(qx[0], kHalfSqrt2, kQuatTol);
+    EXPECT_NEAR(qx[1], kHalfSqrt2, kQuatTol);
+    EXPECT_NEAR(qx[2], 0.0f, kQuatTol);
+    EXPECT_NEAR(qx[3], 0.0f, kQuatTol);
+
+    quatFromAxisY(0.5f*kPi, qy);
+    EXPECT_NEAR(qy[0], kHalfSqrt2, kQuatTol);
+    EXPECT_NEAR(qy[2], kHalfSqrt2, kQuatTol);
+
+    quatFromAxisZ(0.5f*kPi, qz);
+    EXPECT_NEAR(qz[0], kHalfSqrt2, kQuatTol);
+    EXPECT_NEAR(qz[3], kHalfSqrt2, kQuatTol);
+
+    // Hamilton product: qx(90) * qy(90) = (0.5, 0.5, 0.5, 0.5) exactly.
+    quatMul(qx, qy, q);
+    EXPECT_NEAR(q[0], 0.5f, kQuatTol);
+    EXPECT_NEAR(q[1], 0.5f, kQuatTol);
+    EXPECT_NEAR(q[2], 0.5f, kQuatTol);
+    EXPECT_NEAR(q[3], 0.5f, kQuatTol);
 }
 
-TEST(MadgwickFilter, InitFromAccelMatchesTilt)
-{
-   constexpr float kRollDeg = 30.0f;
-   constexpr float kPitchDeg = 20.0f;
-   constexpr float g = 9.81f; // m/s^2
+TEST(QuatHelpers, MulSupportsAliasedOutput) {
+    // quatMul documents that out may alias a or b: q ⊗ q in place must equal
+    // the rotation of twice the angle.
+    constexpr float kAngleDeg = 30.0f;
+    float q[4], expected[4];
+    quatFromAxisX(kAngleDeg*kDegToRad, q);
+    quatFromAxisX(2.0f*kAngleDeg*kDegToRad, expected);
 
-   MadgwickFilter f;
-
-   // Flat: gravity along body +Z.
-   f.initFromAccel(0.0f, 0.0f, 1.0f);
-   EXPECT_TRUE(eulerNear(eulerDegOf(f), {0.0f, 0.0f, 0.0f}, kExactTolDeg));
-
-   // Pure roll: gravity_body = (0, sin r, cos r). Units must not matter,
-   // so feed m/s^2 rather than g.
-   f.initFromAccel(0.0f, g * std::sin(kRollDeg * kDegToRad), g * std::cos(kRollDeg * kDegToRad));
-   EXPECT_TRUE(eulerNear(eulerDegOf(f), {kRollDeg, 0.0f, 0.0f}, kExactTolDeg));
-
-   // Pure pitch: gravity_body = (-sin p, 0, cos p).
-   f.initFromAccel(-std::sin(kPitchDeg * kDegToRad), 0.0f, std::cos(kPitchDeg * kDegToRad));
-   EXPECT_TRUE(eulerNear(eulerDegOf(f), {0.0f, kPitchDeg, 0.0f}, kExactTolDeg));
+    quatMul(q, q, q);
+    for (int i = 0; i < 4; ++i) EXPECT_NEAR(q[i], expected[i], kQuatTol);
 }
 
-TEST(MadgwickFilter, InitFromZeroAccelResetsToIdentity)
-{
-   MadgwickFilter f;
-   f.initFromAccel(0.0f, 1.0f, 0.0f); // some non-identity state first
-   f.initFromAccel(0.0f, 0.0f, 0.0f);
-   float q0, q1, q2, q3;
-   f.getQuaternion(q0, q1, q2, q3);
-   EXPECT_NEAR(q0, 1.0f, kQuatTol);
-   EXPECT_NEAR(q1, 0.0f, kQuatTol);
-   EXPECT_NEAR(q2, 0.0f, kQuatTol);
-   EXPECT_NEAR(q3, 0.0f, kQuatTol);
+TEST(QuatHelpers, EulerExtractionClampsAtGimbalLock) {
+    // A slightly super-unit quaternion pushes |sin(pitch)| past 1; the
+    // extraction must clamp to exactly +/-90 deg and stay finite (no NaN from
+    // asin out of domain).
+    float roll, pitch, yaw;
+
+    const float q_up[4] = {0.7071f, 0.0f, 0.7080f, 0.0f};  // sinp < -1 -> +90
+    quatToEulerDeg(q_up, roll, pitch, yaw);
+    EXPECT_NEAR(pitch, 90.0f, kExactTolDeg);
+    EXPECT_TRUE(std::isfinite(roll) && std::isfinite(yaw));
+
+    const float q_down[4] = {0.7071f, 0.0f, -0.7080f, 0.0f};  // sinp > 1 -> -90
+    quatToEulerDeg(q_down, roll, pitch, yaw);
+    EXPECT_NEAR(pitch, -90.0f, kExactTolDeg);
+    EXPECT_TRUE(std::isfinite(roll) && std::isfinite(yaw));
 }
 
-TEST(MadgwickFilter, NonPositiveDtIsIgnored)
-{
-   MadgwickFilter f;
-   f.initFromAccel(0.0f, 0.0f, 1.0f);
-   float before[4], after[4];
-   f.getQuaternion(before[0], before[1], before[2], before[3]);
-   f.updateIMU(1.0f, 2.0f, 3.0f, 0.0f, 0.0f, 1.0f, 0.0f);
-   f.updateIMU(1.0f, 2.0f, 3.0f, 0.0f, 0.0f, 1.0f, -0.01f);
-   f.getQuaternion(after[0], after[1], after[2], after[3]);
-   for(int i = 0; i < 4; ++i)
-   {
-      EXPECT_EQ(before[i], after[i]);
-   }
+TEST(QuatHelpers, NormalizeScalesToUnitAndHandlesZero) {
+    float q[4] = {2.0f, 0.0f, 0.0f, 0.0f};
+    quatNormalize(q);
+    EXPECT_NEAR(q[0], 1.0f, kQuatTol);
+
+    float z[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    quatNormalize(z);  // must not produce NaN/inf
+    EXPECT_TRUE(std::isfinite(z[0]) && std::isfinite(z[1]) &&
+                std::isfinite(z[2]) && std::isfinite(z[3]));
 }
 
-TEST(MadgwickFilter, TracksRotationWithMeasuredDt)
-{
-   // 90 deg/s roll for 1 s, sampled at 200 Hz. Accel stays consistent with
-   // the true attitude (pure tilt, |a| = 1 g), gyro is exact. The legacy
-   // filter integrated every sample as 1/1000 s regardless of the real rate,
-   // so it tracked this rotation ~5x too slow — the "drift" in PR #5.
-   constexpr float kRateDegS = 90.0f;
-   constexpr float kDt = 0.005f;
-   constexpr int kSteps = 200;
-   constexpr float kExpectedRollDeg = kRateDegS * kDt * kSteps;
+TEST(MadgwickFilter, InitFromAccelMatchesTilt) {
+    constexpr float kRollDeg = 30.0f;
+    constexpr float kPitchDeg = 20.0f;
+    constexpr float g = 9.81f;  // m/s^2
 
-   MadgwickFilter f;
-   f.initFromAccel(0.0f, 0.0f, 1.0f);
-   for(int i = 0; i < kSteps; ++i)
-   {
-      const float rollTrue = kRateDegS * kDt * static_cast<float>(i) * kDegToRad;
-      f.updateIMU(kRateDegS * kDegToRad, 0.0f, 0.0f, 0.0f, std::sin(rollTrue), std::cos(rollTrue), kDt);
-   }
-   EXPECT_TRUE(eulerNear(eulerDegOf(f), {kExpectedRollDeg, 0.0f, 0.0f}, kTrackingTolDeg));
+    MadgwickFilter f;
+
+    // Flat: gravity along body +Z.
+    f.initFromAccel(0.0f, 0.0f, 1.0f);
+    EXPECT_TRUE(eulerNear(eulerDegOf(f), {0.0f, 0.0f, 0.0f}, kExactTolDeg));
+
+    // Pure roll: gravity_body = (0, sin r, cos r). Units must not matter,
+    // so feed m/s^2 rather than g.
+    f.initFromAccel(0.0f, g * std::sin(kRollDeg * kDegToRad),
+                    g * std::cos(kRollDeg * kDegToRad));
+    EXPECT_TRUE(eulerNear(eulerDegOf(f), {kRollDeg, 0.0f, 0.0f}, kExactTolDeg));
+
+    // Pure pitch: gravity_body = (-sin p, 0, cos p).
+    f.initFromAccel(-std::sin(kPitchDeg * kDegToRad), 0.0f,
+                    std::cos(kPitchDeg * kDegToRad));
+    EXPECT_TRUE(eulerNear(eulerDegOf(f), {0.0f, kPitchDeg, 0.0f}, kExactTolDeg));
 }
 
-TEST(MadgwickFilter, AccelGateRejectsMotionBursts)
-{
-   // Stationary sensor, zero rotation, but a sustained linear-acceleration
-   // burst (|a| ~ 1.35 g). The legacy filter treated the burst as a tilted
-   // gravity vector and walked the attitude away — the "noisy in transition"
-   // in PR #5. Accel feedback outside [0.85, 1.15] g must be gated, so the
-   // attitude must not move at all.
-   constexpr float kDt = 0.005f;
-   constexpr int kBurstSteps = 1000; // 5 s of burst at 200 Hz
-   // gravity (1 g on Z) + 0.9 g lateral -> |a| ~ 1.35 g, outside the accel gate
-   constexpr float kBurstLateralG = 0.9f;
+TEST(MadgwickFilter, InitFromAccelCombinedRollPitch) {
+    // Gravity in body frame for roll r, pitch p (ZYX, yaw-free):
+    // g_body = (-sin p, sin r * cos p, cos r * cos p).
+    constexpr float kRollDeg = 30.0f;
+    constexpr float kPitchDeg = 20.0f;
+    const float sr = std::sin(kRollDeg*kDegToRad);
+    const float cr = std::cos(kRollDeg*kDegToRad);
+    const float sp = std::sin(kPitchDeg*kDegToRad);
+    const float cp = std::cos(kPitchDeg*kDegToRad);
 
-   MadgwickFilter f;
-   f.initFromAccel(0.0f, 0.0f, 1.0f);
-
-   float peakDeg = 0.0f;
-   for(int i = 0; i < kBurstSteps; ++i)
-   {
-      f.updateIMU(0.0f, 0.0f, 0.0f, kBurstLateralG, 0.0f, 1.0f, kDt);
-      peakDeg = std::max(peakDeg, maxAbsDeg(eulerDegOf(f)));
-   }
-
-   EXPECT_LT(peakDeg, kGateLeakTolDeg);
+    MadgwickFilter f;
+    f.initFromAccel(-sp, sr*cp, cr*cp);
+    EXPECT_TRUE(eulerNear(eulerDegOf(f), {kRollDeg, kPitchDeg, 0.0f}, kExactTolDeg));
 }
 
-} // namespace
+TEST(MadgwickFilter, InitFromZeroAccelResetsToIdentity) {
+    MadgwickFilter f;
+    f.initFromAccel(0.0f, 1.0f, 0.0f);  // some non-identity state first
+    f.initFromAccel(0.0f, 0.0f, 0.0f);
+    float q0, q1, q2, q3;
+    f.getQuaternion(q0, q1, q2, q3);
+    EXPECT_NEAR(q0, 1.0f, kQuatTol);
+    EXPECT_NEAR(q1, 0.0f, kQuatTol);
+    EXPECT_NEAR(q2, 0.0f, kQuatTol);
+    EXPECT_NEAR(q3, 0.0f, kQuatTol);
+}
+
+TEST(MadgwickFilter, NonPositiveDtIsIgnored) {
+    MadgwickFilter f;
+    f.initFromAccel(0.0f, 0.0f, 1.0f);
+    float before[4], after[4];
+    f.getQuaternion(before[0], before[1], before[2], before[3]);
+    f.updateIMU(1.0f, 2.0f, 3.0f, 0.0f, 0.0f, 1.0f, 0.0f);
+    f.updateIMU(1.0f, 2.0f, 3.0f, 0.0f, 0.0f, 1.0f, -0.01f);
+    f.getQuaternion(after[0], after[1], after[2], after[3]);
+    for (int i = 0; i < 4; ++i) EXPECT_EQ(before[i], after[i]);
+}
+
+TEST(MadgwickFilter, TracksRotationWithMeasuredDt) {
+    // 90 deg/s roll for 1 s, sampled at 200 Hz. Accel stays consistent with
+    // the true attitude (pure tilt, |a| = 1 g), gyro is exact. The legacy
+    // filter integrated every sample as 1/1000 s regardless of the real rate,
+    // so it tracked this rotation ~5x too slow — the "drift" in PR #5.
+    constexpr float kRateDegS = 90.0f;
+    constexpr float kDt = 0.005f;
+    constexpr int kSteps = 200;
+    constexpr float kExpectedRollDeg = kRateDegS * kDt * kSteps;
+
+    MadgwickFilter f;
+    f.initFromAccel(0.0f, 0.0f, 1.0f);
+    for (int i = 0; i < kSteps; ++i) {
+        const float rollTrue = kRateDegS * kDt * static_cast<float>(i) * kDegToRad;
+        f.updateIMU(kRateDegS * kDegToRad, 0.0f, 0.0f,
+                    0.0f, std::sin(rollTrue), std::cos(rollTrue), kDt);
+    }
+    EXPECT_TRUE(eulerNear(eulerDegOf(f), {kExpectedRollDeg, 0.0f, 0.0f}, kTrackingTolDeg));
+}
+
+TEST(MadgwickFilter, AccelGateRejectsMotionBursts) {
+    // Stationary sensor, zero rotation, but a sustained linear-acceleration
+    // burst (|a| ~ 1.35 g). The legacy filter treated the burst as a tilted
+    // gravity vector and walked the attitude away — the "noisy in transition"
+    // in PR #5. Accel feedback outside [0.85, 1.15] g must be gated, so the
+    // attitude must not move at all.
+    constexpr float kDt = 0.005f;
+    constexpr int kBurstSteps = 1000;  // 5 s of burst at 200 Hz
+    // gravity (1 g on Z) + 0.9 g lateral -> |a| ~ 1.35 g, outside the accel gate
+    constexpr float kBurstLateralG = 0.9f;
+
+    MadgwickFilter f;
+    f.initFromAccel(0.0f, 0.0f, 1.0f);
+
+    float peakDeg = 0.0f;
+    for (int i = 0; i < kBurstSteps; ++i) {
+        f.updateIMU(0.0f, 0.0f, 0.0f, kBurstLateralG, 0.0f, 1.0f, kDt);
+        peakDeg = std::max(peakDeg, maxAbsDeg(eulerDegOf(f)));
+    }
+
+    EXPECT_LT(peakDeg, kGateLeakTolDeg);
+}
+
+TEST(MadgwickFilter, GoldenTrajectoryCheckpoints) {
+    // End-to-end numeric regression: a fixed synthetic IMU stream must keep
+    // reproducing the quaternion checkpoints recorded from the pre-Eigen
+    // implementation. Guards the library migration against any behavior
+    // change beyond float-op reordering: 1e-5 (~80 float32 ulps at unit
+    // scale) absorbs reordering drift accumulated over the 350 updates while
+    // staying orders of magnitude below a real algorithmic change.
+    constexpr float kGoldenTol = 1e-5f;
+    constexpr float kDt = 0.005f;
+    struct Checkpoint { const char* tag; float q[4]; };
+
+    MadgwickFilter f;
+    f.initFromAccel(0.0f, 0.0f, 1.0f);
+
+    auto expectCheckpoint = [&f](const Checkpoint &c) {
+        float q[4];
+        f.getQuaternion(q[0], q[1], q[2], q[3]);
+        for (int i = 0; i < 4; ++i) {
+            EXPECT_NEAR(q[i], c.q[i], kGoldenTol)
+                << "checkpoint " << c.tag << " component " << i;
+        }
+    };
+
+    // Segment A: 100 steps stationary (accel gate open, gradient active).
+    for (int i = 0; i < 100; ++i)
+        f.updateIMU(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, kDt);
+    expectCheckpoint({"A", {1.00000000f, 0.00000000f, 0.00000000f, 0.00000000f}});
+
+    // Segment B: 150 steps rolling at 60 deg/s with attitude-consistent accel.
+    for (int i = 0; i < 150; ++i) {
+        const float roll = 60.0f*kDt*static_cast<float>(i)*kDegToRad;
+        f.updateIMU(60.0f*kDegToRad, 0.0f, 0.0f,
+                    0.0f, std::sin(roll), std::cos(roll), kDt);
+    }
+    expectCheckpoint({"B", {0.92394269f, 0.38253102f, 0.00000000f, 0.00000000f}});
+
+    // Segment C: 100 steps yawing at 45 deg/s while accel is gated
+    // (|a| = 1.4 g): pure gyro integration path.
+    for (int i = 0; i < 100; ++i)
+        f.updateIMU(0.0f, 0.0f, 45.0f*kDegToRad, 0.98f, 0.0f, 1.0f, kDt);
+    expectCheckpoint({"C", {0.90618920f, 0.37518126f, -0.07462808f, 0.18025191f}});
+}
+
+}  // namespace

--- a/robotiq_tsf/test/test_tactile_viz.py
+++ b/robotiq_tsf/test/test_tactile_viz.py
@@ -1,3 +1,31 @@
+# Copyright (c) 2026 Robotiq
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the copyright holder nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
 """Unit tests for scripts/tactile_viz_node (baseline zeroing, noise floor,
 marker/heatmap generation, colormap, rpy->quat).
 
@@ -15,9 +43,11 @@ import rclpy
 from rclpy.parameter import Parameter
 from robotiq_tsf.msg import StaticData
 
-_SCRIPT = pathlib.Path(__file__).resolve().parent.parent / 'scripts' / 'tactile_viz_node'
-_loader = importlib.machinery.SourceFileLoader('tactile_viz_node', str(_SCRIPT))
-_spec = importlib.util.spec_from_loader('tactile_viz_node', _loader)
+_SCRIPT = (
+    pathlib.Path(__file__).resolve().parent.parent / "scripts" / "tactile_viz_node"
+)
+_loader = importlib.machinery.SourceFileLoader("tactile_viz_node", str(_SCRIPT))
+_spec = importlib.util.spec_from_loader("tactile_viz_node", _loader)
 viz = importlib.util.module_from_spec(_spec)
 _loader.exec_module(viz)
 
@@ -34,7 +64,7 @@ class _RecordingPub:
         self.msgs.append(msg)
 
 
-@pytest.fixture(scope='module', autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def ros():
     rclpy.init()
     yield
@@ -43,8 +73,9 @@ def ros():
 
 def make_node(**params):
     overrides = [Parameter(k, value=v) for k, v in params.items()]
-    node = viz.TactileVizNode(parameter_overrides=overrides,
-                              start_parameter_services=False)
+    node = viz.TactileVizNode(
+        parameter_overrides=overrides, start_parameter_services=False
+    )
     node._marker_pub = _RecordingPub()
     node._heatmap_pubs = [_RecordingPub(), _RecordingPub()]
     return node
@@ -54,7 +85,7 @@ def make_msg(f0=0, f1=None):
     """StaticData with constant (or per-taxel list) values per finger."""
     msg = StaticData()
     for fi, v in enumerate((f0, f0 if f1 is None else f1)):
-        values = [v]*TAXELS if isinstance(v, int) else list(v)
+        values = [v] * TAXELS if isinstance(v, int) else list(v)
         msg.taxels[fi].values = values
     return msg
 
@@ -62,7 +93,7 @@ def make_msg(f0=0, f1=None):
 def marker_values(node):
     """Colors of the last published MarkerArray, as [(r, g, b)] per finger."""
     array = node._marker_pub.msgs[-1]
-    assert len(array.markers) == 2*TAXELS
+    assert len(array.markers) == 2 * TAXELS
     out = [[], []]
     for m in array.markers:
         fi = int(m.ns[-1])
@@ -75,14 +106,14 @@ def test_colormap_endpoints_and_clamp():
     assert viz._colormap(1.0) == pytest.approx(RED)
     assert viz._colormap(-5.0) == pytest.approx(NAVY)
     assert viz._colormap(5.0) == pytest.approx(RED)
-    assert viz._colormap(1.0/3.0) == pytest.approx((0.0, 0.7, 0.9))
-    assert viz._colormap(2.0/3.0) == pytest.approx((1.0, 0.95, 0.2))
+    assert viz._colormap(1.0 / 3.0) == pytest.approx((0.0, 0.7, 0.9))
+    assert viz._colormap(2.0 / 3.0) == pytest.approx((1.0, 0.95, 0.2))
 
 
 def test_colormap_is_continuous():
     prev = viz._colormap(0.0)
     for i in range(1, 101):
-        cur = viz._colormap(i/100.0)
+        cur = viz._colormap(i / 100.0)
         assert all(abs(a - b) < 0.05 for a, b in zip(prev, cur))
         prev = cur
 
@@ -92,14 +123,16 @@ def test_rpy_to_quat():
     assert (q.w, q.x, q.y, q.z) == pytest.approx((1.0, 0.0, 0.0, 0.0))
     q = viz._rpy_to_quat(0.0, 0.0, math.pi)
     assert (q.w, q.x, q.y, q.z) == pytest.approx((0.0, 0.0, 0.0, 1.0), abs=1e-9)
-    q = viz._rpy_to_quat(math.pi/2, 0.0, 0.0)
+    q = viz._rpy_to_quat(math.pi / 2, 0.0, 0.0)
     assert (q.w, q.x, q.y, q.z) == pytest.approx(
-        (math.cos(math.pi/4), math.sin(math.pi/4), 0.0, 0.0))
+        (math.cos(math.pi / 4), math.sin(math.pi / 4), 0.0, 0.0)
+    )
     # General-case golden (ZYX composition), pinned so a future swap to a
     # library helper cannot silently change convention.
     q = viz._rpy_to_quat(0.3, -0.7, 1.1)
     assert (q.w, q.x, q.y, q.z) == pytest.approx(
-        (0.765062179348, 0.296891540058, -0.215672410090, 0.529169808944))
+        (0.765062179348, 0.296891540058, -0.215672410090, 0.529169808944)
+    )
     assert q.w**2 + q.x**2 + q.y**2 + q.z**2 == pytest.approx(1.0)
 
 
@@ -117,18 +150,18 @@ def test_baseline_subtraction_and_noise_floor():
     node = make_node(baseline_frames=2, noise_floor=50.0, vmin=0.0, vmax=700.0)
     try:
         node._on_data(make_msg(1000))
-        node._on_data(make_msg(1000))          # baseline = 1000 captured
+        node._on_data(make_msg(1000))  # baseline = 1000 captured
 
-        node._on_data(make_msg(1049))          # residual 49 < floor -> zero
+        node._on_data(make_msg(1049))  # residual 49 < floor -> zero
         for finger in marker_values(node):
             assert all(c == pytest.approx(NAVY) for c in finger)
 
-        node._on_data(make_msg(1050))          # residual 50 == floor -> kept
-        expected = viz._colormap(50.0/700.0)
+        node._on_data(make_msg(1050))  # residual 50 == floor -> kept
+        expected = viz._colormap(50.0 / 700.0)
         for finger in marker_values(node):
             assert all(c == pytest.approx(expected) for c in finger)
 
-        node._on_data(make_msg(500))           # below baseline -> clamped to 0
+        node._on_data(make_msg(500))  # below baseline -> clamped to 0
         for finger in marker_values(node):
             assert all(c == pytest.approx(NAVY) for c in finger)
     finally:
@@ -138,13 +171,13 @@ def test_baseline_subtraction_and_noise_floor():
 def test_rezero_recaptures_baseline():
     node = make_node(baseline_frames=1, noise_floor=0.0)
     try:
-        node._on_data(make_msg(100))           # baseline = 100
-        node._on_data(make_msg(300))           # residual 200
+        node._on_data(make_msg(100))  # baseline = 100
+        node._on_data(make_msg(300))  # residual 200
         assert marker_values(node)[0][0] != pytest.approx(NAVY)
 
         node._on_zero(None)
-        node._on_data(make_msg(300))           # new baseline = 300, shows zeros
-        node._on_data(make_msg(300))           # residual 0
+        node._on_data(make_msg(300))  # new baseline = 300, shows zeros
+        node._on_data(make_msg(300))  # residual 0
         for finger in marker_values(node):
             assert all(c == pytest.approx(NAVY) for c in finger)
     finally:
@@ -166,13 +199,13 @@ def test_marker_geometry_and_ids():
     try:
         node._on_data(make_msg(0))
         array = node._marker_pub.msgs[-1]
-        f0 = [m for m in array.markers if m.ns == 'tactile_finger_0']
+        f0 = [m for m in array.markers if m.ns == "tactile_finger_0"]
         assert sorted(m.id for m in f0) == list(range(TAXELS))
-        assert all(m.header.frame_id == 'tactile_finger_0' for m in f0)
-        pitch_y, pitch_z = 0.022/4, 0.037/7
-        y_half = (COLS - 1)*0.5*pitch_y
-        z_half = (ROWS - 1)*0.5*pitch_z
-        top_left = next(m for m in f0 if m.id == 0)          # r=0, c=0
+        assert all(m.header.frame_id == "tactile_finger_0" for m in f0)
+        pitch_y, pitch_z = 0.022 / 4, 0.037 / 7
+        y_half = (COLS - 1) * 0.5 * pitch_y
+        z_half = (ROWS - 1) * 0.5 * pitch_z
+        top_left = next(m for m in f0 if m.id == 0)  # r=0, c=0
         assert top_left.pose.position.y == pytest.approx(y_half)
         assert top_left.pose.position.z == pytest.approx(z_half)
         bottom_right = next(m for m in f0 if m.id == TAXELS - 1)
@@ -183,64 +216,73 @@ def test_marker_geometry_and_ids():
 
 
 def test_flip_finger_1_reverses_columns():
-    ramp = list(range(TAXELS))                 # distinct value per taxel
+    ramp = list(range(TAXELS))  # distinct value per taxel
     node = make_node(zero_on_start=False, flip_finger_1=True, noise_floor=0.0)
     try:
         node._on_data(make_msg(ramp, ramp))
         array = node._marker_pub.msgs[-1]
-        by_id = {m.id: m for m in array.markers if m.ns == 'tactile_finger_1'}
-        ref = {m.id: m for m in array.markers if m.ns == 'tactile_finger_0'}
+        by_id = {m.id: m for m in array.markers if m.ns == "tactile_finger_1"}
+        ref = {m.id: m for m in array.markers if m.ns == "tactile_finger_0"}
         for r in range(ROWS):
             for c in range(COLS):
-                flipped = by_id[r*COLS + c].color
-                straight = ref[r*COLS + (COLS - 1 - c)].color
+                flipped = by_id[r * COLS + c].color
+                straight = ref[r * COLS + (COLS - 1 - c)].color
                 assert (flipped.r, flipped.g, flipped.b) == pytest.approx(
-                    (straight.r, straight.g, straight.b))
+                    (straight.r, straight.g, straight.b)
+                )
     finally:
         node.destroy_node()
 
 
 def test_heatmap_image_shape_and_scaling():
-    node = make_node(zero_on_start=False, heatmap_scale_px=10,
-                     heatmap_publish_hz=0.0, heatmap_floor=0.0)
+    node = make_node(
+        zero_on_start=False,
+        heatmap_scale_px=10,
+        heatmap_publish_hz=0.0,
+        heatmap_floor=0.0,
+    )
     try:
         node._on_data(make_msg(100))
         for pub in node._heatmap_pubs:
             img = pub.msgs[-1]
-            assert (img.height, img.width) == (ROWS*10, COLS*10)
-            assert img.encoding == 'rgb8'
-            assert img.step == img.width*3
-            assert len(img.data) == img.height*img.step
+            assert (img.height, img.width) == (ROWS * 10, COLS * 10)
+            assert img.encoding == "rgb8"
+            assert img.step == img.width * 3
+            assert len(img.data) == img.height * img.step
     finally:
         node.destroy_node()
 
 
 def test_heatmap_autoscale_tracks_running_max():
-    node = make_node(zero_on_start=False, heatmap_scale_px=1,
-                     heatmap_publish_hz=0.0, heatmap_floor=0.0,
-                     heatmap_autoscale=True)
+    node = make_node(
+        zero_on_start=False,
+        heatmap_scale_px=1,
+        heatmap_publish_hz=0.0,
+        heatmap_floor=0.0,
+        heatmap_autoscale=True,
+    )
+
     def px(t):
-        return bytes(round(v*255) for v in viz._colormap(t))
+        return bytes(round(v * 255) for v in viz._colormap(t))
 
     try:
-        node._on_data(make_msg(200))           # max: 200 -> full scale
+        node._on_data(make_msg(200))  # max: 200 -> full scale
         assert bytes(node._heatmap_pubs[0].msgs[-1].data[0:3]) == px(1.0)
 
-        node._on_data(make_msg(400))           # new max: 400, still full scale
+        node._on_data(make_msg(400))  # new max: 400, still full scale
         assert bytes(node._heatmap_pubs[0].msgs[-1].data[0:3]) == px(1.0)
 
-        node._on_data(make_msg(200))           # now mid-scale vs max 400
+        node._on_data(make_msg(200))  # now mid-scale vs max 400
         assert bytes(node._heatmap_pubs[0].msgs[-1].data[0:3]) == px(0.5)
     finally:
         node.destroy_node()
 
 
 def test_heatmap_rate_limit():
-    node = make_node(zero_on_start=False, heatmap_publish_hz=1.0,
-                     heatmap_scale_px=1)
+    node = make_node(zero_on_start=False, heatmap_publish_hz=1.0, heatmap_scale_px=1)
     try:
         node._on_data(make_msg(100))
-        node._on_data(make_msg(100))           # within 1s window -> throttled
+        node._on_data(make_msg(100))  # within 1s window -> throttled
         assert len(node._heatmap_pubs[0].msgs) == 1
         assert len(node._marker_pub.msgs) == 2  # markers are never throttled
     finally:
@@ -262,7 +304,7 @@ def test_wrong_taxel_count_is_dropped():
     # guard with a duck-typed message (e.g. a future variable-length source).
     class FakeTaxels:
         def __init__(self, n):
-            self.values = [0]*n
+            self.values = [0] * n
 
     class FakeMsg:
         def __init__(self):
@@ -271,7 +313,7 @@ def test_wrong_taxel_count_is_dropped():
     node = make_node(zero_on_start=False)
     try:
         node._on_data(FakeMsg())
-        assert node._marker_pub.msgs == []     # dropped, nothing published
+        assert node._marker_pub.msgs == []  # dropped, nothing published
     finally:
         node.destroy_node()
 
@@ -290,15 +332,20 @@ def test_publish_static_tfs():
         node._tf_broadcaster = bc
         node._publish_static_tfs()
         assert [t.child_frame_id for t in bc.transforms] == [
-            'tactile_finger_0', 'tactile_finger_1', 'tactile_tip']
-        assert all(t.header.frame_id == 'tactile_world' for t in bc.transforms)
+            "tactile_finger_0",
+            "tactile_finger_1",
+            "tactile_tip",
+        ]
+        assert all(t.header.frame_id == "tactile_world" for t in bc.transforms)
         f0, f1, tip = bc.transforms
         assert f0.transform.translation.x == pytest.approx(-0.0425)
         assert f1.transform.translation.x == pytest.approx(0.0425)
         assert tip.transform.translation.z == pytest.approx(0.0209)
         assert f0.transform.rotation.w == pytest.approx(1.0)
-        q = f1.transform.rotation                # finger 1 yawed pi to face finger 0
-        assert (q.w, q.x, q.y, abs(q.z)) == pytest.approx((0.0, 0.0, 0.0, 1.0), abs=1e-9)
+        q = f1.transform.rotation  # finger 1 yawed pi to face finger 0
+        assert (q.w, q.x, q.y, abs(q.z)) == pytest.approx(
+            (0.0, 0.0, 0.0, 1.0), abs=1e-9
+        )
     finally:
         node.destroy_node()
 
@@ -307,22 +354,28 @@ def test_heatmap_pixel_orientation():
     # Ramp value = r*COLS + c: every pixel unique, pinning the image's
     # row/column orientation, not just pixel (0,0).
     ramp = list(range(TAXELS))
-    node = make_node(zero_on_start=False, heatmap_scale_px=1,
-                     heatmap_publish_hz=0.0, heatmap_autoscale=False,
-                     vmin=0.0, vmax=float(TAXELS - 1), noise_floor=0.0)
+    node = make_node(
+        zero_on_start=False,
+        heatmap_scale_px=1,
+        heatmap_publish_hz=0.0,
+        heatmap_autoscale=False,
+        vmin=0.0,
+        vmax=float(TAXELS - 1),
+        noise_floor=0.0,
+    )
     try:
         node._on_data(make_msg(ramp, ramp))
         img = node._heatmap_pubs[0].msgs[-1]
 
         def px(r, c):
-            o = (r*img.width + c)*3
-            return bytes(img.data[o:o + 3])
+            o = (r * img.width + c) * 3
+            return bytes(img.data[o : o + 3])
 
         def expected(r, c):
-            t = (r*COLS + c)/(TAXELS - 1)
-            return bytes(round(v*255) for v in viz._colormap(t))
+            t = (r * COLS + c) / (TAXELS - 1)
+            return bytes(round(v * 255) for v in viz._colormap(t))
 
         for r, c in [(0, 0), (0, 3), (2, 1), (4, 3), (6, 0), (6, 3)]:
-            assert px(r, c) == expected(r, c), f'pixel ({r},{c})'
+            assert px(r, c) == expected(r, c), f"pixel ({r},{c})"
     finally:
         node.destroy_node()

--- a/robotiq_tsf/test/test_tactile_viz.py
+++ b/robotiq_tsf/test/test_tactile_viz.py
@@ -1,31 +1,3 @@
-# Copyright (c) 2026 Robotiq
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-#    * Redistributions of source code must retain the above copyright
-#      notice, this list of conditions and the following disclaimer.
-#
-#    * Redistributions in binary form must reproduce the above copyright
-#      notice, this list of conditions and the following disclaimer in the
-#      documentation and/or other materials provided with the distribution.
-#
-#    * Neither the name of the copyright holder nor the names of its
-#      contributors may be used to endorse or promote products derived from
-#      this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
-
 """Unit tests for scripts/tactile_viz_node (baseline zeroing, noise floor,
 marker/heatmap generation, colormap, rpy->quat).
 
@@ -33,7 +5,6 @@ The script has no .py extension, so it is loaded via importlib; the node's
 callbacks are driven directly with constructed StaticData messages and the
 publishers are replaced with recording stubs — no executor or driver needed.
 """
-
 import importlib.machinery
 import importlib.util
 import math
@@ -44,11 +15,9 @@ import rclpy
 from rclpy.parameter import Parameter
 from robotiq_tsf.msg import StaticData
 
-_SCRIPT = (
-    pathlib.Path(__file__).resolve().parent.parent / "scripts" / "tactile_viz_node"
-)
-_loader = importlib.machinery.SourceFileLoader("tactile_viz_node", str(_SCRIPT))
-_spec = importlib.util.spec_from_loader("tactile_viz_node", _loader)
+_SCRIPT = pathlib.Path(__file__).resolve().parent.parent / 'scripts' / 'tactile_viz_node'
+_loader = importlib.machinery.SourceFileLoader('tactile_viz_node', str(_SCRIPT))
+_spec = importlib.util.spec_from_loader('tactile_viz_node', _loader)
 viz = importlib.util.module_from_spec(_spec)
 _loader.exec_module(viz)
 
@@ -65,7 +34,7 @@ class _RecordingPub:
         self.msgs.append(msg)
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope='module', autouse=True)
 def ros():
     rclpy.init()
     yield
@@ -74,9 +43,8 @@ def ros():
 
 def make_node(**params):
     overrides = [Parameter(k, value=v) for k, v in params.items()]
-    node = viz.TactileVizNode(
-        parameter_overrides=overrides, start_parameter_services=False
-    )
+    node = viz.TactileVizNode(parameter_overrides=overrides,
+                              start_parameter_services=False)
     node._marker_pub = _RecordingPub()
     node._heatmap_pubs = [_RecordingPub(), _RecordingPub()]
     return node
@@ -86,7 +54,7 @@ def make_msg(f0=0, f1=None):
     """StaticData with constant (or per-taxel list) values per finger."""
     msg = StaticData()
     for fi, v in enumerate((f0, f0 if f1 is None else f1)):
-        values = [v] * TAXELS if isinstance(v, int) else list(v)
+        values = [v]*TAXELS if isinstance(v, int) else list(v)
         msg.taxels[fi].values = values
     return msg
 
@@ -94,7 +62,7 @@ def make_msg(f0=0, f1=None):
 def marker_values(node):
     """Colors of the last published MarkerArray, as [(r, g, b)] per finger."""
     array = node._marker_pub.msgs[-1]
-    assert len(array.markers) == 2 * TAXELS
+    assert len(array.markers) == 2*TAXELS
     out = [[], []]
     for m in array.markers:
         fi = int(m.ns[-1])
@@ -107,14 +75,14 @@ def test_colormap_endpoints_and_clamp():
     assert viz._colormap(1.0) == pytest.approx(RED)
     assert viz._colormap(-5.0) == pytest.approx(NAVY)
     assert viz._colormap(5.0) == pytest.approx(RED)
-    assert viz._colormap(1.0 / 3.0) == pytest.approx((0.0, 0.7, 0.9))
-    assert viz._colormap(2.0 / 3.0) == pytest.approx((1.0, 0.95, 0.2))
+    assert viz._colormap(1.0/3.0) == pytest.approx((0.0, 0.7, 0.9))
+    assert viz._colormap(2.0/3.0) == pytest.approx((1.0, 0.95, 0.2))
 
 
 def test_colormap_is_continuous():
     prev = viz._colormap(0.0)
     for i in range(1, 101):
-        cur = viz._colormap(i / 100.0)
+        cur = viz._colormap(i/100.0)
         assert all(abs(a - b) < 0.05 for a, b in zip(prev, cur))
         prev = cur
 
@@ -124,11 +92,14 @@ def test_rpy_to_quat():
     assert (q.w, q.x, q.y, q.z) == pytest.approx((1.0, 0.0, 0.0, 0.0))
     q = viz._rpy_to_quat(0.0, 0.0, math.pi)
     assert (q.w, q.x, q.y, q.z) == pytest.approx((0.0, 0.0, 0.0, 1.0), abs=1e-9)
-    q = viz._rpy_to_quat(math.pi / 2, 0.0, 0.0)
+    q = viz._rpy_to_quat(math.pi/2, 0.0, 0.0)
     assert (q.w, q.x, q.y, q.z) == pytest.approx(
-        (math.cos(math.pi / 4), math.sin(math.pi / 4), 0.0, 0.0)
-    )
+        (math.cos(math.pi/4), math.sin(math.pi/4), 0.0, 0.0))
+    # General-case golden (ZYX composition), pinned so a future swap to a
+    # library helper cannot silently change convention.
     q = viz._rpy_to_quat(0.3, -0.7, 1.1)
+    assert (q.w, q.x, q.y, q.z) == pytest.approx(
+        (0.765062179348, 0.296891540058, -0.215672410090, 0.529169808944))
     assert q.w**2 + q.x**2 + q.y**2 + q.z**2 == pytest.approx(1.0)
 
 
@@ -146,18 +117,18 @@ def test_baseline_subtraction_and_noise_floor():
     node = make_node(baseline_frames=2, noise_floor=50.0, vmin=0.0, vmax=700.0)
     try:
         node._on_data(make_msg(1000))
-        node._on_data(make_msg(1000))  # baseline = 1000 captured
+        node._on_data(make_msg(1000))          # baseline = 1000 captured
 
-        node._on_data(make_msg(1049))  # residual 49 < floor -> zero
+        node._on_data(make_msg(1049))          # residual 49 < floor -> zero
         for finger in marker_values(node):
             assert all(c == pytest.approx(NAVY) for c in finger)
 
-        node._on_data(make_msg(1050))  # residual 50 == floor -> kept
-        expected = viz._colormap(50.0 / 700.0)
+        node._on_data(make_msg(1050))          # residual 50 == floor -> kept
+        expected = viz._colormap(50.0/700.0)
         for finger in marker_values(node):
             assert all(c == pytest.approx(expected) for c in finger)
 
-        node._on_data(make_msg(500))  # below baseline -> clamped to 0
+        node._on_data(make_msg(500))           # below baseline -> clamped to 0
         for finger in marker_values(node):
             assert all(c == pytest.approx(NAVY) for c in finger)
     finally:
@@ -167,13 +138,13 @@ def test_baseline_subtraction_and_noise_floor():
 def test_rezero_recaptures_baseline():
     node = make_node(baseline_frames=1, noise_floor=0.0)
     try:
-        node._on_data(make_msg(100))  # baseline = 100
-        node._on_data(make_msg(300))  # residual 200
+        node._on_data(make_msg(100))           # baseline = 100
+        node._on_data(make_msg(300))           # residual 200
         assert marker_values(node)[0][0] != pytest.approx(NAVY)
 
         node._on_zero(None)
-        node._on_data(make_msg(300))  # new baseline = 300, shows zeros
-        node._on_data(make_msg(300))  # residual 0
+        node._on_data(make_msg(300))           # new baseline = 300, shows zeros
+        node._on_data(make_msg(300))           # residual 0
         for finger in marker_values(node):
             assert all(c == pytest.approx(NAVY) for c in finger)
     finally:
@@ -195,13 +166,13 @@ def test_marker_geometry_and_ids():
     try:
         node._on_data(make_msg(0))
         array = node._marker_pub.msgs[-1]
-        f0 = [m for m in array.markers if m.ns == "tactile_finger_0"]
+        f0 = [m for m in array.markers if m.ns == 'tactile_finger_0']
         assert sorted(m.id for m in f0) == list(range(TAXELS))
-        assert all(m.header.frame_id == "tactile_finger_0" for m in f0)
-        pitch_y, pitch_z = 0.022 / 4, 0.037 / 7
-        y_half = (COLS - 1) * 0.5 * pitch_y
-        z_half = (ROWS - 1) * 0.5 * pitch_z
-        top_left = next(m for m in f0 if m.id == 0)  # r=0, c=0
+        assert all(m.header.frame_id == 'tactile_finger_0' for m in f0)
+        pitch_y, pitch_z = 0.022/4, 0.037/7
+        y_half = (COLS - 1)*0.5*pitch_y
+        z_half = (ROWS - 1)*0.5*pitch_z
+        top_left = next(m for m in f0 if m.id == 0)          # r=0, c=0
         assert top_left.pose.position.y == pytest.approx(y_half)
         assert top_left.pose.position.z == pytest.approx(z_half)
         bottom_right = next(m for m in f0 if m.id == TAXELS - 1)
@@ -212,73 +183,64 @@ def test_marker_geometry_and_ids():
 
 
 def test_flip_finger_1_reverses_columns():
-    ramp = list(range(TAXELS))  # distinct value per taxel
+    ramp = list(range(TAXELS))                 # distinct value per taxel
     node = make_node(zero_on_start=False, flip_finger_1=True, noise_floor=0.0)
     try:
         node._on_data(make_msg(ramp, ramp))
         array = node._marker_pub.msgs[-1]
-        by_id = {m.id: m for m in array.markers if m.ns == "tactile_finger_1"}
-        ref = {m.id: m for m in array.markers if m.ns == "tactile_finger_0"}
+        by_id = {m.id: m for m in array.markers if m.ns == 'tactile_finger_1'}
+        ref = {m.id: m for m in array.markers if m.ns == 'tactile_finger_0'}
         for r in range(ROWS):
             for c in range(COLS):
-                flipped = by_id[r * COLS + c].color
-                straight = ref[r * COLS + (COLS - 1 - c)].color
+                flipped = by_id[r*COLS + c].color
+                straight = ref[r*COLS + (COLS - 1 - c)].color
                 assert (flipped.r, flipped.g, flipped.b) == pytest.approx(
-                    (straight.r, straight.g, straight.b)
-                )
+                    (straight.r, straight.g, straight.b))
     finally:
         node.destroy_node()
 
 
 def test_heatmap_image_shape_and_scaling():
-    node = make_node(
-        zero_on_start=False,
-        heatmap_scale_px=10,
-        heatmap_publish_hz=0.0,
-        heatmap_floor=0.0,
-    )
+    node = make_node(zero_on_start=False, heatmap_scale_px=10,
+                     heatmap_publish_hz=0.0, heatmap_floor=0.0)
     try:
         node._on_data(make_msg(100))
         for pub in node._heatmap_pubs:
             img = pub.msgs[-1]
-            assert (img.height, img.width) == (ROWS * 10, COLS * 10)
-            assert img.encoding == "rgb8"
-            assert img.step == img.width * 3
-            assert len(img.data) == img.height * img.step
+            assert (img.height, img.width) == (ROWS*10, COLS*10)
+            assert img.encoding == 'rgb8'
+            assert img.step == img.width*3
+            assert len(img.data) == img.height*img.step
     finally:
         node.destroy_node()
 
 
 def test_heatmap_autoscale_tracks_running_max():
-    node = make_node(
-        zero_on_start=False,
-        heatmap_scale_px=1,
-        heatmap_publish_hz=0.0,
-        heatmap_floor=0.0,
-        heatmap_autoscale=True,
-    )
-
+    node = make_node(zero_on_start=False, heatmap_scale_px=1,
+                     heatmap_publish_hz=0.0, heatmap_floor=0.0,
+                     heatmap_autoscale=True)
     def px(t):
-        return bytes(round(v * 255) for v in viz._colormap(t))
+        return bytes(round(v*255) for v in viz._colormap(t))
 
     try:
-        node._on_data(make_msg(200))  # max: 200 -> full scale
+        node._on_data(make_msg(200))           # max: 200 -> full scale
         assert bytes(node._heatmap_pubs[0].msgs[-1].data[0:3]) == px(1.0)
 
-        node._on_data(make_msg(400))  # new max: 400, still full scale
+        node._on_data(make_msg(400))           # new max: 400, still full scale
         assert bytes(node._heatmap_pubs[0].msgs[-1].data[0:3]) == px(1.0)
 
-        node._on_data(make_msg(200))  # now mid-scale vs max 400
+        node._on_data(make_msg(200))           # now mid-scale vs max 400
         assert bytes(node._heatmap_pubs[0].msgs[-1].data[0:3]) == px(0.5)
     finally:
         node.destroy_node()
 
 
 def test_heatmap_rate_limit():
-    node = make_node(zero_on_start=False, heatmap_publish_hz=1.0, heatmap_scale_px=1)
+    node = make_node(zero_on_start=False, heatmap_publish_hz=1.0,
+                     heatmap_scale_px=1)
     try:
         node._on_data(make_msg(100))
-        node._on_data(make_msg(100))  # within 1s window -> throttled
+        node._on_data(make_msg(100))           # within 1s window -> throttled
         assert len(node._heatmap_pubs[0].msgs) == 1
         assert len(node._marker_pub.msgs) == 2  # markers are never throttled
     finally:
@@ -300,7 +262,7 @@ def test_wrong_taxel_count_is_dropped():
     # guard with a duck-typed message (e.g. a future variable-length source).
     class FakeTaxels:
         def __init__(self, n):
-            self.values = [0] * n
+            self.values = [0]*n
 
     class FakeMsg:
         def __init__(self):
@@ -309,7 +271,7 @@ def test_wrong_taxel_count_is_dropped():
     node = make_node(zero_on_start=False)
     try:
         node._on_data(FakeMsg())
-        assert node._marker_pub.msgs == []  # dropped, nothing published
+        assert node._marker_pub.msgs == []     # dropped, nothing published
     finally:
         node.destroy_node()
 
@@ -328,20 +290,15 @@ def test_publish_static_tfs():
         node._tf_broadcaster = bc
         node._publish_static_tfs()
         assert [t.child_frame_id for t in bc.transforms] == [
-            "tactile_finger_0",
-            "tactile_finger_1",
-            "tactile_tip",
-        ]
-        assert all(t.header.frame_id == "tactile_world" for t in bc.transforms)
+            'tactile_finger_0', 'tactile_finger_1', 'tactile_tip']
+        assert all(t.header.frame_id == 'tactile_world' for t in bc.transforms)
         f0, f1, tip = bc.transforms
         assert f0.transform.translation.x == pytest.approx(-0.0425)
         assert f1.transform.translation.x == pytest.approx(0.0425)
         assert tip.transform.translation.z == pytest.approx(0.0209)
         assert f0.transform.rotation.w == pytest.approx(1.0)
-        q = f1.transform.rotation  # finger 1 yawed pi to face finger 0
-        assert (q.w, q.x, q.y, abs(q.z)) == pytest.approx(
-            (0.0, 0.0, 0.0, 1.0), abs=1e-9
-        )
+        q = f1.transform.rotation                # finger 1 yawed pi to face finger 0
+        assert (q.w, q.x, q.y, abs(q.z)) == pytest.approx((0.0, 0.0, 0.0, 1.0), abs=1e-9)
     finally:
         node.destroy_node()
 
@@ -350,28 +307,22 @@ def test_heatmap_pixel_orientation():
     # Ramp value = r*COLS + c: every pixel unique, pinning the image's
     # row/column orientation, not just pixel (0,0).
     ramp = list(range(TAXELS))
-    node = make_node(
-        zero_on_start=False,
-        heatmap_scale_px=1,
-        heatmap_publish_hz=0.0,
-        heatmap_autoscale=False,
-        vmin=0.0,
-        vmax=float(TAXELS - 1),
-        noise_floor=0.0,
-    )
+    node = make_node(zero_on_start=False, heatmap_scale_px=1,
+                     heatmap_publish_hz=0.0, heatmap_autoscale=False,
+                     vmin=0.0, vmax=float(TAXELS - 1), noise_floor=0.0)
     try:
         node._on_data(make_msg(ramp, ramp))
         img = node._heatmap_pubs[0].msgs[-1]
 
         def px(r, c):
-            o = (r * img.width + c) * 3
-            return bytes(img.data[o : o + 3])
+            o = (r*img.width + c)*3
+            return bytes(img.data[o:o + 3])
 
         def expected(r, c):
-            t = (r * COLS + c) / (TAXELS - 1)
-            return bytes(round(v * 255) for v in viz._colormap(t))
+            t = (r*COLS + c)/(TAXELS - 1)
+            return bytes(round(v*255) for v in viz._colormap(t))
 
         for r, c in [(0, 0), (0, 3), (2, 1), (4, 3), (6, 0), (6, 3)]:
-            assert px(r, c) == expected(r, c), f"pixel ({r},{c})"
+            assert px(r, c) == expected(r, c), f'pixel ({r},{c})'
     finally:
         node.destroy_node()


### PR DESCRIPTION
## What

Migrates the AHRS/fusion code from hand-rolled quaternion and vector math to Eigen, with the numerics regression-pinned by tests recorded before the conversion.

- **test**: pre-migration hardening — Hamilton-convention component pinning, gimbal-lock clamp, combined roll+pitch init, golden-trajectory quaternion checkpoints, rpy→quat golden (Python viz).
- **chore**: delete dead `MahonyAHRS.{h,cpp}` (never built).
- **refactor**: `MadgwickFilter` state becomes `Eigen::Quaternionf`; gyro derivative, integration, normalization, and `initFromAccel` use Eigen. The Madgwick gradient-descent step stays as the reference scalar expansion. Free helpers `quatMul`/`quatConj`/`quatNormalize`/`quatFromAxis*` deleted (Eigen covers them); `quatToEulerRad/Deg` kept as thin helpers — Eigen's `eulerAngles(2,1,0)` constrains its first angle to `[0, π]`, which doesn't match the published aerospace ±180° ZYX convention.
- **refactor**: `fusion.hpp` and the poller vectorized with `Eigen::Vector3f`; the duplicated finger-0/finger-1 fusion blocks collapse into one `FINGER_COUNT` loop; new reusable `test/eigen_test_utils.hpp` (`expectEigenFloatEq`).

## Numeric parity

- Golden-trajectory checkpoints (recorded from the pre-Eigen implementation) pass unmodified at 1e-5 tolerance; accel normalization deliberately keeps reciprocal-multiply to match the reference rounding (plain division drifted the trajectory by ~1e-4).
- `initFromAccel` keeps the original norm-vs-eps degenerate-input guard.

## Testing

- 61/61 unit tests green on a clean from-scratch Release build.
- Hardware check (TSF-85): both orientation topics publish after bias calibration; quaternions unit-norm to 1e-6; Euler/quaternion self-consistent on both fingers; stationary drift over 5 s ~1.3°/0.6° (normal gyro-only yaw drift).
FYI @jkski-robotiq 