### PR TITLE
build(robotiq_tsf): enforce clang-format (monorepo style)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# Revisions to ignore in `git blame` — bulk, mechanical reformatting commits
+# with no functional change. GitHub honors this file automatically; locally run:
+#
+#     git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# robotiq_tsf: clang-format the whole package to the new .clang-format
+fb691c20c2ad272e26125e39be736bba64d8939e

--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -1,25 +1,27 @@
-# pre-commit (black, flake8, codespell, clang-format, whitespace/eol hooks)
-# over the vendored gripper tree, using grippers/.pre-commit-config.yaml.
+# pre-commit formatting checks, one job per package that carries its own config.
 #
-# Scoping: this repo is multi-package, but only grippers/ carries a pre-commit
-# config, so we restrict the run to grippers/** files. pre-commit runs hooks
-# from the git root, so flake8 wouldn't find grippers/.flake8 on its own — we
-# place it at the root for the run (clang-format finds grippers/.clang-format
-# by walking up per-file, so it needs no such help).
-name: Format (grippers)
+# - grippers/: black, flake8, codespell, clang-format, whitespace/eol hooks over
+#   the vendored gripper tree, using grippers/.pre-commit-config.yaml. pre-commit
+#   runs hooks from the git root, so flake8 wouldn't find grippers/.flake8 on its
+#   own — we place it at the root for the run (clang-format finds
+#   grippers/.clang-format by walking up per-file, so it needs no such help).
+# - robotiq_tsf/: clang-format only, using robotiq_tsf/.pre-commit-config.yaml
+#   (clang-format walks up to robotiq_tsf/.clang-format per-file).
+name: Format
 
 on:
   pull_request:
     paths:
       - "grippers/**"
+      - "robotiq_tsf/**"
       - ".github/workflows/ci-format.yml"
   push:
     branches: [main]
   workflow_dispatch:
 
 jobs:
-  pre-commit:
-    name: Format
+  grippers:
+    name: Format (grippers)
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
@@ -36,5 +38,25 @@ jobs:
           mapfile -t files < <(git ls-files grippers)
           pre-commit run \
             --config grippers/.pre-commit-config.yaml \
+            --files "${files[@]}" \
+            --show-diff-on-failure
+
+  robotiq_tsf:
+    name: Format (robotiq_tsf)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Run clang-format on robotiq_tsf/
+        run: |
+          python -m pip install --upgrade pre-commit
+          # Restrict to tracked files under robotiq_tsf/ (paths are relative to
+          # the git root, which is where pre-commit runs hooks from). The hook's
+          # own `files:` filter narrows this to C/C++ sources.
+          mapfile -t files < <(git ls-files robotiq_tsf)
+          pre-commit run \
+            --config robotiq_tsf/.pre-commit-config.yaml \
             --files "${files[@]}" \
             --show-diff-on-failure

--- a/robotiq_tsf/.clang-format
+++ b/robotiq_tsf/.clang-format
@@ -1,0 +1,74 @@
+---
+BasedOnStyle: Google
+ColumnLimit: 120
+MaxEmptyLinesToKeep: 1
+SortIncludes: false
+
+Standard: Auto
+IndentWidth: 2
+TabWidth: 2
+UseTab: Never
+AccessModifierOffset: -2
+ConstructorInitializerIndentWidth: 2
+NamespaceIndentation: None
+ContinuationIndentWidth: 4
+IndentCaseLabels: true
+IndentFunctionDeclarationAfterType: false
+
+AlignEscapedNewlinesLeft: false
+AlignTrailingComments: true
+
+AllowAllParametersOfDeclarationOnNextLine: false
+ExperimentalAutoDetectBinPacking: false
+ObjCSpaceBeforeProtocolList: true
+Cpp11BracedListStyle: false
+
+AllowShortBlocksOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortCaseLabelsOnASingleLine: false
+
+AlwaysBreakTemplateDeclarations: true
+AlwaysBreakBeforeMultilineStrings: false
+BreakBeforeBinaryOperators: false
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: true
+
+BinPackParameters: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+DerivePointerBinding: false
+PointerBindsToType: true
+
+PenaltyExcessCharacter: 50
+PenaltyBreakBeforeFirstCallParameter: 30
+PenaltyBreakComment: 1000
+PenaltyBreakFirstLessLess: 10
+PenaltyBreakString: 100
+PenaltyReturnTypeOnItsOwnLine: 50
+
+SpacesBeforeTrailingComments: 2
+SpacesInParentheses: false
+SpacesInAngles: false
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpaceAfterCStyleCast: false
+SpaceAfterControlStatementKeyword: true
+SpaceBeforeAssignmentOperators: true
+
+# Configure each individual brace in BraceWrapping
+BreakBeforeBraces: Custom
+
+# Control of individual brace wrapping cases
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: true
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterUnion: true
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false

--- a/robotiq_tsf/.pre-commit-config.yaml
+++ b/robotiq_tsf/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+# clang-format enforcement for the robotiq_tsf package.
+#
+# Mirrors grippers/.pre-commit-config.yaml but scoped to C/C++ formatting only.
+# clang-format walks up per-file and picks up robotiq_tsf/.clang-format (a copy
+# of the monorepo/grippers Google-based style). Pinned to v19 to match the
+# clang-format-19 mandated by the Robotiq C++ conventions.
+#
+# To use locally:
+#
+#     pre-commit run --config robotiq_tsf/.pre-commit-config.yaml -a
+#
+repos:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v19.1.1
+    hooks:
+      - id: clang-format
+        files: ^robotiq_tsf/.*\.(c|cc|cxx|cpp|h|hpp|hxx|ipp)$
+        # -i arg is included by default by the hook
+        args: ["-fallback-style=none"]

--- a/robotiq_tsf/include/robotiq_tsf/MadgwickAHRS.h
+++ b/robotiq_tsf/include/robotiq_tsf/MadgwickAHRS.h
@@ -10,33 +10,32 @@
 #ifndef ROBOTIQ_TSF_MADGWICK_AHRS_H
 #define ROBOTIQ_TSF_MADGWICK_AHRS_H
 
-class MadgwickFilter {
+class MadgwickFilter
+{
 public:
-    explicit MadgwickFilter(float beta = 0.041f);
+  explicit MadgwickFilter(float beta = 0.041f);
 
-    void reset();
-    void setBeta(float beta);
-    void setAccelGate(float lo, float hi);
+  void reset();
+  void setBeta(float beta);
+  void setAccelGate(float lo, float hi);
 
-    // Seed the quaternion so the gravity vector in the body frame matches the
-    // supplied accelerometer reading (any units; only the direction is used).
-    // Yaw is set to zero. Use the calibration-time accel mean.
-    void initFromAccel(float ax, float ay, float az);
+  // Seed the quaternion so the gravity vector in the body frame matches the
+  // supplied accelerometer reading (any units; only the direction is used).
+  // Yaw is set to zero. Use the calibration-time accel mean.
+  void initFromAccel(float ax, float ay, float az);
 
-    // gyro in rad/s, accel in any consistent unit (normalised internally),
-    // dt in seconds (use the measured interval between samples).
-    void updateIMU(float gx, float gy, float gz,
-                   float ax, float ay, float az,
-                   float dt);
+  // gyro in rad/s, accel in any consistent unit (normalised internally),
+  // dt in seconds (use the measured interval between samples).
+  void updateIMU(float gx, float gy, float gz, float ax, float ay, float az, float dt);
 
-    void getQuaternion(float &q0, float &q1, float &q2, float &q3) const;
-    void getEulerDeg(float &roll, float &pitch, float &yaw) const;
+  void getQuaternion(float& q0, float& q1, float& q2, float& q3) const;
+  void getEulerDeg(float& roll, float& pitch, float& yaw) const;
 
 private:
-    float q0_, q1_, q2_, q3_;
-    float beta_;
-    float accel_gate_lo_;   // expected |a| ≈ 1.0 g when stationary
-    float accel_gate_hi_;
+  float q0_, q1_, q2_, q3_;
+  float beta_;
+  float accel_gate_lo_;  // expected |a| ≈ 1.0 g when stationary
+  float accel_gate_hi_;
 };
 
 // --- quaternion-math helpers (free functions) ---------------------------------
@@ -51,7 +50,7 @@ void quatNormalize(float q[4]);
 void quatFromAxisX(float angle_rad, float out[4]);
 void quatFromAxisY(float angle_rad, float out[4]);
 void quatFromAxisZ(float angle_rad, float out[4]);
-void quatToEulerDeg(const float q[4], float &roll, float &pitch, float &yaw);
-void quatToEulerRad(const float q[4], float &roll, float &pitch, float &yaw);
+void quatToEulerDeg(const float q[4], float& roll, float& pitch, float& yaw);
+void quatToEulerRad(const float q[4], float& roll, float& pitch, float& yaw);
 
-#endif // ROBOTIQ_TSF_MADGWICK_AHRS_H
+#endif  // ROBOTIQ_TSF_MADGWICK_AHRS_H

--- a/robotiq_tsf/include/robotiq_tsf/MahonyAHRS.h
+++ b/robotiq_tsf/include/robotiq_tsf/MahonyAHRS.h
@@ -16,9 +16,9 @@
 //----------------------------------------------------------------------------------------------------
 // Variable declaration
 
-extern volatile float twoKp;			// 2 * proportional gain (Kp)
-extern volatile float twoKi;			// 2 * integral gain (Ki)
-extern volatile float q0, q1, q2, q3;	// quaternion of sensor frame relative to auxiliary frame
+extern volatile float twoKp;           // 2 * proportional gain (Kp)
+extern volatile float twoKi;           // 2 * integral gain (Ki)
+extern volatile float q0, q1, q2, q3;  // quaternion of sensor frame relative to auxiliary frame
 
 //---------------------------------------------------------------------------------------------------
 // Function declarations

--- a/robotiq_tsf/src/MadgwickAHRS.cpp
+++ b/robotiq_tsf/src/MadgwickAHRS.cpp
@@ -16,216 +16,233 @@
 
 #include <cmath>
 
-namespace {
+namespace
+{
 constexpr float kEpsNorm = 1e-12f;
 
-inline float safeRecipSqrt(float x) {
-    if (x <= kEpsNorm) return 0.0f;
-    return 1.0f / std::sqrt(x);
+inline float safeRecipSqrt(float x)
+{
+  if (x <= kEpsNorm)
+    return 0.0f;
+  return 1.0f / std::sqrt(x);
 }
 }  // namespace
 
 MadgwickFilter::MadgwickFilter(float beta)
-    : q0_(1.0f), q1_(0.0f), q2_(0.0f), q3_(0.0f),
-      beta_(beta),
-      accel_gate_lo_(0.85f),
-      accel_gate_hi_(1.15f) {}
-
-void MadgwickFilter::reset() {
-    q0_ = 1.0f;
-    q1_ = 0.0f;
-    q2_ = 0.0f;
-    q3_ = 0.0f;
+  : q0_(1.0f), q1_(0.0f), q2_(0.0f), q3_(0.0f), beta_(beta), accel_gate_lo_(0.85f), accel_gate_hi_(1.15f)
+{
 }
 
-void MadgwickFilter::setBeta(float beta) { beta_ = beta; }
-
-void MadgwickFilter::setAccelGate(float lo, float hi) {
-    accel_gate_lo_ = lo;
-    accel_gate_hi_ = hi;
+void MadgwickFilter::reset()
+{
+  q0_ = 1.0f;
+  q1_ = 0.0f;
+  q2_ = 0.0f;
+  q3_ = 0.0f;
 }
 
-void MadgwickFilter::initFromAccel(float ax, float ay, float az) {
-    // Normalise the accelerometer reading to get the gravity direction in body
-    // frame. Build the quaternion that rotates body gravity onto world +Z, with
-    // yaw fixed at zero (no magnetometer reference available).
-    const float norm = std::sqrt(ax * ax + ay * ay + az * az);
-    if (norm <= kEpsNorm) {
-        reset();
-        return;
+void MadgwickFilter::setBeta(float beta)
+{
+  beta_ = beta;
+}
+
+void MadgwickFilter::setAccelGate(float lo, float hi)
+{
+  accel_gate_lo_ = lo;
+  accel_gate_hi_ = hi;
+}
+
+void MadgwickFilter::initFromAccel(float ax, float ay, float az)
+{
+  // Normalise the accelerometer reading to get the gravity direction in body
+  // frame. Build the quaternion that rotates body gravity onto world +Z, with
+  // yaw fixed at zero (no magnetometer reference available).
+  const float norm = std::sqrt(ax * ax + ay * ay + az * az);
+  if (norm <= kEpsNorm)
+  {
+    reset();
+    return;
+  }
+  const float gx = ax / norm;
+  const float gy = ay / norm;
+  const float gz = az / norm;
+
+  // Tait-Bryan: with gravity = (-sin(pitch), sin(roll)*cos(pitch), cos(roll)*cos(pitch))
+  // in body frame for ZYX rotation from world (assuming world gravity = +Z).
+  const float roll = std::atan2(gy, gz);
+  const float pitch = std::atan2(-gx, std::sqrt(gy * gy + gz * gz));
+  const float yaw = 0.0f;
+
+  const float cr = std::cos(roll * 0.5f);
+  const float sr = std::sin(roll * 0.5f);
+  const float cp = std::cos(pitch * 0.5f);
+  const float sp = std::sin(pitch * 0.5f);
+  const float cy = std::cos(yaw * 0.5f);
+  const float sy = std::sin(yaw * 0.5f);
+
+  // ZYX composition: q = qz * qy * qx
+  q0_ = cr * cp * cy + sr * sp * sy;
+  q1_ = sr * cp * cy - cr * sp * sy;
+  q2_ = cr * sp * cy + sr * cp * sy;
+  q3_ = cr * cp * sy - sr * sp * cy;
+}
+
+void MadgwickFilter::updateIMU(float gx, float gy, float gz, float ax, float ay, float az, float dt)
+{
+  if (dt <= 0.0f)
+    return;
+
+  // Rate of change of quaternion from gyroscope.
+  float qDot1 = 0.5f * (-q1_ * gx - q2_ * gy - q3_ * gz);
+  float qDot2 = 0.5f * (q0_ * gx + q2_ * gz - q3_ * gy);
+  float qDot3 = 0.5f * (q0_ * gy - q1_ * gz + q3_ * gx);
+  float qDot4 = 0.5f * (q0_ * gz + q1_ * gy - q2_ * gx);
+
+  const float accelNormSq = ax * ax + ay * ay + az * az;
+  if (accelNormSq > kEpsNorm)
+  {
+    const float accelNorm = std::sqrt(accelNormSq);
+    // Only trust accel as a gravity reference when its magnitude is close
+    // to 1 g; outside this band the sensor is in non-gravity motion and
+    // the gradient step would corrupt the estimate.
+    if (accelNorm > accel_gate_lo_ && accelNorm < accel_gate_hi_)
+    {
+      const float recipNorm = 1.0f / accelNorm;
+      ax *= recipNorm;
+      ay *= recipNorm;
+      az *= recipNorm;
+
+      const float _2q0 = 2.0f * q0_;
+      const float _2q1 = 2.0f * q1_;
+      const float _2q2 = 2.0f * q2_;
+      const float _2q3 = 2.0f * q3_;
+      const float _4q0 = 4.0f * q0_;
+      const float _4q1 = 4.0f * q1_;
+      const float _4q2 = 4.0f * q2_;
+      const float _8q1 = 8.0f * q1_;
+      const float _8q2 = 8.0f * q2_;
+      const float q0q0 = q0_ * q0_;
+      const float q1q1 = q1_ * q1_;
+      const float q2q2 = q2_ * q2_;
+      const float q3q3 = q3_ * q3_;
+
+      float s0 = _4q0 * q2q2 + _2q2 * ax + _4q0 * q1q1 - _2q1 * ay;
+      float s1 = _4q1 * q3q3 - _2q3 * ax + 4.0f * q0q0 * q1_ - _2q0 * ay - _4q1 + _8q1 * q1q1 + _8q1 * q2q2 + _4q1 * az;
+      float s2 = 4.0f * q0q0 * q2_ + _2q0 * ax + _4q2 * q3q3 - _2q3 * ay - _4q2 + _8q2 * q1q1 + _8q2 * q2q2 + _4q2 * az;
+      float s3 = 4.0f * q1q1 * q3_ - _2q1 * ax + 4.0f * q2q2 * q3_ - _2q2 * ay;
+      const float recipStep = safeRecipSqrt(s0 * s0 + s1 * s1 + s2 * s2 + s3 * s3);
+      s0 *= recipStep;
+      s1 *= recipStep;
+      s2 *= recipStep;
+      s3 *= recipStep;
+
+      qDot1 -= beta_ * s0;
+      qDot2 -= beta_ * s1;
+      qDot3 -= beta_ * s2;
+      qDot4 -= beta_ * s3;
     }
-    const float gx = ax / norm;
-    const float gy = ay / norm;
-    const float gz = az / norm;
+  }
 
-    // Tait-Bryan: with gravity = (-sin(pitch), sin(roll)*cos(pitch), cos(roll)*cos(pitch))
-    // in body frame for ZYX rotation from world (assuming world gravity = +Z).
-    const float roll = std::atan2(gy, gz);
-    const float pitch = std::atan2(-gx, std::sqrt(gy * gy + gz * gz));
-    const float yaw = 0.0f;
+  q0_ += qDot1 * dt;
+  q1_ += qDot2 * dt;
+  q2_ += qDot3 * dt;
+  q3_ += qDot4 * dt;
 
-    const float cr = std::cos(roll * 0.5f);
-    const float sr = std::sin(roll * 0.5f);
-    const float cp = std::cos(pitch * 0.5f);
-    const float sp = std::sin(pitch * 0.5f);
-    const float cy = std::cos(yaw * 0.5f);
-    const float sy = std::sin(yaw * 0.5f);
-
-    // ZYX composition: q = qz * qy * qx
-    q0_ = cr * cp * cy + sr * sp * sy;
-    q1_ = sr * cp * cy - cr * sp * sy;
-    q2_ = cr * sp * cy + sr * cp * sy;
-    q3_ = cr * cp * sy - sr * sp * cy;
+  const float recipQ = safeRecipSqrt(q0_ * q0_ + q1_ * q1_ + q2_ * q2_ + q3_ * q3_);
+  q0_ *= recipQ;
+  q1_ *= recipQ;
+  q2_ *= recipQ;
+  q3_ *= recipQ;
 }
 
-void MadgwickFilter::updateIMU(float gx, float gy, float gz,
-                               float ax, float ay, float az,
-                               float dt) {
-    if (dt <= 0.0f) return;
-
-    // Rate of change of quaternion from gyroscope.
-    float qDot1 = 0.5f * (-q1_ * gx - q2_ * gy - q3_ * gz);
-    float qDot2 = 0.5f * ( q0_ * gx + q2_ * gz - q3_ * gy);
-    float qDot3 = 0.5f * ( q0_ * gy - q1_ * gz + q3_ * gx);
-    float qDot4 = 0.5f * ( q0_ * gz + q1_ * gy - q2_ * gx);
-
-    const float accelNormSq = ax * ax + ay * ay + az * az;
-    if (accelNormSq > kEpsNorm) {
-        const float accelNorm = std::sqrt(accelNormSq);
-        // Only trust accel as a gravity reference when its magnitude is close
-        // to 1 g; outside this band the sensor is in non-gravity motion and
-        // the gradient step would corrupt the estimate.
-        if (accelNorm > accel_gate_lo_ && accelNorm < accel_gate_hi_) {
-            const float recipNorm = 1.0f / accelNorm;
-            ax *= recipNorm;
-            ay *= recipNorm;
-            az *= recipNorm;
-
-            const float _2q0 = 2.0f * q0_;
-            const float _2q1 = 2.0f * q1_;
-            const float _2q2 = 2.0f * q2_;
-            const float _2q3 = 2.0f * q3_;
-            const float _4q0 = 4.0f * q0_;
-            const float _4q1 = 4.0f * q1_;
-            const float _4q2 = 4.0f * q2_;
-            const float _8q1 = 8.0f * q1_;
-            const float _8q2 = 8.0f * q2_;
-            const float q0q0 = q0_ * q0_;
-            const float q1q1 = q1_ * q1_;
-            const float q2q2 = q2_ * q2_;
-            const float q3q3 = q3_ * q3_;
-
-            float s0 = _4q0 * q2q2 + _2q2 * ax + _4q0 * q1q1 - _2q1 * ay;
-            float s1 = _4q1 * q3q3 - _2q3 * ax + 4.0f * q0q0 * q1_ - _2q0 * ay
-                       - _4q1 + _8q1 * q1q1 + _8q1 * q2q2 + _4q1 * az;
-            float s2 = 4.0f * q0q0 * q2_ + _2q0 * ax + _4q2 * q3q3 - _2q3 * ay
-                       - _4q2 + _8q2 * q1q1 + _8q2 * q2q2 + _4q2 * az;
-            float s3 = 4.0f * q1q1 * q3_ - _2q1 * ax + 4.0f * q2q2 * q3_ - _2q2 * ay;
-            const float recipStep = safeRecipSqrt(s0 * s0 + s1 * s1 + s2 * s2 + s3 * s3);
-            s0 *= recipStep;
-            s1 *= recipStep;
-            s2 *= recipStep;
-            s3 *= recipStep;
-
-            qDot1 -= beta_ * s0;
-            qDot2 -= beta_ * s1;
-            qDot3 -= beta_ * s2;
-            qDot4 -= beta_ * s3;
-        }
-    }
-
-    q0_ += qDot1 * dt;
-    q1_ += qDot2 * dt;
-    q2_ += qDot3 * dt;
-    q3_ += qDot4 * dt;
-
-    const float recipQ = safeRecipSqrt(q0_ * q0_ + q1_ * q1_ + q2_ * q2_ + q3_ * q3_);
-    q0_ *= recipQ;
-    q1_ *= recipQ;
-    q2_ *= recipQ;
-    q3_ *= recipQ;
+void MadgwickFilter::getQuaternion(float& q0, float& q1, float& q2, float& q3) const
+{
+  q0 = q0_;
+  q1 = q1_;
+  q2 = q2_;
+  q3 = q3_;
 }
 
-void MadgwickFilter::getQuaternion(float &q0, float &q1, float &q2, float &q3) const {
-    q0 = q0_;
-    q1 = q1_;
-    q2 = q2_;
-    q3 = q3_;
-}
-
-void MadgwickFilter::getEulerDeg(float &roll, float &pitch, float &yaw) const {
-    const float q[4] = {q0_, q1_, q2_, q3_};
-    quatToEulerDeg(q, roll, pitch, yaw);
+void MadgwickFilter::getEulerDeg(float& roll, float& pitch, float& yaw) const
+{
+  const float q[4] = { q0_, q1_, q2_, q3_ };
+  quatToEulerDeg(q, roll, pitch, yaw);
 }
 
 // --- free helpers --------------------------------------------------------------
 
-void quatMul(const float a[4], const float b[4], float out[4]) {
-    // Hamilton product. out = a ⊗ b. Local temporaries so out may alias a or b.
-    const float w = a[0] * b[0] - a[1] * b[1] - a[2] * b[2] - a[3] * b[3];
-    const float x = a[0] * b[1] + a[1] * b[0] + a[2] * b[3] - a[3] * b[2];
-    const float y = a[0] * b[2] - a[1] * b[3] + a[2] * b[0] + a[3] * b[1];
-    const float z = a[0] * b[3] + a[1] * b[2] - a[2] * b[1] + a[3] * b[0];
-    out[0] = w;
-    out[1] = x;
-    out[2] = y;
-    out[3] = z;
+void quatMul(const float a[4], const float b[4], float out[4])
+{
+  // Hamilton product. out = a ⊗ b. Local temporaries so out may alias a or b.
+  const float w = a[0] * b[0] - a[1] * b[1] - a[2] * b[2] - a[3] * b[3];
+  const float x = a[0] * b[1] + a[1] * b[0] + a[2] * b[3] - a[3] * b[2];
+  const float y = a[0] * b[2] - a[1] * b[3] + a[2] * b[0] + a[3] * b[1];
+  const float z = a[0] * b[3] + a[1] * b[2] - a[2] * b[1] + a[3] * b[0];
+  out[0] = w;
+  out[1] = x;
+  out[2] = y;
+  out[3] = z;
 }
 
-void quatConj(const float q[4], float out[4]) {
-    out[0] =  q[0];
-    out[1] = -q[1];
-    out[2] = -q[2];
-    out[3] = -q[3];
+void quatConj(const float q[4], float out[4])
+{
+  out[0] = q[0];
+  out[1] = -q[1];
+  out[2] = -q[2];
+  out[3] = -q[3];
 }
 
-void quatNormalize(float q[4]) {
-    const float n = q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3];
-    const float r = safeRecipSqrt(n);
-    q[0] *= r;
-    q[1] *= r;
-    q[2] *= r;
-    q[3] *= r;
+void quatNormalize(float q[4])
+{
+  const float n = q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3];
+  const float r = safeRecipSqrt(n);
+  q[0] *= r;
+  q[1] *= r;
+  q[2] *= r;
+  q[3] *= r;
 }
 
-void quatFromAxisX(float angle_rad, float out[4]) {
-    const float h = 0.5f * angle_rad;
-    out[0] = std::cos(h);
-    out[1] = std::sin(h);
-    out[2] = 0.0f;
-    out[3] = 0.0f;
+void quatFromAxisX(float angle_rad, float out[4])
+{
+  const float h = 0.5f * angle_rad;
+  out[0] = std::cos(h);
+  out[1] = std::sin(h);
+  out[2] = 0.0f;
+  out[3] = 0.0f;
 }
 
-void quatFromAxisY(float angle_rad, float out[4]) {
-    const float h = 0.5f * angle_rad;
-    out[0] = std::cos(h);
-    out[1] = 0.0f;
-    out[2] = std::sin(h);
-    out[3] = 0.0f;
+void quatFromAxisY(float angle_rad, float out[4])
+{
+  const float h = 0.5f * angle_rad;
+  out[0] = std::cos(h);
+  out[1] = 0.0f;
+  out[2] = std::sin(h);
+  out[3] = 0.0f;
 }
 
-void quatFromAxisZ(float angle_rad, float out[4]) {
-    const float h = 0.5f * angle_rad;
-    out[0] = std::cos(h);
-    out[1] = 0.0f;
-    out[2] = 0.0f;
-    out[3] = std::sin(h);
+void quatFromAxisZ(float angle_rad, float out[4])
+{
+  const float h = 0.5f * angle_rad;
+  out[0] = std::cos(h);
+  out[1] = 0.0f;
+  out[2] = 0.0f;
+  out[3] = std::sin(h);
 }
 
-void quatToEulerRad(const float q[4], float &roll, float &pitch, float &yaw) {
-    // Matches the legacy ZYX extraction used by PollData.cpp.
-    roll  = std::atan2(2.0f * (q[0] * q[1] + q[2] * q[3]),
-                       q[0] * q[0] - q[1] * q[1] - q[2] * q[2] + q[3] * q[3]);
-    const float sinp = 2.0f * (q[1] * q[3] - q[0] * q[2]);
-    pitch = -std::asin(sinp < -1.0f ? -1.0f : (sinp > 1.0f ? 1.0f : sinp));
-    yaw   = std::atan2(2.0f * (q[1] * q[2] + q[0] * q[3]),
-                       q[0] * q[0] + q[1] * q[1] - q[2] * q[2] - q[3] * q[3]);
+void quatToEulerRad(const float q[4], float& roll, float& pitch, float& yaw)
+{
+  // Matches the legacy ZYX extraction used by PollData.cpp.
+  roll = std::atan2(2.0f * (q[0] * q[1] + q[2] * q[3]), q[0] * q[0] - q[1] * q[1] - q[2] * q[2] + q[3] * q[3]);
+  const float sinp = 2.0f * (q[1] * q[3] - q[0] * q[2]);
+  pitch = -std::asin(sinp < -1.0f ? -1.0f : (sinp > 1.0f ? 1.0f : sinp));
+  yaw = std::atan2(2.0f * (q[1] * q[2] + q[0] * q[3]), q[0] * q[0] + q[1] * q[1] - q[2] * q[2] - q[3] * q[3]);
 }
 
-void quatToEulerDeg(const float q[4], float &roll, float &pitch, float &yaw) {
-    quatToEulerRad(q, roll, pitch, yaw);
-    constexpr float k = 57.2957795130823f;  // 180/pi
-    roll  *= k;
-    pitch *= k;
-    yaw   *= k;
+void quatToEulerDeg(const float q[4], float& roll, float& pitch, float& yaw)
+{
+  quatToEulerRad(q, roll, pitch, yaw);
+  constexpr float k = 57.2957795130823f;  // 180/pi
+  roll *= k;
+  pitch *= k;
+  yaw *= k;
 }

--- a/robotiq_tsf/src/MahonyAHRS.cpp
+++ b/robotiq_tsf/src/MahonyAHRS.cpp
@@ -20,17 +20,17 @@
 //---------------------------------------------------------------------------------------------------
 // Definitions
 
-#define sampleFreq	512.0f			// sample frequency in Hz
-#define twoKpDef	(2.0f * 0.5f)	// 2 * proportional gain
-#define twoKiDef	(2.0f * 0.0f)	// 2 * integral gain
+#define sampleFreq 512.0f       // sample frequency in Hz
+#define twoKpDef (2.0f * 0.5f)  // 2 * proportional gain
+#define twoKiDef (2.0f * 0.0f)  // 2 * integral gain
 
 //---------------------------------------------------------------------------------------------------
 // Variable definitions
 
-volatile float twoKp = twoKpDef;											// 2 * proportional gain (Kp)
-volatile float twoKi = twoKiDef;											// 2 * integral gain (Ki)
-volatile float q0 = 1.0f, q1 = 0.0f, q2 = 0.0f, q3 = 0.0f;					// quaternion of sensor frame relative to auxiliary frame
-volatile float integralFBx = 0.0f,  integralFBy = 0.0f, integralFBz = 0.0f;	// integral error terms scaled by Ki
+volatile float twoKp = twoKpDef;                            // 2 * proportional gain (Kp)
+volatile float twoKi = twoKiDef;                            // 2 * integral gain (Ki)
+volatile float q0 = 1.0f, q1 = 0.0f, q2 = 0.0f, q3 = 0.0f;  // quaternion of sensor frame relative to auxiliary frame
+volatile float integralFBx = 0.0f, integralFBy = 0.0f, integralFBz = 0.0f;  // integral error terms scaled by Ki
 
 //---------------------------------------------------------------------------------------------------
 // Function declarations
@@ -43,188 +43,196 @@ float invSqrt(float x);
 //---------------------------------------------------------------------------------------------------
 // AHRS algorithm update
 
-void MahonyAHRSupdate(float gx, float gy, float gz, float ax, float ay, float az, float mx, float my, float mz) {
-	float recipNorm;
-    float q0q0, q0q1, q0q2, q0q3, q1q1, q1q2, q1q3, q2q2, q2q3, q3q3;  
-	float hx, hy, bx, bz;
-	float halfvx, halfvy, halfvz, halfwx, halfwy, halfwz;
-	float halfex, halfey, halfez;
-	float qa, qb, qc;
+void MahonyAHRSupdate(float gx, float gy, float gz, float ax, float ay, float az, float mx, float my, float mz)
+{
+  float recipNorm;
+  float q0q0, q0q1, q0q2, q0q3, q1q1, q1q2, q1q3, q2q2, q2q3, q3q3;
+  float hx, hy, bx, bz;
+  float halfvx, halfvy, halfvz, halfwx, halfwy, halfwz;
+  float halfex, halfey, halfez;
+  float qa, qb, qc;
 
-	// Use IMU algorithm if magnetometer measurement invalid (avoids NaN in magnetometer normalisation)
-	if((mx == 0.0f) && (my == 0.0f) && (mz == 0.0f)) {
-		MahonyAHRSupdateIMU(gx, gy, gz, ax, ay, az);
-		return;
-	}
+  // Use IMU algorithm if magnetometer measurement invalid (avoids NaN in magnetometer normalisation)
+  if ((mx == 0.0f) && (my == 0.0f) && (mz == 0.0f))
+  {
+    MahonyAHRSupdateIMU(gx, gy, gz, ax, ay, az);
+    return;
+  }
 
-	// Compute feedback only if accelerometer measurement valid (avoids NaN in accelerometer normalisation)
-	if(!((ax == 0.0f) && (ay == 0.0f) && (az == 0.0f))) {
+  // Compute feedback only if accelerometer measurement valid (avoids NaN in accelerometer normalisation)
+  if (!((ax == 0.0f) && (ay == 0.0f) && (az == 0.0f)))
+  {
+    // Normalise accelerometer measurement
+    recipNorm = invSqrt(ax * ax + ay * ay + az * az);
+    ax *= recipNorm;
+    ay *= recipNorm;
+    az *= recipNorm;
 
-		// Normalise accelerometer measurement
-		recipNorm = invSqrt(ax * ax + ay * ay + az * az);
-		ax *= recipNorm;
-		ay *= recipNorm;
-		az *= recipNorm;     
+    // Normalise magnetometer measurement
+    recipNorm = invSqrt(mx * mx + my * my + mz * mz);
+    mx *= recipNorm;
+    my *= recipNorm;
+    mz *= recipNorm;
 
-		// Normalise magnetometer measurement
-		recipNorm = invSqrt(mx * mx + my * my + mz * mz);
-		mx *= recipNorm;
-		my *= recipNorm;
-		mz *= recipNorm;   
+    // Auxiliary variables to avoid repeated arithmetic
+    q0q0 = q0 * q0;
+    q0q1 = q0 * q1;
+    q0q2 = q0 * q2;
+    q0q3 = q0 * q3;
+    q1q1 = q1 * q1;
+    q1q2 = q1 * q2;
+    q1q3 = q1 * q3;
+    q2q2 = q2 * q2;
+    q2q3 = q2 * q3;
+    q3q3 = q3 * q3;
 
-        // Auxiliary variables to avoid repeated arithmetic
-        q0q0 = q0 * q0;
-        q0q1 = q0 * q1;
-        q0q2 = q0 * q2;
-        q0q3 = q0 * q3;
-        q1q1 = q1 * q1;
-        q1q2 = q1 * q2;
-        q1q3 = q1 * q3;
-        q2q2 = q2 * q2;
-        q2q3 = q2 * q3;
-        q3q3 = q3 * q3;   
+    // Reference direction of Earth's magnetic field
+    hx = 2.0f * (mx * (0.5f - q2q2 - q3q3) + my * (q1q2 - q0q3) + mz * (q1q3 + q0q2));
+    hy = 2.0f * (mx * (q1q2 + q0q3) + my * (0.5f - q1q1 - q3q3) + mz * (q2q3 - q0q1));
+    bx = sqrt(hx * hx + hy * hy);
+    bz = 2.0f * (mx * (q1q3 - q0q2) + my * (q2q3 + q0q1) + mz * (0.5f - q1q1 - q2q2));
 
-        // Reference direction of Earth's magnetic field
-        hx = 2.0f * (mx * (0.5f - q2q2 - q3q3) + my * (q1q2 - q0q3) + mz * (q1q3 + q0q2));
-        hy = 2.0f * (mx * (q1q2 + q0q3) + my * (0.5f - q1q1 - q3q3) + mz * (q2q3 - q0q1));
-        bx = sqrt(hx * hx + hy * hy);
-        bz = 2.0f * (mx * (q1q3 - q0q2) + my * (q2q3 + q0q1) + mz * (0.5f - q1q1 - q2q2));
+    // Estimated direction of gravity and magnetic field
+    halfvx = q1q3 - q0q2;
+    halfvy = q0q1 + q2q3;
+    halfvz = q0q0 - 0.5f + q3q3;
+    halfwx = bx * (0.5f - q2q2 - q3q3) + bz * (q1q3 - q0q2);
+    halfwy = bx * (q1q2 - q0q3) + bz * (q0q1 + q2q3);
+    halfwz = bx * (q0q2 + q1q3) + bz * (0.5f - q1q1 - q2q2);
 
-		// Estimated direction of gravity and magnetic field
-		halfvx = q1q3 - q0q2;
-		halfvy = q0q1 + q2q3;
-		halfvz = q0q0 - 0.5f + q3q3;
-        halfwx = bx * (0.5f - q2q2 - q3q3) + bz * (q1q3 - q0q2);
-        halfwy = bx * (q1q2 - q0q3) + bz * (q0q1 + q2q3);
-        halfwz = bx * (q0q2 + q1q3) + bz * (0.5f - q1q1 - q2q2);  
-	
-		// Error is sum of cross product between estimated direction and measured direction of field vectors
-		halfex = (ay * halfvz - az * halfvy) + (my * halfwz - mz * halfwy);
-		halfey = (az * halfvx - ax * halfvz) + (mz * halfwx - mx * halfwz);
-		halfez = (ax * halfvy - ay * halfvx) + (mx * halfwy - my * halfwx);
+    // Error is sum of cross product between estimated direction and measured direction of field vectors
+    halfex = (ay * halfvz - az * halfvy) + (my * halfwz - mz * halfwy);
+    halfey = (az * halfvx - ax * halfvz) + (mz * halfwx - mx * halfwz);
+    halfez = (ax * halfvy - ay * halfvx) + (mx * halfwy - my * halfwx);
 
-		// Compute and apply integral feedback if enabled
-		if(twoKi > 0.0f) {
-			integralFBx += twoKi * halfex * (1.0f / sampleFreq);	// integral error scaled by Ki
-			integralFBy += twoKi * halfey * (1.0f / sampleFreq);
-			integralFBz += twoKi * halfez * (1.0f / sampleFreq);
-			gx += integralFBx;	// apply integral feedback
-			gy += integralFBy;
-			gz += integralFBz;
-		}
-		else {
-			integralFBx = 0.0f;	// prevent integral windup
-			integralFBy = 0.0f;
-			integralFBz = 0.0f;
-		}
+    // Compute and apply integral feedback if enabled
+    if (twoKi > 0.0f)
+    {
+      integralFBx += twoKi * halfex * (1.0f / sampleFreq);  // integral error scaled by Ki
+      integralFBy += twoKi * halfey * (1.0f / sampleFreq);
+      integralFBz += twoKi * halfez * (1.0f / sampleFreq);
+      gx += integralFBx;  // apply integral feedback
+      gy += integralFBy;
+      gz += integralFBz;
+    }
+    else
+    {
+      integralFBx = 0.0f;  // prevent integral windup
+      integralFBy = 0.0f;
+      integralFBz = 0.0f;
+    }
 
-		// Apply proportional feedback
-		gx += twoKp * halfex;
-		gy += twoKp * halfey;
-		gz += twoKp * halfez;
-	}
-	
-	// Integrate rate of change of quaternion
-	gx *= (0.5f * (1.0f / sampleFreq));		// pre-multiply common factors
-	gy *= (0.5f * (1.0f / sampleFreq));
-	gz *= (0.5f * (1.0f / sampleFreq));
-	qa = q0;
-	qb = q1;
-	qc = q2;
-	q0 += (-qb * gx - qc * gy - q3 * gz);
-	q1 += (qa * gx + qc * gz - q3 * gy);
-	q2 += (qa * gy - qb * gz + q3 * gx);
-	q3 += (qa * gz + qb * gy - qc * gx); 
-	
-	// Normalise quaternion
-	recipNorm = invSqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
-	q0 *= recipNorm;
-	q1 *= recipNorm;
-	q2 *= recipNorm;
-	q3 *= recipNorm;
+    // Apply proportional feedback
+    gx += twoKp * halfex;
+    gy += twoKp * halfey;
+    gz += twoKp * halfez;
+  }
+
+  // Integrate rate of change of quaternion
+  gx *= (0.5f * (1.0f / sampleFreq));  // pre-multiply common factors
+  gy *= (0.5f * (1.0f / sampleFreq));
+  gz *= (0.5f * (1.0f / sampleFreq));
+  qa = q0;
+  qb = q1;
+  qc = q2;
+  q0 += (-qb * gx - qc * gy - q3 * gz);
+  q1 += (qa * gx + qc * gz - q3 * gy);
+  q2 += (qa * gy - qb * gz + q3 * gx);
+  q3 += (qa * gz + qb * gy - qc * gx);
+
+  // Normalise quaternion
+  recipNorm = invSqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
+  q0 *= recipNorm;
+  q1 *= recipNorm;
+  q2 *= recipNorm;
+  q3 *= recipNorm;
 }
 
 //---------------------------------------------------------------------------------------------------
 // IMU algorithm update
 
-void MahonyAHRSupdateIMU(float gx, float gy, float gz, float ax, float ay, float az) {
-	float recipNorm;
-	float halfvx, halfvy, halfvz;
-	float halfex, halfey, halfez;
-	float qa, qb, qc;
+void MahonyAHRSupdateIMU(float gx, float gy, float gz, float ax, float ay, float az)
+{
+  float recipNorm;
+  float halfvx, halfvy, halfvz;
+  float halfex, halfey, halfez;
+  float qa, qb, qc;
 
-	// Compute feedback only if accelerometer measurement valid (avoids NaN in accelerometer normalisation)
-	if(!((ax == 0.0f) && (ay == 0.0f) && (az == 0.0f))) {
+  // Compute feedback only if accelerometer measurement valid (avoids NaN in accelerometer normalisation)
+  if (!((ax == 0.0f) && (ay == 0.0f) && (az == 0.0f)))
+  {
+    // Normalise accelerometer measurement
+    recipNorm = invSqrt(ax * ax + ay * ay + az * az);
+    ax *= recipNorm;
+    ay *= recipNorm;
+    az *= recipNorm;
 
-		// Normalise accelerometer measurement
-		recipNorm = invSqrt(ax * ax + ay * ay + az * az);
-		ax *= recipNorm;
-		ay *= recipNorm;
-		az *= recipNorm;        
+    // Estimated direction of gravity and vector perpendicular to magnetic flux
+    halfvx = q1 * q3 - q0 * q2;
+    halfvy = q0 * q1 + q2 * q3;
+    halfvz = q0 * q0 - 0.5f + q3 * q3;
 
-		// Estimated direction of gravity and vector perpendicular to magnetic flux
-		halfvx = q1 * q3 - q0 * q2;
-		halfvy = q0 * q1 + q2 * q3;
-		halfvz = q0 * q0 - 0.5f + q3 * q3;
-	
-		// Error is sum of cross product between estimated and measured direction of gravity
-		halfex = (ay * halfvz - az * halfvy);
-		halfey = (az * halfvx - ax * halfvz);
-		halfez = (ax * halfvy - ay * halfvx);
+    // Error is sum of cross product between estimated and measured direction of gravity
+    halfex = (ay * halfvz - az * halfvy);
+    halfey = (az * halfvx - ax * halfvz);
+    halfez = (ax * halfvy - ay * halfvx);
 
-		// Compute and apply integral feedback if enabled
-		if(twoKi > 0.0f) {
-			integralFBx += twoKi * halfex * (1.0f / sampleFreq);	// integral error scaled by Ki
-			integralFBy += twoKi * halfey * (1.0f / sampleFreq);
-			integralFBz += twoKi * halfez * (1.0f / sampleFreq);
-			gx += integralFBx;	// apply integral feedback
-			gy += integralFBy;
-			gz += integralFBz;
-		}
-		else {
-			integralFBx = 0.0f;	// prevent integral windup
-			integralFBy = 0.0f;
-			integralFBz = 0.0f;
-		}
+    // Compute and apply integral feedback if enabled
+    if (twoKi > 0.0f)
+    {
+      integralFBx += twoKi * halfex * (1.0f / sampleFreq);  // integral error scaled by Ki
+      integralFBy += twoKi * halfey * (1.0f / sampleFreq);
+      integralFBz += twoKi * halfez * (1.0f / sampleFreq);
+      gx += integralFBx;  // apply integral feedback
+      gy += integralFBy;
+      gz += integralFBz;
+    }
+    else
+    {
+      integralFBx = 0.0f;  // prevent integral windup
+      integralFBy = 0.0f;
+      integralFBz = 0.0f;
+    }
 
-		// Apply proportional feedback
-		gx += twoKp * halfex;
-		gy += twoKp * halfey;
-		gz += twoKp * halfez;
-	}
-	
-	// Integrate rate of change of quaternion
-	gx *= (0.5f * (1.0f / sampleFreq));		// pre-multiply common factors
-	gy *= (0.5f * (1.0f / sampleFreq));
-	gz *= (0.5f * (1.0f / sampleFreq));
-	qa = q0;
-	qb = q1;
-	qc = q2;
-	q0 += (-qb * gx - qc * gy - q3 * gz);
-	q1 += (qa * gx + qc * gz - q3 * gy);
-	q2 += (qa * gy - qb * gz + q3 * gx);
-	q3 += (qa * gz + qb * gy - qc * gx); 
-	
-	// Normalise quaternion
-	recipNorm = invSqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
-	q0 *= recipNorm;
-	q1 *= recipNorm;
-	q2 *= recipNorm;
-	q3 *= recipNorm;
+    // Apply proportional feedback
+    gx += twoKp * halfex;
+    gy += twoKp * halfey;
+    gz += twoKp * halfez;
+  }
+
+  // Integrate rate of change of quaternion
+  gx *= (0.5f * (1.0f / sampleFreq));  // pre-multiply common factors
+  gy *= (0.5f * (1.0f / sampleFreq));
+  gz *= (0.5f * (1.0f / sampleFreq));
+  qa = q0;
+  qb = q1;
+  qc = q2;
+  q0 += (-qb * gx - qc * gy - q3 * gz);
+  q1 += (qa * gx + qc * gz - q3 * gy);
+  q2 += (qa * gy - qb * gz + q3 * gx);
+  q3 += (qa * gz + qb * gy - qc * gx);
+
+  // Normalise quaternion
+  recipNorm = invSqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
+  q0 *= recipNorm;
+  q1 *= recipNorm;
+  q2 *= recipNorm;
+  q3 *= recipNorm;
 }
 
 //---------------------------------------------------------------------------------------------------
 // Fast inverse square-root
 // See: http://en.wikipedia.org/wiki/Fast_inverse_square_root
 
-float invSqrt(float x) {
-	float halfx = 0.5f * x;
-	float y = x;
-	long i = *(long*)&y;
-	i = 0x5f3759df - (i>>1);
-	y = *(float*)&i;
-	y = y * (1.5f - (halfx * y * y));
-	return y;
+float invSqrt(float x)
+{
+  float halfx = 0.5f * x;
+  float y = x;
+  long i = *(long*)&y;
+  i = 0x5f3759df - (i >> 1);
+  y = *(float*)&i;
+  y = y * (1.5f - (halfx * y * y));
+  return y;
 }
 
 //====================================================================================================

--- a/robotiq_tsf/src/PollData.cpp
+++ b/robotiq_tsf/src/PollData.cpp
@@ -102,7 +102,7 @@ rosrun tactilesensors PollData [-device PATH_TO_DEV]
 #include <vector>
 #include <strings.h>
 
-//Using std namespace
+// Using std namespace
 using namespace std;
 
 #define NODE_LOGGER (g_node ? g_node->get_logger() : rclcpp::get_logger("poll_data4"))
@@ -127,17 +127,17 @@ rclcpp::Service<srv::TactileSensors>::SharedPtr g_service;
 #define FINGER_STATIC_TACTILE_COUNT (FINGER_STATIC_TACTILE_ROW * FINGER_STATIC_TACTILE_COL)
 #define FINGER_DYNAMIC_TACTILE_COUNT 1
 
-//Global Variables:
+// Global Variables:
 [[maybe_unused]] bool IMUCalibrationMode = false;
-bool StopSensorDataAcquisition=false;
-[[maybe_unused]] bool ModeHasChanged=true;
-//struct timespec th, stop;
+bool StopSensorDataAcquisition = false;
+[[maybe_unused]] bool ModeHasChanged = true;
+// struct timespec th, stop;
 double EllapsedMicroSeconds;
-//IMU Biases:
-const int BIASCalculationIterations=5000; // Number of samples we want to collect to compute IMU biases
-int BIASCalculationIterator=0;
-float ax1_bias=0,ay1_bias=0,az1_bias=0,ax2_bias=0,ay2_bias=0,az2_bias=0;
-float gx1_bias=0,gy1_bias=0,gz1_bias=0,gx2_bias=0,gy2_bias=0,gz2_bias=0;
+// IMU Biases:
+const int BIASCalculationIterations = 5000;  // Number of samples we want to collect to compute IMU biases
+int BIASCalculationIterator = 0;
+float ax1_bias = 0, ay1_bias = 0, az1_bias = 0, ax2_bias = 0, ay2_bias = 0, az2_bias = 0;
+float gx1_bias = 0, gy1_bias = 0, gz1_bias = 0, gx2_bias = 0, gy2_bias = 0, gz2_bias = 0;
 
 // AHRS filter state — one instance per finger, owned by the IO thread.
 MadgwickFilter g_filter[FINGER_COUNT];
@@ -145,461 +145,452 @@ MadgwickFilter g_filter[FINGER_COUNT];
 // Per-finger MCU timestamp (milliseconds, as exposed by the firmware) of the
 // last sample we used to integrate the filter. 0 means "not yet seeded after
 // calibration".
-uint64_t g_last_ts_ms[FINGER_COUNT] = {0, 0};
+uint64_t g_last_ts_ms[FINGER_COUNT] = { 0, 0 };
 
 // Tunables, populated from ROS parameters in main().
-struct AhrsConfig {
-    float beta = 0.041f;
-    float accel_gate_lo = 0.85f;
-    float accel_gate_hi = 1.15f;
-    float bias_learn_rate = 0.0005f;     // EMA step toward residual gyro when still
-    float still_gyro_eps_deg_s = 0.8f;   // |omega| below this counts as still
-    float still_accel_eps_g = 0.05f;     // ||a| - 1g| below this counts as still
-    float dt_clamp_lo = 1e-4f;           // 0.1 ms
-    float dt_clamp_hi = 0.1f;            // 100 ms
+struct AhrsConfig
+{
+  float beta = 0.041f;
+  float accel_gate_lo = 0.85f;
+  float accel_gate_hi = 1.15f;
+  float bias_learn_rate = 0.0005f;    // EMA step toward residual gyro when still
+  float still_gyro_eps_deg_s = 0.8f;  // |omega| below this counts as still
+  float still_accel_eps_g = 0.05f;    // ||a| - 1g| below this counts as still
+  float dt_clamp_lo = 1e-4f;          // 0.1 ms
+  float dt_clamp_hi = 0.1f;           // 100 ms
 };
 AhrsConfig g_ahrs_cfg;
 
 enum UsbPacketSpecial
 {
-    USB_PACKET_START_BYTE = 0x9A,
-    USB_PACKET_HEADER_SIZE = 4,
-    USB_PACKET_MAX_DATA_SIZE = 256,
-    USB_PACKET_MAX_SIZE = USB_PACKET_HEADER_SIZE + USB_PACKET_MAX_DATA_SIZE,
+  USB_PACKET_START_BYTE = 0x9A,
+  USB_PACKET_HEADER_SIZE = 4,
+  USB_PACKET_MAX_DATA_SIZE = 256,
+  USB_PACKET_MAX_SIZE = USB_PACKET_HEADER_SIZE + USB_PACKET_MAX_DATA_SIZE,
 };
 
 enum UsbCommands
 {
-    USB_COMMAND_READ_SENSORS = 0x61,
-    USB_COMMAND_AUTOSEND_SYNC_SENSORS = 0x58,
-    USB_COMMAND_AUTOSEND_ASYNC_SENSORS = 0x59,
-    USB_COMMAND_ENTER_BOOTLOADER = 0xE2,
-    USB_COMMAND_GET_VERSION = 0xE3,
+  USB_COMMAND_READ_SENSORS = 0x61,
+  USB_COMMAND_AUTOSEND_SYNC_SENSORS = 0x58,
+  USB_COMMAND_AUTOSEND_ASYNC_SENSORS = 0x59,
+  USB_COMMAND_ENTER_BOOTLOADER = 0xE2,
+  USB_COMMAND_GET_VERSION = 0xE3,
 };
 
 // Sensor types occupy the higher 4 bits, the 2 bits lower than that identify finger, and the lower 2 bits is used as an index.
 enum UsbSensorType
 {
-    USB_SENSOR_TYPE_STATIC_TACTILE = 0x10,
-    USB_SENSOR_TYPE_DYNAMIC_TACTILE = 0x20,
-    USB_SENSOR_TYPE_ACCELEROMETER = 0x30,
-    USB_SENSOR_TYPE_GYROSCOPE = 0x40,
-    USB_SENSOR_TYPE_TEMPERATURE = 0x60,
-    USB_SENSOR_TYPE_TIMESTAMP = 0x70,
+  USB_SENSOR_TYPE_STATIC_TACTILE = 0x10,
+  USB_SENSOR_TYPE_DYNAMIC_TACTILE = 0x20,
+  USB_SENSOR_TYPE_ACCELEROMETER = 0x30,
+  USB_SENSOR_TYPE_GYROSCOPE = 0x40,
+  USB_SENSOR_TYPE_TEMPERATURE = 0x60,
+  USB_SENSOR_TYPE_TIMESTAMP = 0x70,
 };
 
 struct UsbPacket
 {
-    uint8_t start_byte;
-    uint8_t crc8;           // over command, data_length and data
-    uint8_t command;        // 4 bits of flag (MSB) and 4 bits of command (LSB)
-    uint8_t data_length;
-    uint8_t data[USB_PACKET_MAX_DATA_SIZE];
+  uint8_t start_byte;
+  uint8_t crc8;     // over command, data_length and data
+  uint8_t command;  // 4 bits of flag (MSB) and 4 bits of command (LSB)
+  uint8_t data_length;
+  uint8_t data[USB_PACKET_MAX_DATA_SIZE];
 };
 
 struct FingerData
 {
-    bool newDataAvailable;
+  bool newDataAvailable;
 
-    uint16_t staticTactile[FINGER_STATIC_TACTILE_COUNT];
-    int16_t dynamicTactile[FINGER_DYNAMIC_TACTILE_COUNT];
-    int16_t accelerometer[3];
-    int16_t gyroscope[3];
-    int16_t temperature;
-    uint64_t timestamp;
+  uint16_t staticTactile[FINGER_STATIC_TACTILE_COUNT];
+  int16_t dynamicTactile[FINGER_DYNAMIC_TACTILE_COUNT];
+  int16_t accelerometer[3];
+  int16_t gyroscope[3];
+  int16_t temperature;
+  uint64_t timestamp;
 
-    uint16_t baseline[FINGER_STATIC_TACTILE_COUNT];
+  uint16_t baseline[FINGER_STATIC_TACTILE_COUNT];
 };
 
 struct Fingers
 {
-    int64_t timestamp;
-    FingerData finger[FINGER_COUNT];
+  int64_t timestamp;
+  FingerData finger[FINGER_COUNT];
 };
 
-//Function prototypes:
+// Function prototypes:
 bool cmdOptionExists(char** begin, char** end, const string& option);
-char* getCmdOption(char ** begin, char ** end, const string & option);
-bool OpenAndConfigurePort(int *USB, char const *TheDevice);
-static void usbSend(int *USB, UsbPacket *packet);
-static uint8_t calcCrc8(uint8_t *data, size_t len);
-static bool usbReadByte(UsbPacket *packet, unsigned int *readSoFar, uint8_t d);
-static void parseSensors(UsbPacket *packet, Fingers *fingers);
-static inline uint16_t parseBigEndian2(uint8_t *data);
-static inline uint64_t parseBigEndian8(uint8_t *data);
-static uint8_t extractUint16(uint16_t *to, uint16_t toCount, uint8_t *data, unsigned int size);
-static unsigned int extractUint64(uint64_t *to, unsigned int toCount, uint8_t *data, unsigned int size);
-static std::string trimWhitespace(const std::string &value);
-static bool matchesKnownUsbString(const std::string &value);
-static bool readSysfsEntry(const std::string &path, std::string &value);
-static bool deviceMatchesKnownSensor(const std::string &device_path);
+char* getCmdOption(char** begin, char** end, const string& option);
+bool OpenAndConfigurePort(int* USB, char const* TheDevice);
+static void usbSend(int* USB, UsbPacket* packet);
+static uint8_t calcCrc8(uint8_t* data, size_t len);
+static bool usbReadByte(UsbPacket* packet, unsigned int* readSoFar, uint8_t d);
+static void parseSensors(UsbPacket* packet, Fingers* fingers);
+static inline uint16_t parseBigEndian2(uint8_t* data);
+static inline uint64_t parseBigEndian8(uint8_t* data);
+static uint8_t extractUint16(uint16_t* to, uint16_t toCount, uint8_t* data, unsigned int size);
+static unsigned int extractUint64(uint64_t* to, unsigned int toCount, uint8_t* data, unsigned int size);
+static std::string trimWhitespace(const std::string& value);
+static bool matchesKnownUsbString(const std::string& value);
+static bool readSysfsEntry(const std::string& path, std::string& value);
+static bool deviceMatchesKnownSensor(const std::string& device_path);
 static std::string autoDetectSensorDevice();
-static void forceReconnectSensor(int *USB);
+static void forceReconnectSensor(int* USB);
 
-constexpr const char *kDefaultDevice = "/dev/rq_tsf85_0";
+constexpr const char* kDefaultDevice = "/dev/rq_tsf85_0";
 
-
-//Callbacks:
-void TactileSensorServiceCallback(
-    const std::shared_ptr<srv::TactileSensors::Request> req,
-    std::shared_ptr<srv::TactileSensors::Response> res)
+// Callbacks:
+void TactileSensorServiceCallback(const std::shared_ptr<srv::TactileSensors::Request> req,
+                                  std::shared_ptr<srv::TactileSensors::Response> res)
 {
-    RCLCPP_INFO(NODE_LOGGER, "The Tactile Sensors Service has received a request: [%s]", req->request.c_str());
-    ModeHasChanged = true;
-    if (strcasecmp(req->request.c_str(), "start") == 0)
-    {
-        StopSensorDataAcquisition = false;
-        res->response = true;
-        return;
-    }
-    if (strcasecmp(req->request.c_str(), "stop") == 0)
-    {
-        StopSensorDataAcquisition = true;
-        res->response = true;
-        return;
-    }
+  RCLCPP_INFO(NODE_LOGGER, "The Tactile Sensors Service has received a request: [%s]", req->request.c_str());
+  ModeHasChanged = true;
+  if (strcasecmp(req->request.c_str(), "start") == 0)
+  {
+    StopSensorDataAcquisition = false;
+    res->response = true;
+    return;
+  }
+  if (strcasecmp(req->request.c_str(), "stop") == 0)
+  {
+    StopSensorDataAcquisition = true;
+    res->response = true;
+    return;
+  }
 
-    RCLCPP_WARN(NODE_LOGGER, "The Tactile Sensor service has received an invalid request.");
-    res->response = false;
+  RCLCPP_WARN(NODE_LOGGER, "The Tactile Sensor service has received an invalid request.");
+  res->response = false;
 }
 
-//Main
-int main(int argc, char **argv)
+// Main
+int main(int argc, char** argv)
 {
-    rclcpp::init(argc, argv);
-    g_node = std::make_shared<rclcpp::Node>("poll_data4");
-    g_node->declare_parameter<std::string>("device", kDefaultDevice);
+  rclcpp::init(argc, argv);
+  g_node = std::make_shared<rclcpp::Node>("poll_data4");
+  g_node->declare_parameter<std::string>("device", kDefaultDevice);
 
-    // AHRS tuning parameters — see AhrsConfig for what each one does.
-    g_node->declare_parameter<double>("madgwick.beta", g_ahrs_cfg.beta);
-    g_node->declare_parameter<double>("madgwick.accel_gate_lo", g_ahrs_cfg.accel_gate_lo);
-    g_node->declare_parameter<double>("madgwick.accel_gate_hi", g_ahrs_cfg.accel_gate_hi);
-    g_node->declare_parameter<double>("madgwick.bias_learn_rate", g_ahrs_cfg.bias_learn_rate);
-    g_node->declare_parameter<double>("madgwick.still_gyro_eps_deg_s", g_ahrs_cfg.still_gyro_eps_deg_s);
-    g_node->declare_parameter<double>("madgwick.still_accel_eps_g", g_ahrs_cfg.still_accel_eps_g);
+  // AHRS tuning parameters — see AhrsConfig for what each one does.
+  g_node->declare_parameter<double>("madgwick.beta", g_ahrs_cfg.beta);
+  g_node->declare_parameter<double>("madgwick.accel_gate_lo", g_ahrs_cfg.accel_gate_lo);
+  g_node->declare_parameter<double>("madgwick.accel_gate_hi", g_ahrs_cfg.accel_gate_hi);
+  g_node->declare_parameter<double>("madgwick.bias_learn_rate", g_ahrs_cfg.bias_learn_rate);
+  g_node->declare_parameter<double>("madgwick.still_gyro_eps_deg_s", g_ahrs_cfg.still_gyro_eps_deg_s);
+  g_node->declare_parameter<double>("madgwick.still_accel_eps_g", g_ahrs_cfg.still_accel_eps_g);
 
-    g_ahrs_cfg.beta = static_cast<float>(g_node->get_parameter("madgwick.beta").as_double());
-    g_ahrs_cfg.accel_gate_lo = static_cast<float>(g_node->get_parameter("madgwick.accel_gate_lo").as_double());
-    g_ahrs_cfg.accel_gate_hi = static_cast<float>(g_node->get_parameter("madgwick.accel_gate_hi").as_double());
-    g_ahrs_cfg.bias_learn_rate = static_cast<float>(g_node->get_parameter("madgwick.bias_learn_rate").as_double());
-    g_ahrs_cfg.still_gyro_eps_deg_s = static_cast<float>(g_node->get_parameter("madgwick.still_gyro_eps_deg_s").as_double());
-    g_ahrs_cfg.still_accel_eps_g = static_cast<float>(g_node->get_parameter("madgwick.still_accel_eps_g").as_double());
+  g_ahrs_cfg.beta = static_cast<float>(g_node->get_parameter("madgwick.beta").as_double());
+  g_ahrs_cfg.accel_gate_lo = static_cast<float>(g_node->get_parameter("madgwick.accel_gate_lo").as_double());
+  g_ahrs_cfg.accel_gate_hi = static_cast<float>(g_node->get_parameter("madgwick.accel_gate_hi").as_double());
+  g_ahrs_cfg.bias_learn_rate = static_cast<float>(g_node->get_parameter("madgwick.bias_learn_rate").as_double());
+  g_ahrs_cfg.still_gyro_eps_deg_s =
+      static_cast<float>(g_node->get_parameter("madgwick.still_gyro_eps_deg_s").as_double());
+  g_ahrs_cfg.still_accel_eps_g = static_cast<float>(g_node->get_parameter("madgwick.still_accel_eps_g").as_double());
 
-    for (int f = 0; f < FINGER_COUNT; ++f)
+  for (int f = 0; f < FINGER_COUNT; ++f)
+  {
+    g_filter[f].setBeta(g_ahrs_cfg.beta);
+    g_filter[f].setAccelGate(g_ahrs_cfg.accel_gate_lo, g_ahrs_cfg.accel_gate_hi);
+  }
+
+  g_service = g_node->create_service<srv::TactileSensors>("tactile_sensors_service", &TactileSensorServiceCallback);
+
+  auto sensor_qos = rclcpp::SensorDataQoS();
+  auto orientation_qos = sensor_qos;
+  g_static_pub = g_node->create_publisher<msg::StaticData>("TactileSensor/StaticData", sensor_qos);
+  g_dynamic_pub = g_node->create_publisher<msg::Dynamic>("TactileSensor/Dynamic", sensor_qos);
+  g_accel_pub = g_node->create_publisher<msg::Accelerometer>("TactileSensor/Accelerometer", sensor_qos);
+  g_euler_pub = g_node->create_publisher<msg::EulerAngle>("TactileSensor/EulerAngle", orientation_qos);
+  g_gyro_pub = g_node->create_publisher<msg::Gyroscope>("TactileSensor/Gyroscope", sensor_qos);
+  g_quat_pub = g_node->create_publisher<msg::Quaternion>("TactileSensor/Quaternion", orientation_qos);
+  g_timestamp_pub = g_node->create_publisher<msg::Timestamp>("TactileSensor/Timestamp", sensor_qos);
+
+  std::string device = g_node->get_parameter("device").as_string();
+  bool cliDeviceOverride = false;
+  if (cmdOptionExists(argv, argv + argc, "-device"))
+  {
+    if (char* filename = getCmdOption(argv, argv + argc, "-device"))
     {
-        g_filter[f].setBeta(g_ahrs_cfg.beta);
-        g_filter[f].setAccelGate(g_ahrs_cfg.accel_gate_lo, g_ahrs_cfg.accel_gate_hi);
+      device = filename;
+      cliDeviceOverride = true;
+      g_node->set_parameter(rclcpp::Parameter("device", device));
     }
+  }
 
-    g_service = g_node->create_service<srv::TactileSensors>(
-        "tactile_sensors_service", &TactileSensorServiceCallback);
-
-    auto sensor_qos = rclcpp::SensorDataQoS();
-    auto orientation_qos = sensor_qos;
-    g_static_pub = g_node->create_publisher<msg::StaticData>("TactileSensor/StaticData", sensor_qos);
-    g_dynamic_pub = g_node->create_publisher<msg::Dynamic>("TactileSensor/Dynamic", sensor_qos);
-    g_accel_pub = g_node->create_publisher<msg::Accelerometer>("TactileSensor/Accelerometer", sensor_qos);
-    g_euler_pub = g_node->create_publisher<msg::EulerAngle>("TactileSensor/EulerAngle", orientation_qos);
-    g_gyro_pub = g_node->create_publisher<msg::Gyroscope>("TactileSensor/Gyroscope", sensor_qos);
-    g_quat_pub = g_node->create_publisher<msg::Quaternion>("TactileSensor/Quaternion", orientation_qos);
-    g_timestamp_pub = g_node->create_publisher<msg::Timestamp>("TactileSensor/Timestamp", sensor_qos);
-
-    std::string device = g_node->get_parameter("device").as_string();
-    bool cliDeviceOverride = false;
-    if (cmdOptionExists(argv, argv + argc, "-device"))
+  const bool paramOverridesDefault = device != kDefaultDevice;
+  if (!cliDeviceOverride && !paramOverridesDefault)
+  {
+    const std::string detected = autoDetectSensorDevice();
+    if (!detected.empty())
     {
-        if (char *filename = getCmdOption(argv, argv + argc, "-device"))
-        {
-            device = filename;
-            cliDeviceOverride = true;
-            g_node->set_parameter(rclcpp::Parameter("device", device));
-        }
+      RCLCPP_INFO(NODE_LOGGER, "Auto-detected tactile sensor on %s", detected.c_str());
+      device = detected;
+      g_node->set_parameter(rclcpp::Parameter("device", device));
     }
-
-    const bool paramOverridesDefault = device != kDefaultDevice;
-    if (!cliDeviceOverride && !paramOverridesDefault)
+    else
     {
-        const std::string detected = autoDetectSensorDevice();
-        if (!detected.empty())
-        {
-            RCLCPP_INFO(NODE_LOGGER, "Auto-detected tactile sensor on %s", detected.c_str());
-            device = detected;
-            g_node->set_parameter(rclcpp::Parameter("device", device));
-        }
-        else
-        {
-            RCLCPP_WARN(NODE_LOGGER, "Could not auto-detect tactile sensor device; falling back to %s", device.c_str());
-        }
+      RCLCPP_WARN(NODE_LOGGER, "Could not auto-detect tactile sensor device; falling back to %s", device.c_str());
     }
+  }
 
-    int USB;
-    if (!OpenAndConfigurePort(&USB, device.c_str()))
-    {
-        RCLCPP_FATAL(NODE_LOGGER, "Failed to open device: %s", device.c_str());
-        rclcpp::shutdown();
-        return 1;
-    }
-
-    forceReconnectSensor(&USB);
-
-    Fingers fingers = {0};
-    msg::Sensor sensors_data;
-    msg::Quaternion quaternions;
-    UsbPacket send{}, recv{};
-    unsigned int recvSoFar = 0;
-    std::vector<char> receiveBuffer(4096);
-    float ax1, ay1, az1, gx1, gy1, gz1, ax2, ay2, az2, gx2, gy2, gz2;
-    const float aRes = 2.0F / 32768.0F;
-    const float gRes = 250.0F / 32768.0F;
-
-    send.command = USB_COMMAND_AUTOSEND_SYNC_SENSORS;
-    send.data_length = 1;
-    send.data[0] = READ_DATA_PERIOD_MS;
-    usbSend(&USB, &send);
-
-    rclcpp::executors::SingleThreadedExecutor executor;
-    executor.add_node(g_node);
-    std::thread spin_thread([&executor]() { executor.spin(); });
-
-    while (rclcpp::ok())
-    {
-        int n_read = read(USB, receiveBuffer.data(), receiveBuffer.size());
-        if (n_read < 0)
-        {
-            if (errno == EINTR)
-            {
-                continue;
-            }
-            RCLCPP_ERROR(NODE_LOGGER, "Read error on %s: %s", device.c_str(), strerror(errno));
-            break;
-        }
-
-        for (int64_t i = 0; i < n_read; ++i)
-        {
-            if (usbReadByte(&recv, &recvSoFar, static_cast<uint8_t>(receiveBuffer[i])))
-            {
-                // The firmware no longer emits a single "end-of-frame" sensor type; instead
-                // each finger advertises whether it received new data in this packet.
-                if (recv.command != USB_COMMAND_AUTOSEND_SYNC_SENSORS &&
-                    recv.command != USB_COMMAND_AUTOSEND_ASYNC_SENSORS &&
-                    recv.command != USB_COMMAND_READ_SENSORS)
-                {
-                    continue;
-                }
-
-                parseSensors(&recv, &fingers);
-
-                bool newSetOfData = false;
-                for (int f = 0; f < FINGER_COUNT; ++f)
-                {
-                    if (fingers.finger[f].newDataAvailable)
-                    {
-                        newSetOfData = true;
-                        break;
-                    }
-                }
-
-                if (newSetOfData)
-                {
-                    sensors_data.dynamic.data[0].value = fingers.finger[0].dynamicTactile[0];
-                    sensors_data.dynamic.data[1].value = fingers.finger[1].dynamicTactile[0];
-
-                    std::memcpy(sensors_data.staticdata.taxels[0].values.data(),
-                                fingers.finger[0].staticTactile,
-                                sizeof(fingers.finger[0].staticTactile));
-                    std::memcpy(sensors_data.staticdata.taxels[1].values.data(),
-                                fingers.finger[1].staticTactile,
-                                sizeof(fingers.finger[1].staticTactile));
-
-                    std::memcpy(sensors_data.accelerometer.data[0].values.data(),
-                                fingers.finger[0].accelerometer,
-                                sizeof(fingers.finger[0].accelerometer));
-                    std::memcpy(sensors_data.accelerometer.data[1].values.data(),
-                                fingers.finger[1].accelerometer,
-                                sizeof(fingers.finger[1].accelerometer));
-
-                    std::memcpy(sensors_data.gyroscope.data[0].values.data(),
-                                fingers.finger[0].gyroscope,
-                                sizeof(fingers.finger[0].gyroscope));
-                    std::memcpy(sensors_data.gyroscope.data[1].values.data(),
-                                fingers.finger[1].gyroscope,
-                                sizeof(fingers.finger[1].gyroscope));
-
-                    sensors_data.timestamp.values[0] = fingers.finger[0].timestamp;
-                    sensors_data.timestamp.values[1] = fingers.finger[1].timestamp;
-
-                    if (BIASCalculationIterator > BIASCalculationIterations)
-                    {
-                        // Apply bias correction. ax/ay/az in g, gx/gy/gz in deg/s.
-                        ax1 = fingers.finger[0].accelerometer[0] * aRes - ax1_bias;
-                        ay1 = fingers.finger[0].accelerometer[1] * aRes - ay1_bias;
-                        az1 = fingers.finger[0].accelerometer[2] * aRes - az1_bias;
-                        ax2 = fingers.finger[1].accelerometer[0] * aRes - ax2_bias;
-                        ay2 = fingers.finger[1].accelerometer[1] * aRes - ay2_bias;
-                        az2 = fingers.finger[1].accelerometer[2] * aRes - az2_bias;
-                        gx1 = fingers.finger[0].gyroscope[0] * gRes - gx1_bias;
-                        gy1 = fingers.finger[0].gyroscope[1] * gRes - gy1_bias;
-                        gz1 = fingers.finger[0].gyroscope[2] * gRes - gz1_bias;
-                        gx2 = fingers.finger[1].gyroscope[0] * gRes - gx2_bias;
-                        gy2 = fingers.finger[1].gyroscope[1] * gRes - gy2_bias;
-                        gz2 = fingers.finger[1].gyroscope[2] * gRes - gz2_bias;
-
-                        constexpr float deg_to_rad = static_cast<float>(M_PI / 180.0f);
-
-                        const float ax_per_finger[FINGER_COUNT] = {ax1, ax2};
-                        const float ay_per_finger[FINGER_COUNT] = {ay1, ay2};
-                        const float az_per_finger[FINGER_COUNT] = {az1, az2};
-                        const float gx_per_finger[FINGER_COUNT] = {gx1, gx2};
-                        const float gy_per_finger[FINGER_COUNT] = {gy1, gy2};
-                        const float gz_per_finger[FINGER_COUNT] = {gz1, gz2};
-                        float *const gx_bias_per_finger[FINGER_COUNT] = {&gx1_bias, &gx2_bias};
-                        float *const gy_bias_per_finger[FINGER_COUNT] = {&gy1_bias, &gy2_bias};
-                        float *const gz_bias_per_finger[FINGER_COUNT] = {&gz1_bias, &gz2_bias};
-
-                        for (int f = 0; f < FINGER_COUNT; ++f)
-                        {
-                            const float ax = ax_per_finger[f];
-                            const float ay = ay_per_finger[f];
-                            const float az = az_per_finger[f];
-                            const float gx = gx_per_finger[f];
-                            const float gy = gy_per_finger[f];
-                            const float gz = gz_per_finger[f];
-
-                            // Measured dt from MCU per-finger timestamp (ms).
-                            const uint64_t ts = fingers.finger[f].timestamp;
-                            float dt = 0.0f;
-                            if (g_last_ts_ms[f] != 0 && ts > g_last_ts_ms[f])
-                            {
-                                dt = static_cast<float>(ts - g_last_ts_ms[f]) * 1e-3f;
-                                if (dt < g_ahrs_cfg.dt_clamp_lo) dt = g_ahrs_cfg.dt_clamp_lo;
-                                if (dt > g_ahrs_cfg.dt_clamp_hi) dt = g_ahrs_cfg.dt_clamp_hi;
-                            }
-                            g_last_ts_ms[f] = ts;
-
-                            if (dt > 0.0f)
-                            {
-                                g_filter[f].updateIMU(gx * deg_to_rad, gy * deg_to_rad, gz * deg_to_rad,
-                                                      ax, ay, az, dt);
-                            }
-
-                            // Online gyro-bias trim when stationary. The residual gx/gy/gz
-                            // (post-bias-subtraction) should be ~0 if the sensor really is
-                            // still and the bias is still right; if it's not, slowly drift
-                            // the stored bias toward the current reading.
-                            const float gyroMag = std::sqrt(gx * gx + gy * gy + gz * gz);
-                            const float accelNorm = std::sqrt(ax * ax + ay * ay + az * az);
-                            const bool still =
-                                (gyroMag < g_ahrs_cfg.still_gyro_eps_deg_s) &&
-                                (std::fabs(accelNorm - 1.0f) < g_ahrs_cfg.still_accel_eps_g);
-                            if (still)
-                            {
-                                const float alpha = g_ahrs_cfg.bias_learn_rate;
-                                *gx_bias_per_finger[f] += alpha * gx;
-                                *gy_bias_per_finger[f] += alpha * gy;
-                                *gz_bias_per_finger[f] += alpha * gz;
-                            }
-
-                            // Absolute filter quaternion sources both topics.
-                            // Published Euler is bounded to ±180° (ZYX Tait-Bryan) and will
-                            // wrap discretely at the boundary; consumers that need continuous
-                            // angles should subscribe to TactileSensor/Quaternion and decode
-                            // it themselves.
-                            float qRaw[4];
-                            g_filter[f].getQuaternion(qRaw[0], qRaw[1], qRaw[2], qRaw[3]);
-                            quaternions.data[f].values[0] = qRaw[0];
-                            quaternions.data[f].values[1] = qRaw[1];
-                            quaternions.data[f].values[2] = qRaw[2];
-                            quaternions.data[f].values[3] = qRaw[3];
-
-                            float roll, pitch, yaw;
-                            quatToEulerDeg(qRaw, roll, pitch, yaw);
-
-                            sensors_data.eulerangle.data[f].values[0] = roll;
-                            sensors_data.eulerangle.data[f].values[1] = pitch;
-                            sensors_data.eulerangle.data[f].values[2] = yaw;
-                        }
-                    }
-                    else if (BIASCalculationIterator == BIASCalculationIterations)
-                    {
-                        gx1_bias /= BIASCalculationIterations;
-                        gy1_bias /= BIASCalculationIterations;
-                        gz1_bias /= BIASCalculationIterations;
-                        gx2_bias /= BIASCalculationIterations;
-                        gy2_bias /= BIASCalculationIterations;
-                        gz2_bias /= BIASCalculationIterations;
-                        ax1_bias /= BIASCalculationIterations;
-                        ay1_bias /= BIASCalculationIterations;
-                        az1_bias /= BIASCalculationIterations;
-                        ax2_bias /= BIASCalculationIterations;
-                        ay2_bias /= BIASCalculationIterations;
-                        az2_bias /= BIASCalculationIterations;
-
-                        // The calibration-time accel mean *is* gravity expressed in the
-                        // body frame at rest — it's the signal, not a bias to subtract.
-                        // Seed each filter's quaternion from it, then null out the accel
-                        // bias so the runtime path stops subtracting a phantom offset.
-                        g_filter[0].initFromAccel(ax1_bias, ay1_bias, az1_bias);
-                        g_filter[1].initFromAccel(ax2_bias, ay2_bias, az2_bias);
-                        ax1_bias = ay1_bias = az1_bias = 0.0f;
-                        ax2_bias = ay2_bias = az2_bias = 0.0f;
-
-                        g_last_ts_ms[0] = 0;
-                        g_last_ts_ms[1] = 0;
-
-                        ++BIASCalculationIterator;
-                    }
-                    else if (BIASCalculationIterator < BIASCalculationIterations)
-                    {
-                        gx1_bias += fingers.finger[0].gyroscope[0] * gRes;
-                        gy1_bias += fingers.finger[0].gyroscope[1] * gRes;
-                        gz1_bias += fingers.finger[0].gyroscope[2] * gRes;
-                        gx2_bias += fingers.finger[1].gyroscope[0] * gRes;
-                        gy2_bias += fingers.finger[1].gyroscope[1] * gRes;
-                        gz2_bias += fingers.finger[1].gyroscope[2] * gRes;
-                        ax1_bias += fingers.finger[0].accelerometer[0] * aRes;
-                        ay1_bias += fingers.finger[0].accelerometer[1] * aRes;
-                        az1_bias += fingers.finger[0].accelerometer[2] * aRes;
-                        ax2_bias += fingers.finger[1].accelerometer[0] * aRes;
-                        ay2_bias += fingers.finger[1].accelerometer[1] * aRes;
-                        az2_bias += fingers.finger[1].accelerometer[2] * aRes;
-                        BIASCalculationIterator++;
-                    }
-
-                    if (!StopSensorDataAcquisition)
-                    {
-                        g_dynamic_pub->publish(sensors_data.dynamic);
-                        g_static_pub->publish(sensors_data.staticdata);
-                        g_accel_pub->publish(sensors_data.accelerometer);
-                        g_gyro_pub->publish(sensors_data.gyroscope);
-                        g_timestamp_pub->publish(sensors_data.timestamp);
-
-                        if (BIASCalculationIterator > BIASCalculationIterations)
-                        {
-                            g_euler_pub->publish(sensors_data.eulerangle);
-                            g_quat_pub->publish(quaternions);
-                        }
-                    }
-
-                    for (int f = 0; f < FINGER_COUNT; ++f)
-                        fingers.finger[f].newDataAvailable = false;
-                }
-            }
-        }
-    }
-
-    send.command = USB_COMMAND_AUTOSEND_SYNC_SENSORS;
-    send.data_length = 1;
-    send.data[0] = 0;
-    usbSend(&USB, &send);
-
-    close(USB);
-    executor.cancel();
-    spin_thread.join();
-
+  int USB;
+  if (!OpenAndConfigurePort(&USB, device.c_str()))
+  {
+    RCLCPP_FATAL(NODE_LOGGER, "Failed to open device: %s", device.c_str());
     rclcpp::shutdown();
-    return 0;
-}
+    return 1;
+  }
 
+  forceReconnectSensor(&USB);
+
+  Fingers fingers = { 0 };
+  msg::Sensor sensors_data;
+  msg::Quaternion quaternions;
+  UsbPacket send{}, recv{};
+  unsigned int recvSoFar = 0;
+  std::vector<char> receiveBuffer(4096);
+  float ax1, ay1, az1, gx1, gy1, gz1, ax2, ay2, az2, gx2, gy2, gz2;
+  const float aRes = 2.0F / 32768.0F;
+  const float gRes = 250.0F / 32768.0F;
+
+  send.command = USB_COMMAND_AUTOSEND_SYNC_SENSORS;
+  send.data_length = 1;
+  send.data[0] = READ_DATA_PERIOD_MS;
+  usbSend(&USB, &send);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(g_node);
+  std::thread spin_thread([&executor]() { executor.spin(); });
+
+  while (rclcpp::ok())
+  {
+    int n_read = read(USB, receiveBuffer.data(), receiveBuffer.size());
+    if (n_read < 0)
+    {
+      if (errno == EINTR)
+      {
+        continue;
+      }
+      RCLCPP_ERROR(NODE_LOGGER, "Read error on %s: %s", device.c_str(), strerror(errno));
+      break;
+    }
+
+    for (int64_t i = 0; i < n_read; ++i)
+    {
+      if (usbReadByte(&recv, &recvSoFar, static_cast<uint8_t>(receiveBuffer[i])))
+      {
+        // The firmware no longer emits a single "end-of-frame" sensor type; instead
+        // each finger advertises whether it received new data in this packet.
+        if (recv.command != USB_COMMAND_AUTOSEND_SYNC_SENSORS && recv.command != USB_COMMAND_AUTOSEND_ASYNC_SENSORS &&
+            recv.command != USB_COMMAND_READ_SENSORS)
+        {
+          continue;
+        }
+
+        parseSensors(&recv, &fingers);
+
+        bool newSetOfData = false;
+        for (int f = 0; f < FINGER_COUNT; ++f)
+        {
+          if (fingers.finger[f].newDataAvailable)
+          {
+            newSetOfData = true;
+            break;
+          }
+        }
+
+        if (newSetOfData)
+        {
+          sensors_data.dynamic.data[0].value = fingers.finger[0].dynamicTactile[0];
+          sensors_data.dynamic.data[1].value = fingers.finger[1].dynamicTactile[0];
+
+          std::memcpy(sensors_data.staticdata.taxels[0].values.data(), fingers.finger[0].staticTactile,
+                      sizeof(fingers.finger[0].staticTactile));
+          std::memcpy(sensors_data.staticdata.taxels[1].values.data(), fingers.finger[1].staticTactile,
+                      sizeof(fingers.finger[1].staticTactile));
+
+          std::memcpy(sensors_data.accelerometer.data[0].values.data(), fingers.finger[0].accelerometer,
+                      sizeof(fingers.finger[0].accelerometer));
+          std::memcpy(sensors_data.accelerometer.data[1].values.data(), fingers.finger[1].accelerometer,
+                      sizeof(fingers.finger[1].accelerometer));
+
+          std::memcpy(sensors_data.gyroscope.data[0].values.data(), fingers.finger[0].gyroscope,
+                      sizeof(fingers.finger[0].gyroscope));
+          std::memcpy(sensors_data.gyroscope.data[1].values.data(), fingers.finger[1].gyroscope,
+                      sizeof(fingers.finger[1].gyroscope));
+
+          sensors_data.timestamp.values[0] = fingers.finger[0].timestamp;
+          sensors_data.timestamp.values[1] = fingers.finger[1].timestamp;
+
+          if (BIASCalculationIterator > BIASCalculationIterations)
+          {
+            // Apply bias correction. ax/ay/az in g, gx/gy/gz in deg/s.
+            ax1 = fingers.finger[0].accelerometer[0] * aRes - ax1_bias;
+            ay1 = fingers.finger[0].accelerometer[1] * aRes - ay1_bias;
+            az1 = fingers.finger[0].accelerometer[2] * aRes - az1_bias;
+            ax2 = fingers.finger[1].accelerometer[0] * aRes - ax2_bias;
+            ay2 = fingers.finger[1].accelerometer[1] * aRes - ay2_bias;
+            az2 = fingers.finger[1].accelerometer[2] * aRes - az2_bias;
+            gx1 = fingers.finger[0].gyroscope[0] * gRes - gx1_bias;
+            gy1 = fingers.finger[0].gyroscope[1] * gRes - gy1_bias;
+            gz1 = fingers.finger[0].gyroscope[2] * gRes - gz1_bias;
+            gx2 = fingers.finger[1].gyroscope[0] * gRes - gx2_bias;
+            gy2 = fingers.finger[1].gyroscope[1] * gRes - gy2_bias;
+            gz2 = fingers.finger[1].gyroscope[2] * gRes - gz2_bias;
+
+            constexpr float deg_to_rad = static_cast<float>(M_PI / 180.0f);
+
+            const float ax_per_finger[FINGER_COUNT] = { ax1, ax2 };
+            const float ay_per_finger[FINGER_COUNT] = { ay1, ay2 };
+            const float az_per_finger[FINGER_COUNT] = { az1, az2 };
+            const float gx_per_finger[FINGER_COUNT] = { gx1, gx2 };
+            const float gy_per_finger[FINGER_COUNT] = { gy1, gy2 };
+            const float gz_per_finger[FINGER_COUNT] = { gz1, gz2 };
+            float* const gx_bias_per_finger[FINGER_COUNT] = { &gx1_bias, &gx2_bias };
+            float* const gy_bias_per_finger[FINGER_COUNT] = { &gy1_bias, &gy2_bias };
+            float* const gz_bias_per_finger[FINGER_COUNT] = { &gz1_bias, &gz2_bias };
+
+            for (int f = 0; f < FINGER_COUNT; ++f)
+            {
+              const float ax = ax_per_finger[f];
+              const float ay = ay_per_finger[f];
+              const float az = az_per_finger[f];
+              const float gx = gx_per_finger[f];
+              const float gy = gy_per_finger[f];
+              const float gz = gz_per_finger[f];
+
+              // Measured dt from MCU per-finger timestamp (ms).
+              const uint64_t ts = fingers.finger[f].timestamp;
+              float dt = 0.0f;
+              if (g_last_ts_ms[f] != 0 && ts > g_last_ts_ms[f])
+              {
+                dt = static_cast<float>(ts - g_last_ts_ms[f]) * 1e-3f;
+                if (dt < g_ahrs_cfg.dt_clamp_lo)
+                  dt = g_ahrs_cfg.dt_clamp_lo;
+                if (dt > g_ahrs_cfg.dt_clamp_hi)
+                  dt = g_ahrs_cfg.dt_clamp_hi;
+              }
+              g_last_ts_ms[f] = ts;
+
+              if (dt > 0.0f)
+              {
+                g_filter[f].updateIMU(gx * deg_to_rad, gy * deg_to_rad, gz * deg_to_rad, ax, ay, az, dt);
+              }
+
+              // Online gyro-bias trim when stationary. The residual gx/gy/gz
+              // (post-bias-subtraction) should be ~0 if the sensor really is
+              // still and the bias is still right; if it's not, slowly drift
+              // the stored bias toward the current reading.
+              const float gyroMag = std::sqrt(gx * gx + gy * gy + gz * gz);
+              const float accelNorm = std::sqrt(ax * ax + ay * ay + az * az);
+              const bool still = (gyroMag < g_ahrs_cfg.still_gyro_eps_deg_s) &&
+                                 (std::fabs(accelNorm - 1.0f) < g_ahrs_cfg.still_accel_eps_g);
+              if (still)
+              {
+                const float alpha = g_ahrs_cfg.bias_learn_rate;
+                *gx_bias_per_finger[f] += alpha * gx;
+                *gy_bias_per_finger[f] += alpha * gy;
+                *gz_bias_per_finger[f] += alpha * gz;
+              }
+
+              // Absolute filter quaternion sources both topics.
+              // Published Euler is bounded to ±180° (ZYX Tait-Bryan) and will
+              // wrap discretely at the boundary; consumers that need continuous
+              // angles should subscribe to TactileSensor/Quaternion and decode
+              // it themselves.
+              float qRaw[4];
+              g_filter[f].getQuaternion(qRaw[0], qRaw[1], qRaw[2], qRaw[3]);
+              quaternions.data[f].values[0] = qRaw[0];
+              quaternions.data[f].values[1] = qRaw[1];
+              quaternions.data[f].values[2] = qRaw[2];
+              quaternions.data[f].values[3] = qRaw[3];
+
+              float roll, pitch, yaw;
+              quatToEulerDeg(qRaw, roll, pitch, yaw);
+
+              sensors_data.eulerangle.data[f].values[0] = roll;
+              sensors_data.eulerangle.data[f].values[1] = pitch;
+              sensors_data.eulerangle.data[f].values[2] = yaw;
+            }
+          }
+          else if (BIASCalculationIterator == BIASCalculationIterations)
+          {
+            gx1_bias /= BIASCalculationIterations;
+            gy1_bias /= BIASCalculationIterations;
+            gz1_bias /= BIASCalculationIterations;
+            gx2_bias /= BIASCalculationIterations;
+            gy2_bias /= BIASCalculationIterations;
+            gz2_bias /= BIASCalculationIterations;
+            ax1_bias /= BIASCalculationIterations;
+            ay1_bias /= BIASCalculationIterations;
+            az1_bias /= BIASCalculationIterations;
+            ax2_bias /= BIASCalculationIterations;
+            ay2_bias /= BIASCalculationIterations;
+            az2_bias /= BIASCalculationIterations;
+
+            // The calibration-time accel mean *is* gravity expressed in the
+            // body frame at rest — it's the signal, not a bias to subtract.
+            // Seed each filter's quaternion from it, then null out the accel
+            // bias so the runtime path stops subtracting a phantom offset.
+            g_filter[0].initFromAccel(ax1_bias, ay1_bias, az1_bias);
+            g_filter[1].initFromAccel(ax2_bias, ay2_bias, az2_bias);
+            ax1_bias = ay1_bias = az1_bias = 0.0f;
+            ax2_bias = ay2_bias = az2_bias = 0.0f;
+
+            g_last_ts_ms[0] = 0;
+            g_last_ts_ms[1] = 0;
+
+            ++BIASCalculationIterator;
+          }
+          else if (BIASCalculationIterator < BIASCalculationIterations)
+          {
+            gx1_bias += fingers.finger[0].gyroscope[0] * gRes;
+            gy1_bias += fingers.finger[0].gyroscope[1] * gRes;
+            gz1_bias += fingers.finger[0].gyroscope[2] * gRes;
+            gx2_bias += fingers.finger[1].gyroscope[0] * gRes;
+            gy2_bias += fingers.finger[1].gyroscope[1] * gRes;
+            gz2_bias += fingers.finger[1].gyroscope[2] * gRes;
+            ax1_bias += fingers.finger[0].accelerometer[0] * aRes;
+            ay1_bias += fingers.finger[0].accelerometer[1] * aRes;
+            az1_bias += fingers.finger[0].accelerometer[2] * aRes;
+            ax2_bias += fingers.finger[1].accelerometer[0] * aRes;
+            ay2_bias += fingers.finger[1].accelerometer[1] * aRes;
+            az2_bias += fingers.finger[1].accelerometer[2] * aRes;
+            BIASCalculationIterator++;
+          }
+
+          if (!StopSensorDataAcquisition)
+          {
+            g_dynamic_pub->publish(sensors_data.dynamic);
+            g_static_pub->publish(sensors_data.staticdata);
+            g_accel_pub->publish(sensors_data.accelerometer);
+            g_gyro_pub->publish(sensors_data.gyroscope);
+            g_timestamp_pub->publish(sensors_data.timestamp);
+
+            if (BIASCalculationIterator > BIASCalculationIterations)
+            {
+              g_euler_pub->publish(sensors_data.eulerangle);
+              g_quat_pub->publish(quaternions);
+            }
+          }
+
+          for (int f = 0; f < FINGER_COUNT; ++f)
+            fingers.finger[f].newDataAvailable = false;
+        }
+      }
+    }
+  }
+
+  send.command = USB_COMMAND_AUTOSEND_SYNC_SENSORS;
+  send.data_length = 1;
+  send.data[0] = 0;
+  usbSend(&USB, &send);
+
+  close(USB);
+  executor.cancel();
+  spin_thread.join();
+
+  rclcpp::shutdown();
+  return 0;
+}
 
 /*****************************************************************************************
 //Function: cmdOptionExists
@@ -611,7 +602,7 @@ int main(int argc, char **argv)
 *****************************************************************************************/
 bool cmdOptionExists(char** begin, char** end, const string& option)
 {
-    return find(begin, end, option) != end;
+  return find(begin, end, option) != end;
 }
 
 /****************************************************************************************
@@ -622,14 +613,14 @@ bool cmdOptionExists(char** begin, char** end, const string& option)
 //              it returns a pointer pointing just after the string that was found.
 //
 ****************************************************************************************/
-char* getCmdOption(char ** begin, char ** end, const string & option)
+char* getCmdOption(char** begin, char** end, const string& option)
 {
-    char ** itr = find(begin, end, option);
-    if (itr != end && ++itr != end)
-    {
-        return *itr;
-    }
-    return 0;
+  char** itr = find(begin, end, option);
+  if (itr != end && ++itr != end)
+  {
+    return *itr;
+  }
+  return 0;
 }
 
 /****************************************************************************************
@@ -653,335 +644,332 @@ char* getCmdOption(char ** begin, char ** end, const string & option)
 //                          case, a timeout loop still need to be coded manually. See the
 //                          Termios documentation for more details.
 ****************************************************************************************/
-bool OpenAndConfigurePort(int *USB, char const * TheDevice)
+bool OpenAndConfigurePort(int* USB, char const* TheDevice)
 {
-    // All written by Jean-Philippe Roberge on April 2015, reviewed by Jean-Philippe Roberge in June 2016
-    /* Open File Descriptor */
-    //            *USB = open( "/tmp/interceptty", O_RDWR| O_NOCTTY ); // For debugging purposes (JP)
-    *USB = open(TheDevice, O_RDWR| O_NOCTTY );
-    /* Error Handling */
-    if ( (*USB) < 0 )
-    {
-        cout << "Error " << errno << " opening " << TheDevice << ": " << strerror (errno) << endl;
-        return false;
-    }
-
-    /**** Configure Port ****/
-    struct termios tty;
-    memset(&tty, 0, sizeof tty);
-    if ( tcgetattr ( (*USB), &tty ) != 0 ) {
-        cout << "Error " << errno << " from tcgetattr: " << strerror(errno) << endl;
-        return false;
-    }
-
-    /* Set Baud Rate */
-    cfsetospeed (&tty, (speed_t)B115200);
-    cfsetispeed (&tty, (speed_t)B115200);
-
-    /* Setting other Port Stuff */
-    tty.c_cflag     &=  ~PARENB;            // Make 8n1
-    tty.c_cflag     &=  ~CSTOPB;
-    tty.c_cflag     &=  ~CSIZE;
-    tty.c_lflag     &=  ~ICANON;            // Remove canonical mode
-    tty.c_cflag     |=  CS8;
-    tty.c_cflag     &=  ~CRTSCTS;           // no flow control
-    tty.c_cc[VMIN]   =  0;        // read doesn't block
-    tty.c_cc[VTIME]  =  0;       // 0.0 seconds read timeout between each byte max
-    tty.c_cflag     |=  CREAD | CLOCAL;     // turn on READ & ignore ctrl lines
-
-    /* Flush Port, then applies attributes */
-    tcflush( (*USB), TCIFLUSH );
-    if ( tcsetattr ( (*USB), TCSANOW, &tty ) != 0) {
-        cout << "Error " << errno << " from tcsetattr" << endl;
-        return false;
-    }
-    return true;
-}
-
-static void usbSend(int *USB, UsbPacket *packet)
-{
-    uint8_t *p = (uint8_t *)packet;
-    int n_written;
-
-    packet->start_byte = USB_PACKET_START_BYTE;
-    packet->crc8 = calcCrc8(p + 2, packet->data_length + 2);
-
-    n_written = write( (*USB), (char *)p, packet->data_length + 4 );
-}
-
-static uint8_t calcCrc8(uint8_t *data, size_t len)
-{
-    // TODO: calculate CRC8
-    return data[-1];
-}
-
-static bool usbReadByte(UsbPacket *packet, unsigned int *readSoFar, uint8_t d)
-{
-    uint8_t *p = (uint8_t *)packet;
-
-    // Make sure start byte is seen
-    if (*readSoFar == 0 && d != USB_PACKET_START_BYTE)
-        return false;
-
-    // Buffer the byte (making sure not to overflow the packet)
-    if (*readSoFar < USB_PACKET_MAX_SIZE)
-        p[*readSoFar] = d;
-    ++*readSoFar;
-
-    // If length is read, stop when done
-    if (*readSoFar > 3 && *readSoFar >= (unsigned)packet->data_length + USB_PACKET_HEADER_SIZE)
-    {
-        *readSoFar = 0;
-
-        // If CRC is ok, we have a new packet!  Return it.
-        if (packet->crc8 == calcCrc8(p + 2, packet->data_length + 2))
-            return true;
-
-        // If CRC is not ok, find the next start byte and shift the packet back in hopes of getting back in sync
-        for (unsigned int i = 1; i < (unsigned)packet->data_length + USB_PACKET_HEADER_SIZE; ++i)
-            if (p[i] == USB_PACKET_START_BYTE)
-            {
-                memmove(p, p + i, packet->data_length + USB_PACKET_HEADER_SIZE - i);
-                *readSoFar = packet->data_length + USB_PACKET_HEADER_SIZE - i;
-                break;
-            }
-    }
-
+  // All written by Jean-Philippe Roberge on April 2015, reviewed by Jean-Philippe Roberge in June 2016
+  /* Open File Descriptor */
+  //            *USB = open( "/tmp/interceptty", O_RDWR| O_NOCTTY ); // For debugging purposes (JP)
+  *USB = open(TheDevice, O_RDWR | O_NOCTTY);
+  /* Error Handling */
+  if ((*USB) < 0)
+  {
+    cout << "Error " << errno << " opening " << TheDevice << ": " << strerror(errno) << endl;
     return false;
+  }
+
+  /**** Configure Port ****/
+  struct termios tty;
+  memset(&tty, 0, sizeof tty);
+  if (tcgetattr((*USB), &tty) != 0)
+  {
+    cout << "Error " << errno << " from tcgetattr: " << strerror(errno) << endl;
+    return false;
+  }
+
+  /* Set Baud Rate */
+  cfsetospeed(&tty, (speed_t)B115200);
+  cfsetispeed(&tty, (speed_t)B115200);
+
+  /* Setting other Port Stuff */
+  tty.c_cflag &= ~PARENB;  // Make 8n1
+  tty.c_cflag &= ~CSTOPB;
+  tty.c_cflag &= ~CSIZE;
+  tty.c_lflag &= ~ICANON;  // Remove canonical mode
+  tty.c_cflag |= CS8;
+  tty.c_cflag &= ~CRTSCTS;        // no flow control
+  tty.c_cc[VMIN] = 0;             // read doesn't block
+  tty.c_cc[VTIME] = 0;            // 0.0 seconds read timeout between each byte max
+  tty.c_cflag |= CREAD | CLOCAL;  // turn on READ & ignore ctrl lines
+
+  /* Flush Port, then applies attributes */
+  tcflush((*USB), TCIFLUSH);
+  if (tcsetattr((*USB), TCSANOW, &tty) != 0)
+  {
+    cout << "Error " << errno << " from tcsetattr" << endl;
+    return false;
+  }
+  return true;
 }
 
-
-static void parseSensors(UsbPacket *packet, Fingers *fingers)
+static void usbSend(int* USB, UsbPacket* packet)
 {
-    for (unsigned int i = 0; i < packet->data_length;)
+  uint8_t* p = (uint8_t*)packet;
+  int n_written;
+
+  packet->start_byte = USB_PACKET_START_BYTE;
+  packet->crc8 = calcCrc8(p + 2, packet->data_length + 2);
+
+  n_written = write((*USB), (char*)p, packet->data_length + 4);
+}
+
+static uint8_t calcCrc8(uint8_t* data, size_t len)
+{
+  // TODO: calculate CRC8
+  return data[-1];
+}
+
+static bool usbReadByte(UsbPacket* packet, unsigned int* readSoFar, uint8_t d)
+{
+  uint8_t* p = (uint8_t*)packet;
+
+  // Make sure start byte is seen
+  if (*readSoFar == 0 && d != USB_PACKET_START_BYTE)
+    return false;
+
+  // Buffer the byte (making sure not to overflow the packet)
+  if (*readSoFar < USB_PACKET_MAX_SIZE)
+    p[*readSoFar] = d;
+  ++*readSoFar;
+
+  // If length is read, stop when done
+  if (*readSoFar > 3 && *readSoFar >= (unsigned)packet->data_length + USB_PACKET_HEADER_SIZE)
+  {
+    *readSoFar = 0;
+
+    // If CRC is ok, we have a new packet!  Return it.
+    if (packet->crc8 == calcCrc8(p + 2, packet->data_length + 2))
+      return true;
+
+    // If CRC is not ok, find the next start byte and shift the packet back in hopes of getting back in sync
+    for (unsigned int i = 1; i < (unsigned)packet->data_length + USB_PACKET_HEADER_SIZE; ++i)
+      if (p[i] == USB_PACKET_START_BYTE)
+      {
+        memmove(p, p + i, packet->data_length + USB_PACKET_HEADER_SIZE - i);
+        *readSoFar = packet->data_length + USB_PACKET_HEADER_SIZE - i;
+        break;
+      }
+  }
+
+  return false;
+}
+
+static void parseSensors(UsbPacket* packet, Fingers* fingers)
+{
+  for (unsigned int i = 0; i < packet->data_length;)
+  {
+    uint8_t sensorType = packet->data[i] & 0xF0;
+    uint8_t f = packet->data[i] >> 2 & 0x03;
+    ++i;
+
+    if (f >= FINGER_COUNT)
+      continue;
+
+    uint8_t* sensorData = packet->data + i;
+    unsigned int sensorDataBytes = packet->data_length - i;
+
+    switch (sensorType)
     {
-        uint8_t sensorType = packet->data[i] & 0xF0;
-        uint8_t f= packet->data[i] >> 2 & 0x03;
-        ++i;
-
-        if (f >= FINGER_COUNT)
-            continue;
-
-        uint8_t *sensorData = packet->data + i;
-        unsigned int sensorDataBytes = packet->data_length - i;
-
-        switch (sensorType)
-        {
-        case USB_SENSOR_TYPE_DYNAMIC_TACTILE:
-            i += extractUint16((uint16_t *)fingers->finger[f].dynamicTactile, FINGER_DYNAMIC_TACTILE_COUNT, sensorData, sensorDataBytes);
-            fingers->finger[f].newDataAvailable = true;
-            break;
-        case USB_SENSOR_TYPE_STATIC_TACTILE:
-            i += extractUint16(fingers->finger[f].staticTactile, FINGER_STATIC_TACTILE_COUNT, sensorData, sensorDataBytes);
-            fingers->finger[f].newDataAvailable = true;
-            break;
-        case USB_SENSOR_TYPE_ACCELEROMETER:
-            i += extractUint16((uint16_t *)fingers->finger[f].accelerometer, 3, sensorData, sensorDataBytes);
-            fingers->finger[f].newDataAvailable = true;
-            break;
-        case USB_SENSOR_TYPE_GYROSCOPE:
-            i += extractUint16((uint16_t *)fingers->finger[f].gyroscope, 3, sensorData, sensorDataBytes);
-            fingers->finger[f].newDataAvailable = true;
-            break;
-        case USB_SENSOR_TYPE_TEMPERATURE:
-            i += extractUint16((uint16_t *)&fingers->finger[f].temperature, 1, sensorData, sensorDataBytes);
-            fingers->finger[f].newDataAvailable = true;
-            break;
-        case USB_SENSOR_TYPE_TIMESTAMP:
-            i += extractUint64(&fingers->finger[f].timestamp, 1, sensorData, sensorDataBytes);
-            fingers->finger[f].newDataAvailable = true;
-            break;
-        default:
-            // Unknown sensor type — skip the marker byte and keep parsing so
-            // forward-compatible additions don't kill the rest of the packet.
-            break;
-        }
+      case USB_SENSOR_TYPE_DYNAMIC_TACTILE:
+        i += extractUint16((uint16_t*)fingers->finger[f].dynamicTactile, FINGER_DYNAMIC_TACTILE_COUNT, sensorData,
+                           sensorDataBytes);
+        fingers->finger[f].newDataAvailable = true;
+        break;
+      case USB_SENSOR_TYPE_STATIC_TACTILE:
+        i += extractUint16(fingers->finger[f].staticTactile, FINGER_STATIC_TACTILE_COUNT, sensorData, sensorDataBytes);
+        fingers->finger[f].newDataAvailable = true;
+        break;
+      case USB_SENSOR_TYPE_ACCELEROMETER:
+        i += extractUint16((uint16_t*)fingers->finger[f].accelerometer, 3, sensorData, sensorDataBytes);
+        fingers->finger[f].newDataAvailable = true;
+        break;
+      case USB_SENSOR_TYPE_GYROSCOPE:
+        i += extractUint16((uint16_t*)fingers->finger[f].gyroscope, 3, sensorData, sensorDataBytes);
+        fingers->finger[f].newDataAvailable = true;
+        break;
+      case USB_SENSOR_TYPE_TEMPERATURE:
+        i += extractUint16((uint16_t*)&fingers->finger[f].temperature, 1, sensorData, sensorDataBytes);
+        fingers->finger[f].newDataAvailable = true;
+        break;
+      case USB_SENSOR_TYPE_TIMESTAMP:
+        i += extractUint64(&fingers->finger[f].timestamp, 1, sensorData, sensorDataBytes);
+        fingers->finger[f].newDataAvailable = true;
+        break;
+      default:
+        // Unknown sensor type — skip the marker byte and keep parsing so
+        // forward-compatible additions don't kill the rest of the packet.
+        break;
     }
+  }
 }
 
-static inline uint16_t parseBigEndian2(uint8_t *data)
+static inline uint16_t parseBigEndian2(uint8_t* data)
 {
-    return (uint16_t)data[0] << 8 | data[1];
+  return (uint16_t)data[0] << 8 | data[1];
 }
 
-static inline uint64_t parseBigEndian8(uint8_t *data)
+static inline uint64_t parseBigEndian8(uint8_t* data)
 {
-    return  (uint64_t)data[0] << 56 | (uint64_t)data[1] << 48
-          | (uint64_t)data[2] << 40 | (uint64_t)data[3] << 32
-          | (uint64_t)data[4] << 24 | (uint64_t)data[5] << 16
-          | (uint64_t)data[6] << 8  | (uint64_t)data[7];
+  return (uint64_t)data[0] << 56 | (uint64_t)data[1] << 48 | (uint64_t)data[2] << 40 | (uint64_t)data[3] << 32 |
+         (uint64_t)data[4] << 24 | (uint64_t)data[5] << 16 | (uint64_t)data[6] << 8 | (uint64_t)data[7];
 }
 
-static uint8_t extractUint16(uint16_t *to, uint16_t toCount, uint8_t *data, unsigned int size)
+static uint8_t extractUint16(uint16_t* to, uint16_t toCount, uint8_t* data, unsigned int size)
 {
-    unsigned int cur;
+  unsigned int cur;
 
-    // Extract 16-bit values.  If not enough data, extract as much data as available
-    for (cur = 0; 2 * cur + 1 < size && cur < toCount; ++cur)
-        to[cur] = parseBigEndian2(&data[2 * cur]);
+  // Extract 16-bit values.  If not enough data, extract as much data as available
+  for (cur = 0; 2 * cur + 1 < size && cur < toCount; ++cur)
+    to[cur] = parseBigEndian2(&data[2 * cur]);
 
-    // Return number of bytes read
-    return cur * 2;
+  // Return number of bytes read
+  return cur * 2;
 }
 
-static unsigned int extractUint64(uint64_t *to, unsigned int toCount, uint8_t *data, unsigned int size)
+static unsigned int extractUint64(uint64_t* to, unsigned int toCount, uint8_t* data, unsigned int size)
 {
-    unsigned int cur;
+  unsigned int cur;
 
-    for (cur = 0; 8 * cur + 7 < size && cur < toCount; ++cur)
-        to[cur] = parseBigEndian8(&data[8 * cur]);
+  for (cur = 0; 8 * cur + 7 < size && cur < toCount; ++cur)
+    to[cur] = parseBigEndian8(&data[8 * cur]);
 
-    return cur * 8;
+  return cur * 8;
 }
 
-static void forceReconnectSensor(int *USB)
+static void forceReconnectSensor(int* USB)
 {
-    if (USB == nullptr || *USB < 0)
-    {
-        return;
-    }
+  if (USB == nullptr || *USB < 0)
+  {
+    return;
+  }
 
-    RCLCPP_INFO(NODE_LOGGER, "Forcing tactile sensor reconnect sequence");
+  RCLCPP_INFO(NODE_LOGGER, "Forcing tactile sensor reconnect sequence");
 
 #ifdef TIOCM_DTR
-    int modem_bits = 0;
-    if (ioctl(*USB, TIOCMGET, &modem_bits) == -1)
+  int modem_bits = 0;
+  if (ioctl(*USB, TIOCMGET, &modem_bits) == -1)
+  {
+    RCLCPP_WARN(NODE_LOGGER, "Failed to read modem bits for %d: %s", *USB, strerror(errno));
+  }
+  else
+  {
+    int cleared = modem_bits & ~TIOCM_DTR;
+    if (ioctl(*USB, TIOCMSET, &cleared) == -1)
     {
-        RCLCPP_WARN(NODE_LOGGER, "Failed to read modem bits for %d: %s", *USB, strerror(errno));
+      RCLCPP_WARN(NODE_LOGGER, "Failed to clear DTR on %d: %s", *USB, strerror(errno));
     }
-    else
-    {
-        int cleared = modem_bits & ~TIOCM_DTR;
-        if (ioctl(*USB, TIOCMSET, &cleared) == -1)
-        {
-            RCLCPP_WARN(NODE_LOGGER, "Failed to clear DTR on %d: %s", *USB, strerror(errno));
-        }
-        usleep(100000);
+    usleep(100000);
 
-        int set_bits = cleared | TIOCM_DTR;
-        if (ioctl(*USB, TIOCMSET, &set_bits) == -1)
-        {
-            RCLCPP_WARN(NODE_LOGGER, "Failed to set DTR on %d: %s", *USB, strerror(errno));
-        }
-        usleep(100000);
+    int set_bits = cleared | TIOCM_DTR;
+    if (ioctl(*USB, TIOCMSET, &set_bits) == -1)
+    {
+      RCLCPP_WARN(NODE_LOGGER, "Failed to set DTR on %d: %s", *USB, strerror(errno));
     }
+    usleep(100000);
+  }
 #endif
 
-    UsbPacket stop_packet{};
-    stop_packet.command = USB_COMMAND_AUTOSEND_SYNC_SENSORS;
-    stop_packet.data_length = 1;
-    stop_packet.data[0] = 0;
-    usbSend(USB, &stop_packet);
+  UsbPacket stop_packet{};
+  stop_packet.command = USB_COMMAND_AUTOSEND_SYNC_SENSORS;
+  stop_packet.data_length = 1;
+  stop_packet.data[0] = 0;
+  usbSend(USB, &stop_packet);
 
-    tcflush(*USB, TCIOFLUSH);
-    usleep(100000);
+  tcflush(*USB, TCIOFLUSH);
+  usleep(100000);
 }
 
-static std::string trimWhitespace(const std::string &value)
+static std::string trimWhitespace(const std::string& value)
 {
-    const auto start = value.find_first_not_of(" \t\r\n");
-    if (start == std::string::npos)
-    {
-        return std::string();
-    }
-    const auto end = value.find_last_not_of(" \t\r\n");
-    return value.substr(start, end - start + 1);
+  const auto start = value.find_first_not_of(" \t\r\n");
+  if (start == std::string::npos)
+  {
+    return std::string();
+  }
+  const auto end = value.find_last_not_of(" \t\r\n");
+  return value.substr(start, end - start + 1);
 }
 
-static bool matchesKnownUsbString(const std::string &value)
+static bool matchesKnownUsbString(const std::string& value)
 {
-    if (value.empty())
-    {
-        return false;
-    }
-
-    static const char *kKnownStrings[] = {
-        "CoRo Tactile Sensor",
-        "Cypress USB UART"
-    };
-
-    for (const char *expected : kKnownStrings)
-    {
-        if (strcasecmp(value.c_str(), expected) == 0)
-        {
-            return true;
-        }
-    }
+  if (value.empty())
+  {
     return false;
+  }
+
+  static const char* kKnownStrings[] = { "CoRo Tactile Sensor", "Cypress USB UART" };
+
+  for (const char* expected : kKnownStrings)
+  {
+    if (strcasecmp(value.c_str(), expected) == 0)
+    {
+      return true;
+    }
+  }
+  return false;
 }
 
-static bool readSysfsEntry(const std::string &path, std::string &value)
+static bool readSysfsEntry(const std::string& path, std::string& value)
 {
-    std::ifstream file(path.c_str());
-    if (!file.is_open())
-    {
-        return false;
-    }
-    std::string line;
-    std::getline(file, line);
-    value = trimWhitespace(line);
-    return !value.empty();
-}
-
-static bool deviceMatchesKnownSensor(const std::string &device_path)
-{
-    const auto slash = device_path.find_last_of('/');
-    const std::string dev_name = (slash == std::string::npos) ? device_path : device_path.substr(slash + 1);
-
-    const std::vector<std::string> candidate_files = {
-        std::string("/sys/class/tty/") + dev_name + "/device/../product",
-        std::string("/sys/class/tty/") + dev_name + "/device/product",
-        std::string("/sys/class/tty/") + dev_name + "/device/../manufacturer",
-        std::string("/sys/class/tty/") + dev_name + "/device/manufacturer"
-    };
-
-    for (const auto &file : candidate_files)
-    {
-        std::string entry;
-        if (readSysfsEntry(file, entry) && matchesKnownUsbString(entry))
-        {
-            return true;
-        }
-    }
+  std::ifstream file(path.c_str());
+  if (!file.is_open())
+  {
     return false;
+  }
+  std::string line;
+  std::getline(file, line);
+  value = trimWhitespace(line);
+  return !value.empty();
+}
+
+static bool deviceMatchesKnownSensor(const std::string& device_path)
+{
+  const auto slash = device_path.find_last_of('/');
+  const std::string dev_name = (slash == std::string::npos) ? device_path : device_path.substr(slash + 1);
+
+  const std::vector<std::string> candidate_files = {
+    std::string("/sys/class/tty/") + dev_name + "/device/../product",
+    std::string("/sys/class/tty/") + dev_name + "/device/product",
+    std::string("/sys/class/tty/") + dev_name + "/device/../manufacturer",
+    std::string("/sys/class/tty/") + dev_name + "/device/manufacturer"
+  };
+
+  for (const auto& file : candidate_files)
+  {
+    std::string entry;
+    if (readSysfsEntry(file, entry) && matchesKnownUsbString(entry))
+    {
+      return true;
+    }
+  }
+  return false;
 }
 
 static std::string autoDetectSensorDevice()
 {
-    // Prefer udev symlinks created by sensor_install.sh
+  // Prefer udev symlinks created by sensor_install.sh
+  {
+    glob_t glob_result{};
+    const int glob_ret = glob("/dev/rq_tsf85_*", 0, nullptr, &glob_result);
+    if (glob_ret == 0 && glob_result.gl_pathc > 0)
     {
-        glob_t glob_result{};
-        const int glob_ret = glob("/dev/rq_tsf85_*", 0, nullptr, &glob_result);
-        if (glob_ret == 0 && glob_result.gl_pathc > 0)
-        {
-            std::string found = glob_result.gl_pathv[0];
-            globfree(&glob_result);
-            return found;
-        }
-        globfree(&glob_result);
+      std::string found = glob_result.gl_pathv[0];
+      globfree(&glob_result);
+      return found;
+    }
+    globfree(&glob_result);
+  }
+
+  const char* patterns[] = { "/dev/ttyACM*", "/dev/ttyUSB*" };
+  for (const char* pattern : patterns)
+  {
+    glob_t glob_result{};
+    const int glob_ret = glob(pattern, 0, nullptr, &glob_result);
+    if (glob_ret != 0)
+    {
+      globfree(&glob_result);
+      continue;
     }
 
-    const char *patterns[] = {"/dev/ttyACM*", "/dev/ttyUSB*"};
-    for (const char *pattern : patterns)
+    for (size_t i = 0; i < glob_result.gl_pathc; ++i)
     {
-        glob_t glob_result{};
-        const int glob_ret = glob(pattern, 0, nullptr, &glob_result);
-        if (glob_ret != 0)
-        {
-            globfree(&glob_result);
-            continue;
-        }
-
-        for (size_t i = 0; i < glob_result.gl_pathc; ++i)
-        {
-            const std::string candidate = glob_result.gl_pathv[i];
-            if (deviceMatchesKnownSensor(candidate))
-            {
-                globfree(&glob_result);
-                return candidate;
-            }
-        }
+      const std::string candidate = glob_result.gl_pathv[i];
+      if (deviceMatchesKnownSensor(candidate))
+      {
         globfree(&glob_result);
+        return candidate;
+      }
     }
-    return std::string();
+    globfree(&glob_result);
+  }
+  return std::string();
 }

--- a/robotiq_tsf/src/tactile_total_sum.cpp
+++ b/robotiq_tsf/src/tactile_total_sum.cpp
@@ -27,16 +27,13 @@ public:
     using std::placeholders::_1;
     auto sensor_qos = rclcpp::SensorDataQoS();
     static_subscription_ = create_subscription<msg::StaticData>(
-      "TactileSensor4/StaticData", sensor_qos,
-      std::bind(&TactileTotalSumNode::handle_static_data, this, _1));
+        "TactileSensor4/StaticData", sensor_qos, std::bind(&TactileTotalSumNode::handle_static_data, this, _1));
 
     force_subscription_ = create_subscription<std_msgs::msg::Float64>(
-      "force_gauge_reading", sensor_qos,
-      std::bind(&TactileTotalSumNode::handle_force_reading, this, _1));
+        "force_gauge_reading", sensor_qos, std::bind(&TactileTotalSumNode::handle_force_reading, this, _1));
 
-    timer_ = create_wall_timer(
-      std::chrono::milliseconds(16),
-      std::bind(&TactileTotalSumNode::publish_diagnostics, this));
+    timer_ =
+        create_wall_timer(std::chrono::milliseconds(16), std::bind(&TactileTotalSumNode::publish_diagnostics, this));
 
     tactile_bias_sums_[0].assign(kTaxelCount, 0.0);
     tactile_bias_sums_[1].assign(kTaxelCount, 0.0);
@@ -45,37 +42,40 @@ public:
     tactile_real_values_[0].assign(kTaxelCount, 0.0);
     tactile_real_values_[1].assign(kTaxelCount, 0.0);
 
-    RCLCPP_INFO(get_logger(),
-                "Tactile sensors initialization started (%zu samples required).",
-                kInitializationSamples);
+    RCLCPP_INFO(get_logger(), "Tactile sensors initialization started (%zu samples required).", kInitializationSamples);
   }
 
 private:
   void handle_static_data(const msg::StaticData::SharedPtr msg)
   {
-    if (msg->taxels.size() < 2) {
-      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000,
-                           "Static message did not contain two sensor arrays.");
+    if (msg->taxels.size() < 2)
+    {
+      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000, "Static message did not contain two sensor arrays.");
       return;
     }
 
-    if (!initialization_complete_) {
-      for (size_t sensor_idx = 0; sensor_idx < 2; ++sensor_idx) {
-        for (size_t taxel_idx = 0; taxel_idx < msg->taxels[sensor_idx].values.size(); ++taxel_idx) {
-          tactile_bias_sums_[sensor_idx][taxel_idx] +=
-            static_cast<double>(msg->taxels[sensor_idx].values[taxel_idx]);
+    if (!initialization_complete_)
+    {
+      for (size_t sensor_idx = 0; sensor_idx < 2; ++sensor_idx)
+      {
+        for (size_t taxel_idx = 0; taxel_idx < msg->taxels[sensor_idx].values.size(); ++taxel_idx)
+        {
+          tactile_bias_sums_[sensor_idx][taxel_idx] += static_cast<double>(msg->taxels[sensor_idx].values[taxel_idx]);
         }
       }
       ++initialization_samples_;
-      if (initialization_samples_ >= kInitializationSamples) {
+      if (initialization_samples_ >= kInitializationSamples)
+      {
         finalize_biases();
       }
       return;
     }
 
-    for (size_t sensor_idx = 0; sensor_idx < 2; ++sensor_idx) {
+    for (size_t sensor_idx = 0; sensor_idx < 2; ++sensor_idx)
+    {
       tactile_sum_[sensor_idx] = 0.0;
-      for (size_t taxel_idx = 0; taxel_idx < msg->taxels[sensor_idx].values.size(); ++taxel_idx) {
+      for (size_t taxel_idx = 0; taxel_idx < msg->taxels[sensor_idx].values.size(); ++taxel_idx)
+      {
         const double raw_value = static_cast<double>(msg->taxels[sensor_idx].values[taxel_idx]);
         const double corrected = raw_value - tactile_bias_[sensor_idx][taxel_idx];
         tactile_real_values_[sensor_idx][taxel_idx] = corrected;
@@ -93,19 +93,19 @@ private:
     force_gauge_ = msg->data;
   }
 
-  std::size_t find_largest_taxel(const std::vector<double> & taxels) const
+  std::size_t find_largest_taxel(const std::vector<double>& taxels) const
   {
-    return static_cast<std::size_t>(
-      std::max_element(taxels.begin(), taxels.end()) - taxels.begin());
+    return static_cast<std::size_t>(std::max_element(taxels.begin(), taxels.end()) - taxels.begin());
   }
 
   void finalize_biases()
   {
-    for (size_t sensor_idx = 0; sensor_idx < 2; ++sensor_idx) {
-      for (size_t taxel_idx = 0; taxel_idx < tactile_bias_sums_[sensor_idx].size(); ++taxel_idx) {
+    for (size_t sensor_idx = 0; sensor_idx < 2; ++sensor_idx)
+    {
+      for (size_t taxel_idx = 0; taxel_idx < tactile_bias_sums_[sensor_idx].size(); ++taxel_idx)
+      {
         tactile_bias_[sensor_idx][taxel_idx] =
-          tactile_bias_sums_[sensor_idx][taxel_idx] /
-          static_cast<double>(kInitializationSamples);
+            tactile_bias_sums_[sensor_idx][taxel_idx] / static_cast<double>(kInitializationSamples);
       }
     }
     initialization_complete_ = true;
@@ -114,20 +114,16 @@ private:
 
   void publish_diagnostics()
   {
-    if (!initialization_complete_ || !new_data_available_) {
+    if (!initialization_complete_ || !new_data_available_)
+    {
       return;
     }
     new_data_available_ = false;
 
     RCLCPP_INFO_THROTTLE(get_logger(), *get_clock(), 500,
-                         "Force %.2f | S1 taxel[%zu]=%.2f sum=%.2f | S2 taxel[%zu]=%.2f sum=%.2f",
-                         force_gauge_,
-                         largest_taxel_idx_[0],
-                         tactile_real_values_[0][largest_taxel_idx_[0]],
-                         tactile_sum_[0],
-                         largest_taxel_idx_[1],
-                         tactile_real_values_[1][largest_taxel_idx_[1]],
-                         tactile_sum_[1]);
+                         "Force %.2f | S1 taxel[%zu]=%.2f sum=%.2f | S2 taxel[%zu]=%.2f sum=%.2f", force_gauge_,
+                         largest_taxel_idx_[0], tactile_real_values_[0][largest_taxel_idx_[0]], tactile_sum_[0],
+                         largest_taxel_idx_[1], tactile_real_values_[1][largest_taxel_idx_[1]], tactile_sum_[1]);
   }
 
   rclcpp::Subscription<msg::StaticData>::SharedPtr static_subscription_;
@@ -137,18 +133,18 @@ private:
   std::array<std::vector<double>, 2> tactile_bias_sums_;
   std::array<std::vector<double>, 2> tactile_bias_;
   std::array<std::vector<double>, 2> tactile_real_values_;
-  std::array<double, 2> tactile_sum_ {0.0, 0.0};
-  std::array<std::size_t, 2> largest_taxel_idx_ {0, 0};
+  std::array<double, 2> tactile_sum_{ 0.0, 0.0 };
+  std::array<std::size_t, 2> largest_taxel_idx_{ 0, 0 };
 
-  std::size_t initialization_samples_ {0};
-  bool initialization_complete_ {false};
-  bool new_data_available_ {false};
-  double force_gauge_ {0.0};
+  std::size_t initialization_samples_{ 0 };
+  bool initialization_complete_{ false };
+  bool new_data_available_{ false };
+  double force_gauge_{ 0.0 };
 };
 
 }  // namespace robotiq_tsf
 
-int main(int argc, char ** argv)
+int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
   rclcpp::spin(std::make_shared<robotiq_tsf::TactileTotalSumNode>());

--- a/robotiq_tsf/test/gtest_main.cpp
+++ b/robotiq_tsf/test/gtest_main.cpp
@@ -2,7 +2,8 @@
 
 #include <gtest/gtest.h>
 
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/robotiq_tsf/test/test_madgwick_ahrs.cpp
+++ b/robotiq_tsf/test/test_madgwick_ahrs.cpp
@@ -10,7 +10,8 @@
 
 #include <cmath>
 
-namespace {
+namespace
+{
 
 constexpr float kPi = 3.14159265358979f;
 constexpr float kDegToRad = kPi / 180.0f;
@@ -32,197 +33,207 @@ constexpr float kTrackingTolDeg = 3.0f;
 // a no-op, so anything beyond float dust is a gating failure.
 constexpr float kGateLeakTolDeg = 0.1f;
 
-struct EulerAngles {
-    float roll;
-    float pitch;
-    float yaw;
+struct EulerAngles
+{
+  float roll;
+  float pitch;
+  float yaw;
 };
 
-EulerAngles eulerDegOf(const float q[4]) {
-    EulerAngles e;
-    quatToEulerDeg(q, e.roll, e.pitch, e.yaw);
-    return e;
+EulerAngles eulerDegOf(const float q[4])
+{
+  EulerAngles e;
+  quatToEulerDeg(q, e.roll, e.pitch, e.yaw);
+  return e;
 }
 
-EulerAngles eulerDegOf(const MadgwickFilter &f) {
-    EulerAngles e;
-    f.getEulerDeg(e.roll, e.pitch, e.yaw);
-    return e;
+EulerAngles eulerDegOf(const MadgwickFilter& f)
+{
+  EulerAngles e;
+  f.getEulerDeg(e.roll, e.pitch, e.yaw);
+  return e;
 }
 
-float maxAbsDeg(const EulerAngles &e) {
-    return std::max(std::fabs(e.roll), std::max(std::fabs(e.pitch), std::fabs(e.yaw)));
+float maxAbsDeg(const EulerAngles& e)
+{
+  return std::max(std::fabs(e.roll), std::max(std::fabs(e.pitch), std::fabs(e.yaw)));
 }
 
-::testing::AssertionResult eulerNear(const EulerAngles &actual,
-                                     const EulerAngles &expected,
-                                     float tol_deg) {
-    if (std::fabs(actual.roll - expected.roll) <= tol_deg &&
-        std::fabs(actual.pitch - expected.pitch) <= tol_deg &&
-        std::fabs(actual.yaw - expected.yaw) <= tol_deg) {
-        return ::testing::AssertionSuccess();
-    }
-    return ::testing::AssertionFailure()
-           << "(roll, pitch, yaw) = (" << actual.roll << ", " << actual.pitch
-           << ", " << actual.yaw << ") deg, expected (" << expected.roll << ", "
-           << expected.pitch << ", " << expected.yaw << ") deg +/- " << tol_deg;
+::testing::AssertionResult eulerNear(const EulerAngles& actual, const EulerAngles& expected, float tol_deg)
+{
+  if (std::fabs(actual.roll - expected.roll) <= tol_deg && std::fabs(actual.pitch - expected.pitch) <= tol_deg &&
+      std::fabs(actual.yaw - expected.yaw) <= tol_deg)
+  {
+    return ::testing::AssertionSuccess();
+  }
+  return ::testing::AssertionFailure() << "(roll, pitch, yaw) = (" << actual.roll << ", " << actual.pitch << ", "
+                                       << actual.yaw << ") deg, expected (" << expected.roll << ", " << expected.pitch
+                                       << ", " << expected.yaw << ") deg +/- " << tol_deg;
 }
 
-TEST(QuatHelpers, EulerFromSingleAxisQuaternions) {
-    constexpr float kRollDeg = 30.0f;
-    constexpr float kPitchDeg = 45.0f;
-    constexpr float kYawDeg = -60.0f;
+TEST(QuatHelpers, EulerFromSingleAxisQuaternions)
+{
+  constexpr float kRollDeg = 30.0f;
+  constexpr float kPitchDeg = 45.0f;
+  constexpr float kYawDeg = -60.0f;
 
-    float q[4];
+  float q[4];
 
-    quatFromAxisX(kRollDeg * kDegToRad, q);
-    EXPECT_TRUE(eulerNear(eulerDegOf(q), {kRollDeg, 0.0f, 0.0f}, kExactTolDeg));
+  quatFromAxisX(kRollDeg * kDegToRad, q);
+  EXPECT_TRUE(eulerNear(eulerDegOf(q), { kRollDeg, 0.0f, 0.0f }, kExactTolDeg));
 
-    quatFromAxisY(kPitchDeg * kDegToRad, q);
-    EXPECT_TRUE(eulerNear(eulerDegOf(q), {0.0f, kPitchDeg, 0.0f}, kExactTolDeg));
+  quatFromAxisY(kPitchDeg * kDegToRad, q);
+  EXPECT_TRUE(eulerNear(eulerDegOf(q), { 0.0f, kPitchDeg, 0.0f }, kExactTolDeg));
 
-    quatFromAxisZ(kYawDeg * kDegToRad, q);
-    EXPECT_TRUE(eulerNear(eulerDegOf(q), {0.0f, 0.0f, kYawDeg}, kExactTolDeg));
+  quatFromAxisZ(kYawDeg * kDegToRad, q);
+  EXPECT_TRUE(eulerNear(eulerDegOf(q), { 0.0f, 0.0f, kYawDeg }, kExactTolDeg));
 }
 
-TEST(QuatHelpers, EulerFromComposedZyxRotation) {
-    // ZYX Tait-Bryan: q = qz(yaw) * qy(pitch) * qx(roll) must decompose back
-    // into the same three angles.
-    constexpr float kRollDeg = 10.0f;
-    constexpr float kPitchDeg = 20.0f;
-    constexpr float kYawDeg = 30.0f;
+TEST(QuatHelpers, EulerFromComposedZyxRotation)
+{
+  // ZYX Tait-Bryan: q = qz(yaw) * qy(pitch) * qx(roll) must decompose back
+  // into the same three angles.
+  constexpr float kRollDeg = 10.0f;
+  constexpr float kPitchDeg = 20.0f;
+  constexpr float kYawDeg = 30.0f;
 
-    float qx[4], qy[4], qz[4], tmp[4], q[4];
-    quatFromAxisX(kRollDeg * kDegToRad, qx);
-    quatFromAxisY(kPitchDeg * kDegToRad, qy);
-    quatFromAxisZ(kYawDeg * kDegToRad, qz);
-    quatMul(qz, qy, tmp);
-    quatMul(tmp, qx, q);
+  float qx[4], qy[4], qz[4], tmp[4], q[4];
+  quatFromAxisX(kRollDeg * kDegToRad, qx);
+  quatFromAxisY(kPitchDeg * kDegToRad, qy);
+  quatFromAxisZ(kYawDeg * kDegToRad, qz);
+  quatMul(qz, qy, tmp);
+  quatMul(tmp, qx, q);
 
-    EXPECT_TRUE(eulerNear(eulerDegOf(q), {kRollDeg, kPitchDeg, kYawDeg}, kExactTolDeg));
+  EXPECT_TRUE(eulerNear(eulerDegOf(q), { kRollDeg, kPitchDeg, kYawDeg }, kExactTolDeg));
 }
 
-TEST(QuatHelpers, MulByConjugateGivesRelativeRotation) {
-    // Zeroing as done for relative orientation: q_rel = conj(q_ref) * q.
-    constexpr float kRefRollDeg = 30.0f;
-    constexpr float kCurRollDeg = 50.0f;
-    constexpr float kRelRollDeg = kCurRollDeg - kRefRollDeg;
+TEST(QuatHelpers, MulByConjugateGivesRelativeRotation)
+{
+  // Zeroing as done for relative orientation: q_rel = conj(q_ref) * q.
+  constexpr float kRefRollDeg = 30.0f;
+  constexpr float kCurRollDeg = 50.0f;
+  constexpr float kRelRollDeg = kCurRollDeg - kRefRollDeg;
 
-    float q_ref[4], q_cur[4], q_ref_conj[4], q_rel[4];
-    quatFromAxisX(kRefRollDeg * kDegToRad, q_ref);
-    quatFromAxisX(kCurRollDeg * kDegToRad, q_cur);
-    quatConj(q_ref, q_ref_conj);
-    quatMul(q_ref_conj, q_cur, q_rel);
+  float q_ref[4], q_cur[4], q_ref_conj[4], q_rel[4];
+  quatFromAxisX(kRefRollDeg * kDegToRad, q_ref);
+  quatFromAxisX(kCurRollDeg * kDegToRad, q_cur);
+  quatConj(q_ref, q_ref_conj);
+  quatMul(q_ref_conj, q_cur, q_rel);
 
-    EXPECT_TRUE(eulerNear(eulerDegOf(q_rel), {kRelRollDeg, 0.0f, 0.0f}, kExactTolDeg));
+  EXPECT_TRUE(eulerNear(eulerDegOf(q_rel), { kRelRollDeg, 0.0f, 0.0f }, kExactTolDeg));
 
-    // Self-relative must be identity.
-    quatConj(q_cur, q_ref_conj);
-    quatMul(q_ref_conj, q_cur, q_rel);
-    EXPECT_NEAR(q_rel[0], 1.0f, kQuatTol);
-    EXPECT_NEAR(q_rel[1], 0.0f, kQuatTol);
-    EXPECT_NEAR(q_rel[2], 0.0f, kQuatTol);
-    EXPECT_NEAR(q_rel[3], 0.0f, kQuatTol);
+  // Self-relative must be identity.
+  quatConj(q_cur, q_ref_conj);
+  quatMul(q_ref_conj, q_cur, q_rel);
+  EXPECT_NEAR(q_rel[0], 1.0f, kQuatTol);
+  EXPECT_NEAR(q_rel[1], 0.0f, kQuatTol);
+  EXPECT_NEAR(q_rel[2], 0.0f, kQuatTol);
+  EXPECT_NEAR(q_rel[3], 0.0f, kQuatTol);
 }
 
-TEST(QuatHelpers, NormalizeScalesToUnitAndHandlesZero) {
-    float q[4] = {2.0f, 0.0f, 0.0f, 0.0f};
-    quatNormalize(q);
-    EXPECT_NEAR(q[0], 1.0f, kQuatTol);
+TEST(QuatHelpers, NormalizeScalesToUnitAndHandlesZero)
+{
+  float q[4] = { 2.0f, 0.0f, 0.0f, 0.0f };
+  quatNormalize(q);
+  EXPECT_NEAR(q[0], 1.0f, kQuatTol);
 
-    float z[4] = {0.0f, 0.0f, 0.0f, 0.0f};
-    quatNormalize(z);  // must not produce NaN/inf
-    EXPECT_TRUE(std::isfinite(z[0]) && std::isfinite(z[1]) &&
-                std::isfinite(z[2]) && std::isfinite(z[3]));
+  float z[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+  quatNormalize(z);  // must not produce NaN/inf
+  EXPECT_TRUE(std::isfinite(z[0]) && std::isfinite(z[1]) && std::isfinite(z[2]) && std::isfinite(z[3]));
 }
 
-TEST(MadgwickFilter, InitFromAccelMatchesTilt) {
-    constexpr float kRollDeg = 30.0f;
-    constexpr float kPitchDeg = 20.0f;
-    constexpr float g = 9.81f;  // m/s^2
+TEST(MadgwickFilter, InitFromAccelMatchesTilt)
+{
+  constexpr float kRollDeg = 30.0f;
+  constexpr float kPitchDeg = 20.0f;
+  constexpr float g = 9.81f;  // m/s^2
 
-    MadgwickFilter f;
+  MadgwickFilter f;
 
-    // Flat: gravity along body +Z.
-    f.initFromAccel(0.0f, 0.0f, 1.0f);
-    EXPECT_TRUE(eulerNear(eulerDegOf(f), {0.0f, 0.0f, 0.0f}, kExactTolDeg));
+  // Flat: gravity along body +Z.
+  f.initFromAccel(0.0f, 0.0f, 1.0f);
+  EXPECT_TRUE(eulerNear(eulerDegOf(f), { 0.0f, 0.0f, 0.0f }, kExactTolDeg));
 
-    // Pure roll: gravity_body = (0, sin r, cos r). Units must not matter,
-    // so feed m/s^2 rather than g.
-    f.initFromAccel(0.0f, g * std::sin(kRollDeg * kDegToRad),
-                    g * std::cos(kRollDeg * kDegToRad));
-    EXPECT_TRUE(eulerNear(eulerDegOf(f), {kRollDeg, 0.0f, 0.0f}, kExactTolDeg));
+  // Pure roll: gravity_body = (0, sin r, cos r). Units must not matter,
+  // so feed m/s^2 rather than g.
+  f.initFromAccel(0.0f, g * std::sin(kRollDeg * kDegToRad), g * std::cos(kRollDeg * kDegToRad));
+  EXPECT_TRUE(eulerNear(eulerDegOf(f), { kRollDeg, 0.0f, 0.0f }, kExactTolDeg));
 
-    // Pure pitch: gravity_body = (-sin p, 0, cos p).
-    f.initFromAccel(-std::sin(kPitchDeg * kDegToRad), 0.0f,
-                    std::cos(kPitchDeg * kDegToRad));
-    EXPECT_TRUE(eulerNear(eulerDegOf(f), {0.0f, kPitchDeg, 0.0f}, kExactTolDeg));
+  // Pure pitch: gravity_body = (-sin p, 0, cos p).
+  f.initFromAccel(-std::sin(kPitchDeg * kDegToRad), 0.0f, std::cos(kPitchDeg * kDegToRad));
+  EXPECT_TRUE(eulerNear(eulerDegOf(f), { 0.0f, kPitchDeg, 0.0f }, kExactTolDeg));
 }
 
-TEST(MadgwickFilter, InitFromZeroAccelResetsToIdentity) {
-    MadgwickFilter f;
-    f.initFromAccel(0.0f, 1.0f, 0.0f);  // some non-identity state first
-    f.initFromAccel(0.0f, 0.0f, 0.0f);
-    float q0, q1, q2, q3;
-    f.getQuaternion(q0, q1, q2, q3);
-    EXPECT_NEAR(q0, 1.0f, kQuatTol);
-    EXPECT_NEAR(q1, 0.0f, kQuatTol);
-    EXPECT_NEAR(q2, 0.0f, kQuatTol);
-    EXPECT_NEAR(q3, 0.0f, kQuatTol);
+TEST(MadgwickFilter, InitFromZeroAccelResetsToIdentity)
+{
+  MadgwickFilter f;
+  f.initFromAccel(0.0f, 1.0f, 0.0f);  // some non-identity state first
+  f.initFromAccel(0.0f, 0.0f, 0.0f);
+  float q0, q1, q2, q3;
+  f.getQuaternion(q0, q1, q2, q3);
+  EXPECT_NEAR(q0, 1.0f, kQuatTol);
+  EXPECT_NEAR(q1, 0.0f, kQuatTol);
+  EXPECT_NEAR(q2, 0.0f, kQuatTol);
+  EXPECT_NEAR(q3, 0.0f, kQuatTol);
 }
 
-TEST(MadgwickFilter, NonPositiveDtIsIgnored) {
-    MadgwickFilter f;
-    f.initFromAccel(0.0f, 0.0f, 1.0f);
-    float before[4], after[4];
-    f.getQuaternion(before[0], before[1], before[2], before[3]);
-    f.updateIMU(1.0f, 2.0f, 3.0f, 0.0f, 0.0f, 1.0f, 0.0f);
-    f.updateIMU(1.0f, 2.0f, 3.0f, 0.0f, 0.0f, 1.0f, -0.01f);
-    f.getQuaternion(after[0], after[1], after[2], after[3]);
-    for (int i = 0; i < 4; ++i) EXPECT_EQ(before[i], after[i]);
+TEST(MadgwickFilter, NonPositiveDtIsIgnored)
+{
+  MadgwickFilter f;
+  f.initFromAccel(0.0f, 0.0f, 1.0f);
+  float before[4], after[4];
+  f.getQuaternion(before[0], before[1], before[2], before[3]);
+  f.updateIMU(1.0f, 2.0f, 3.0f, 0.0f, 0.0f, 1.0f, 0.0f);
+  f.updateIMU(1.0f, 2.0f, 3.0f, 0.0f, 0.0f, 1.0f, -0.01f);
+  f.getQuaternion(after[0], after[1], after[2], after[3]);
+  for (int i = 0; i < 4; ++i)
+    EXPECT_EQ(before[i], after[i]);
 }
 
-TEST(MadgwickFilter, TracksRotationWithMeasuredDt) {
-    // 90 deg/s roll for 1 s, sampled at 200 Hz. Accel stays consistent with
-    // the true attitude (pure tilt, |a| = 1 g), gyro is exact. The legacy
-    // filter integrated every sample as 1/1000 s regardless of the real rate,
-    // so it tracked this rotation ~5x too slow — the "drift" in PR #5.
-    constexpr float kRateDegS = 90.0f;
-    constexpr float kDt = 0.005f;
-    constexpr int kSteps = 200;
-    constexpr float kExpectedRollDeg = kRateDegS * kDt * kSteps;
+TEST(MadgwickFilter, TracksRotationWithMeasuredDt)
+{
+  // 90 deg/s roll for 1 s, sampled at 200 Hz. Accel stays consistent with
+  // the true attitude (pure tilt, |a| = 1 g), gyro is exact. The legacy
+  // filter integrated every sample as 1/1000 s regardless of the real rate,
+  // so it tracked this rotation ~5x too slow — the "drift" in PR #5.
+  constexpr float kRateDegS = 90.0f;
+  constexpr float kDt = 0.005f;
+  constexpr int kSteps = 200;
+  constexpr float kExpectedRollDeg = kRateDegS * kDt * kSteps;
 
-    MadgwickFilter f;
-    f.initFromAccel(0.0f, 0.0f, 1.0f);
-    for (int i = 0; i < kSteps; ++i) {
-        const float rollTrue = kRateDegS * kDt * static_cast<float>(i) * kDegToRad;
-        f.updateIMU(kRateDegS * kDegToRad, 0.0f, 0.0f,
-                    0.0f, std::sin(rollTrue), std::cos(rollTrue), kDt);
-    }
-    EXPECT_TRUE(eulerNear(eulerDegOf(f), {kExpectedRollDeg, 0.0f, 0.0f}, kTrackingTolDeg));
+  MadgwickFilter f;
+  f.initFromAccel(0.0f, 0.0f, 1.0f);
+  for (int i = 0; i < kSteps; ++i)
+  {
+    const float rollTrue = kRateDegS * kDt * static_cast<float>(i) * kDegToRad;
+    f.updateIMU(kRateDegS * kDegToRad, 0.0f, 0.0f, 0.0f, std::sin(rollTrue), std::cos(rollTrue), kDt);
+  }
+  EXPECT_TRUE(eulerNear(eulerDegOf(f), { kExpectedRollDeg, 0.0f, 0.0f }, kTrackingTolDeg));
 }
 
-TEST(MadgwickFilter, AccelGateRejectsMotionBursts) {
-    // Stationary sensor, zero rotation, but a sustained linear-acceleration
-    // burst (|a| ~ 1.35 g). The legacy filter treated the burst as a tilted
-    // gravity vector and walked the attitude away — the "noisy in transition"
-    // in PR #5. Accel feedback outside [0.85, 1.15] g must be gated, so the
-    // attitude must not move at all.
-    constexpr float kDt = 0.005f;
-    constexpr int kBurstSteps = 1000;  // 5 s of burst at 200 Hz
-    // gravity (1 g on Z) + 0.9 g lateral -> |a| ~ 1.35 g, outside the accel gate
-    constexpr float kBurstLateralG = 0.9f;
+TEST(MadgwickFilter, AccelGateRejectsMotionBursts)
+{
+  // Stationary sensor, zero rotation, but a sustained linear-acceleration
+  // burst (|a| ~ 1.35 g). The legacy filter treated the burst as a tilted
+  // gravity vector and walked the attitude away — the "noisy in transition"
+  // in PR #5. Accel feedback outside [0.85, 1.15] g must be gated, so the
+  // attitude must not move at all.
+  constexpr float kDt = 0.005f;
+  constexpr int kBurstSteps = 1000;  // 5 s of burst at 200 Hz
+  // gravity (1 g on Z) + 0.9 g lateral -> |a| ~ 1.35 g, outside the accel gate
+  constexpr float kBurstLateralG = 0.9f;
 
-    MadgwickFilter f;
-    f.initFromAccel(0.0f, 0.0f, 1.0f);
+  MadgwickFilter f;
+  f.initFromAccel(0.0f, 0.0f, 1.0f);
 
-    float peakDeg = 0.0f;
-    for (int i = 0; i < kBurstSteps; ++i) {
-        f.updateIMU(0.0f, 0.0f, 0.0f, kBurstLateralG, 0.0f, 1.0f, kDt);
-        peakDeg = std::max(peakDeg, maxAbsDeg(eulerDegOf(f)));
-    }
+  float peakDeg = 0.0f;
+  for (int i = 0; i < kBurstSteps; ++i)
+  {
+    f.updateIMU(0.0f, 0.0f, 0.0f, kBurstLateralG, 0.0f, 1.0f, kDt);
+    peakDeg = std::max(peakDeg, maxAbsDeg(eulerDegOf(f)));
+  }
 
-    EXPECT_LT(peakDeg, kGateLeakTolDeg);
+  EXPECT_LT(peakDeg, kGateLeakTolDeg);
 }
 
 }  // namespace


### PR DESCRIPTION
## What

Brings the `robotiq_tsf` package under clang-format enforcement, matching the monorepo/`grippers` Google-based style, and reflows the existing code to conform. Motivated by [#17](https://github.com/robotiq/ros/pull/17) review feedback: `robotiq_tsf` had **no** format enforcement (the existing `ci-format.yml` covered `grippers/**` only), so new C++ was landing unformatted.

## Commits (review in order)

1. **build** — add `robotiq_tsf/.clang-format` (verbatim copy of `grippers/.clang-format`), `robotiq_tsf/.pre-commit-config.yaml` (clang-format hook pinned to **v19.1.1**, matching the clang-format-19 the Robotiq C++ conventions mandate), and a `robotiq_tsf` job in `ci-format.yml`.
2. **style** — mechanical `clang-format-19 -i` reflow of all 8 C/C++ files. **Layout-only**: verified that every file is byte-identical to `main` after stripping whitespace (zero token changes). Passes `clang-format --dry-run --Werror`.
3. **chore** — `.git-blame-ignore-revs` pointing at the reflow commit so `git blame` skips the sweep (GitHub honors this automatically).

## Style

The monorepo style (2-space indent, Allman braces) differs from how `robotiq_tsf` was written (4-space, attached braces), so the reflow diff is large but purely cosmetic — best reviewed with **Hide whitespace** on, or by trusting commit 2's whitespace-strip check.

## Follow-up for PR #17

Once this merges, [#17](https://github.com/robotiq/ros/pull/17) (and its base `tactile-sdk-poller`) should rebase onto `main`; the new CI job will then require its Eigen-migration files to be clang-formatted. Expect conflicts in the AHRS files (both this reflow and #17 edit them heavily) — resolve by taking #17's content and running `clang-format-19 -i`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)