### PR TITLE
feat: grippers sdk integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,13 @@
 .git
-# Ignore everything under extern EXCEPT the tactile_sensors SDK, which the
-# image builds into robotiq_tsf's poll_data_sdk_node. (Re-including a nested
-# path requires un-ignoring each parent dir.)
+# Ignore everything under extern EXCEPT the two SDKs the image builds:
+# tactile_sensors (robotiq_tsf's poll_data_sdk_node) and grippers (the gripper
+# SDK). Copying the checkouts rather than re-cloning them means uncommitted
+# local SDK changes compile in the image. (Re-including a nested path requires
+# un-ignoring each parent dir.)
 extern/*
 !extern/tactile_sensors
 extern/tactile_sensors/*
 !extern/tactile_sensors/sdk_cpp
+!extern/grippers
+extern/grippers/*
+!extern/grippers/sdk_cpp

--- a/.github/workflows/ci-ros-build-test.yml
+++ b/.github/workflows/ci-ros-build-test.yml
@@ -33,8 +33,9 @@ jobs:
       # ros-base is minimal: it lacks git (needed by actions/checkout) and the
       # colcon coverage plugins that action-ros-ci invokes by default
       # (colcon lcov-result / coveragepy-result). Install them up front.
-      # libserialport-dev: the SDK's serial backend — no rosdep rule exists for
-      # the bare `libserialport` key, so install it directly and skip the key.
+      # libserialport-dev: the serial backend of both SDKs — no rosdep rule
+      # exists for the bare `libserialport` key, so install it directly and
+      # skip the key.
       - name: Install tooling missing from ros-base
         run: |
           apt-get update
@@ -42,8 +43,8 @@ jobs:
             python3-colcon-lcov-result python3-colcon-coveragepy-result
       - uses: actions/checkout@v5
         with:
-          # poll_data_sdk_node compiles the tactile_sensors SDK from the
-          # extern/ submodule.
+          # Both SDKs are compiled from source out of extern/: tactile_sensors
+          # by robotiq_tsf's poll_data_sdk_node, grippers by robotiq_driver.
           submodules: true
       # action-ros-ci runs git against the checkout as root inside the container;
       # mark it safe to avoid git's "dubious ownership" error.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "extern/tactile_sensors"]
 	path = extern/tactile_sensors
 	url = https://github.com/Robotiq/tactile_sensors.git
+[submodule "extern/grippers"]
+	path = extern/grippers
+	url = https://github.com/Robotiq/grippers.git

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ rm -rf ros2_robotiq_gripper        # remove the PickNik clone to prevent duplica
 git clone --recurse-submodules https://github.com/robotiq/ros.git
 vcs import < ros/grippers/ros2_robotiq_gripper.rolling.repos   # same external `serial` dep as before
 cd ~/ws
-rosdep install --from-paths src --ignore-src -y
+sudo apt install libserialport-dev # the gripper SDK's serial backend; no rosdep key exists for it
+rosdep install --from-paths src --ignore-src -y --skip-keys libserialport
 rm -rf build install               # clear artifacts built from the PickNik sources
 colcon build
 ```
@@ -236,12 +237,11 @@ Two SDKs live under `extern/` as submodules and are built into the image:
 | Submodule | Repository | Used by |
 |---|---|---|
 | `extern/tactile_sensors` | [Robotiq/tactile_sensors](https://github.com/Robotiq/tactile_sensors) | `robotiq_tsf`'s `poll_data_sdk_node` |
-| `extern/grippers` | [Robotiq/grippers](https://github.com/Robotiq/grippers) | the gripper C++ SDK |
+| `extern/grippers` | [Robotiq/grippers](https://github.com/Robotiq/grippers) | `robotiq_driver` |
 
 `extern/COLCON_IGNORE` keeps colcon from building either SDK's standalone
 CMake project as a workspace package; the packages that need them compile them
 in-tree.
-
 
 | Script | Description |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -231,6 +231,18 @@ If you already cloned without `--recurse-submodules`:
 git submodule update --init
 ```
 
+Two SDKs live under `extern/` as submodules and are built into the image:
+
+| Submodule | Repository | Used by |
+|---|---|---|
+| `extern/tactile_sensors` | [Robotiq/tactile_sensors](https://github.com/Robotiq/tactile_sensors) | `robotiq_tsf`'s `poll_data_sdk_node` |
+| `extern/grippers` | [Robotiq/grippers](https://github.com/Robotiq/grippers) | the gripper C++ SDK |
+
+`extern/COLCON_IGNORE` keeps colcon from building either SDK's standalone
+CMake project as a workspace package; the packages that need them compile them
+in-tree.
+
+
 | Script | Description |
 |---|---|
 | `run.sh` | Builds a single ROS 2 Jazzy image with the **whole workspace** (sensor + grippers) and launches a shell with that product's devices mapped: `./run.sh [gripper\|sensor\|both]`. |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,7 @@
 # Multi-stage ROS 2 image for the whole robotiq ros workspace:
 #   - robotiq_tsf   (TSF-85 tactile sensor driver)
 #   - grippers/*    (Robotiq gripper driver, forked from PickNik)
+#   - extern/*      (the tactile-sensor and gripper SDK submodules)
 #
 # Stage 1 (builder): full toolchain, compiles the workspace.
 # Stage 2 (runtime, default): slim — only runtime deps + the built install/, no
@@ -41,6 +42,11 @@ COPY grippers    /ws/src/grippers
 # from building the SDK's own standalone CMakeLists as a separate package.
 COPY extern/tactile_sensors/sdk_cpp /ws/src/extern/tactile_sensors/sdk_cpp
 RUN touch /ws/src/extern/tactile_sensors/sdk_cpp/COLCON_IGNORE
+# Gripper SDK (robotiq/grippers), same arrangement: COPYing the submodule
+# checkout instead of cloning it means local, still-uncommitted SDK work
+# compiles here too.
+COPY extern/grippers/sdk_cpp /ws/src/extern/grippers/sdk_cpp
+RUN touch /ws/src/extern/grippers/sdk_cpp/COLCON_IGNORE
 
 # Gripper's external `serial` dep (tylerjw/serial), via the upstream .repos file.
 RUN cd /ws/src && vcs import < grippers/ros2_robotiq_gripper.rolling.repos

--- a/grippers/robotiq_driver/CMakeLists.txt
+++ b/grippers/robotiq_driver/CMakeLists.txt
@@ -26,6 +26,34 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   serial
 )
 
+###############################################################################
+# GRIPPER SDK
+
+# The Modbus transport, the typed register blocks and the Robotiq::Gripper
+# runtime API live in the extern/grippers submodule. Nothing links against it
+# yet — the hardware interface still runs the in-tree driver — but the build
+# wiring and the adapters below land first so the switch is a diff about
+# behaviour and nothing else.
+#
+# EXCLUDE_FROM_ALL skips the SDK's own install/export rules: it is compiled
+# into robotiq_driver, not shipped as a second installed package.
+set(GRIPPERS_SDK_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../extern/grippers/sdk_cpp")
+if(NOT EXISTS "${GRIPPERS_SDK_DIR}/CMakeLists.txt")
+  message(FATAL_ERROR
+    "The gripper SDK is missing from ${GRIPPERS_SDK_DIR}. "
+    "Run `git submodule update --init extern/grippers` at the repository root.")
+endif()
+# The SDK declares its library without STATIC or SHARED, so it follows
+# BUILD_SHARED_LIBS. Nothing installs it, so a shared one would leave the
+# plugin needing a library that does not ship. Pinned for this subtree only;
+# the enclosing project keeps its own setting.
+set(BUILD_SHARED_LIBS OFF)
+add_subdirectory(${GRIPPERS_SDK_DIR} ${CMAKE_CURRENT_BINARY_DIR}/grippers_sdk EXCLUDE_FROM_ALL)
+unset(BUILD_SHARED_LIBS)
+# A static archive going into a shared plugin has to be position-independent.
+set_target_properties(grippers_sdk PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+###############################################################################
 # Robotiq driver library.
 
 add_library(
@@ -41,7 +69,10 @@ add_library(
   include/robotiq_driver/driver.hpp
   include/robotiq_driver/driver_exception.hpp
   include/robotiq_driver/driver_factory.hpp
+  include/robotiq_driver/gripper_scaling.hpp
   include/robotiq_driver/hardware_interface.hpp
+  include/robotiq_driver/hardware_parameters.hpp
+  include/robotiq_driver/rclcpp_logger.hpp
   include/robotiq_driver/serial.hpp
   include/robotiq_driver/serial_factory.hpp
   include/robotiq_driver/visibility_control.hpp
@@ -53,12 +84,18 @@ add_library(
   src/fake/fake_driver.cpp
   src/default_serial.cpp
   src/default_serial_factory.cpp
+  src/hardware_parameters.cpp
+  src/rclcpp_logger.cpp
 )
 target_link_libraries(robotiq_driver atomic)
 target_include_directories(
   robotiq_driver
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  # The SDK's headers are part of this package's public API: the adapters here
+  # take Robotiq types, so downstream compilations have to see them too. They
+  # are installed next to ours below, hence the single install interface.
+  $<BUILD_INTERFACE:${GRIPPERS_SDK_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
 target_link_libraries(
@@ -68,6 +105,13 @@ target_link_libraries(
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
   serial::serial
+  # $<BUILD_INTERFACE:...> keeps the statically-linked SDK out of the installed
+  # export set, where there would be no target for it to resolve to.
+  # WHOLE_ARCHIVE (CMake 3.24+, satisfied from Jazzy's 24.04 on) because the
+  # SDK's headers ship with this package: a consumer may call any SDK entry
+  # point, so every SDK object has to land in the library — not just the
+  # ones the wrapper itself references.
+  $<BUILD_INTERFACE:$<LINK_LIBRARY:WHOLE_ARCHIVE,Robotiq::grippers>>
 )
 
 ###############################################################################
@@ -111,6 +155,14 @@ install(
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}          # include
 )
 
+# The SDK headers ship alongside ours: they are reachable from this package's
+# public headers, so a consumer including them needs these too.
+install(
+    DIRECTORY ${GRIPPERS_SDK_DIR}/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}          # include
+    FILES_MATCHING PATTERN "*.hpp"                   # not the SDK's own CMakeLists
+)
+
 # Install our library.
 install(
   TARGETS robotiq_driver
@@ -130,15 +182,5 @@ include(CTest)
 if(BUILD_TESTING)
   add_subdirectory(tests)
 endif()
-
-###############################################################################
-# LINTERS
-
-add_custom_target(format
-    COMMAND clang-format -i `git ls-files *.hpp *.cpp`
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-add_custom_target(tidy
-    COMMAND clang-tidy -p ${CMAKE_BINARY_DIR} `git ls-files *.cpp`
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 ament_package()

--- a/grippers/robotiq_driver/CMakeLists.txt
+++ b/grippers/robotiq_driver/CMakeLists.txt
@@ -30,10 +30,8 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 # GRIPPER SDK
 
 # The Modbus transport, the typed register blocks and the Robotiq::Gripper
-# runtime API live in the extern/grippers submodule. Nothing links against it
-# yet — the hardware interface still runs the in-tree driver — but the build
-# wiring and the adapters below land first so the switch is a diff about
-# behaviour and nothing else.
+# runtime API live in the extern/grippers submodule; the hardware interface
+# below drives the gripper through it.
 #
 # EXCLUDE_FROM_ALL skips the SDK's own install/export rules: it is compiled
 # into robotiq_driver, not shipped as a second installed package.
@@ -45,12 +43,13 @@ if(NOT EXISTS "${GRIPPERS_SDK_DIR}/CMakeLists.txt")
 endif()
 # The SDK declares its library without STATIC or SHARED, so it follows
 # BUILD_SHARED_LIBS. Nothing installs it, so a shared one would leave the
-# plugin needing a library that does not ship. Pinned for this subtree only;
-# the enclosing project keeps its own setting.
+# plugin needing a library that does not ship.
+set(_robotiq_saved_build_shared_libs "${BUILD_SHARED_LIBS}")
 set(BUILD_SHARED_LIBS OFF)
 add_subdirectory(${GRIPPERS_SDK_DIR} ${CMAKE_CURRENT_BINARY_DIR}/grippers_sdk EXCLUDE_FROM_ALL)
-unset(BUILD_SHARED_LIBS)
+set(BUILD_SHARED_LIBS "${_robotiq_saved_build_shared_libs}")
 # A static archive going into a shared plugin has to be position-independent.
+# CMake cannot set properties through the Robotiq::grippers alias.
 set_target_properties(grippers_sdk PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 ###############################################################################
@@ -111,6 +110,11 @@ target_link_libraries(
   # SDK's headers ship with this package: a consumer may call any SDK entry
   # point, so every SDK object has to land in the library — not just the
   # ones the wrapper itself references.
+  #
+  # The consequence to know about: the whole SDK symbol set is exported from a
+  # dlopen'd plugin. A second package in the same process linking the SDK the
+  # same way gets its own copy with independent static state, and Robotiq::Gripper
+  # owns a serial link and a thread. One SDK consumer per process.
   $<BUILD_INTERFACE:$<LINK_LIBRARY:WHOLE_ARCHIVE,Robotiq::grippers>>
 )
 
@@ -157,6 +161,10 @@ install(
 
 # The SDK headers ship alongside ours: they are reachable from this package's
 # public headers, so a consumer including them needs these too.
+#
+# The pattern assumes the SDK is .hpp-only, which it is today. Anything else it
+# starts shipping — a C shim, a generated config header — would be dropped here
+# and fail at a downstream consumer's include, not in this build.
 install(
     DIRECTORY ${GRIPPERS_SDK_DIR}/include/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}          # include

--- a/grippers/robotiq_driver/include/robotiq_driver/gripper_scaling.hpp
+++ b/grippers/robotiq_driver/include/robotiq_driver/gripper_scaling.hpp
@@ -38,6 +38,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <limits>
 #include <optional>
 
 namespace robotiq_driver {
@@ -77,18 +78,18 @@ inline constexpr uint8_t kGripperRange = kGripperMaxPos - kGripperMinPos;
    return static_cast<uint8_t>(std::clamp(counts, 0.0, 255.0));
 }
 
-//! An SI speed or force command -> its 0x00..0xFF register (rSP / rFR),
-//! as the fraction of \p maximum it represents. Sign is ignored: the
-//! registers set a magnitude, direction comes from the position request.
-//! Truncates, as above. Nothing when the fraction cannot be computed —
-//! either side non-finite, or a \p maximum that is not positive.
+//! An SI speed or force command -> its 0x00..0xFF register (rSP / rFR), as the
+//! fraction of \p maximum it represents. Truncates, as above. Nothing unless
+//! both sides are in range: \p value from zero up, \p maximum above it. The
+//! range excludes NaN and infinity, which no comparison admits.
 [[nodiscard]] inline std::optional<uint8_t> registerFromFractionOf(double value, double maximum)
 {
-   if(!std::isfinite(value) || !std::isfinite(maximum) || maximum <= 0.0)
+   constexpr double kLargest = std::numeric_limits<double>::max();
+   const bool in_range = value >= 0.0 && value <= kLargest && maximum > 0.0 && maximum <= kLargest;
+   if(!in_range)
    {
       return std::nullopt;
    }
-   const double fraction = std::clamp(std::fabs(value) / maximum, 0.0, 1.0);
-   return static_cast<uint8_t>(fraction * 0xFF);
+   return static_cast<uint8_t>(std::min(value / maximum, 1.0) * 0xFF);
 }
 } // namespace robotiq_driver

--- a/grippers/robotiq_driver/include/robotiq_driver/gripper_scaling.hpp
+++ b/grippers/robotiq_driver/include/robotiq_driver/gripper_scaling.hpp
@@ -38,6 +38,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <optional>
 
 namespace robotiq_driver {
 
@@ -59,23 +60,34 @@ inline constexpr uint8_t kGripperRange = kGripperMaxPos - kGripperMinPos;
 }
 
 //! Joint position -> register count (rPR), in the same unit as
-//! \p closed_position. Counts outside the byte are clamped; the caller is
-//! responsible for rejecting a NaN command.
+//! \p closed_position. Counts outside the byte are clamped. Nothing when the
+//! arithmetic cannot produce a count — a NaN command, or a
+//! \p closed_position of zero: there is no defensible register value, and
+//! commanding a made-up one moves a gripper that may be holding something.
 //!
 //! Truncates rather than rounds, so a position read off the gripper and
 //! commanded straight back can land one count below where it came from.
-[[nodiscard]] inline uint8_t registerFromJointPosition(double joint_position, double closed_position)
+[[nodiscard]] inline std::optional<uint8_t> registerFromJointPosition(double joint_position, double closed_position)
 {
    const double counts = (joint_position / closed_position) * kGripperRange + kGripperMinPos;
+   if(!std::isfinite(counts))
+   {
+      return std::nullopt;
+   }
    return static_cast<uint8_t>(std::clamp(counts, 0.0, 255.0));
 }
 
 //! An SI speed or force command -> its 0x00..0xFF register (rSP / rFR),
 //! as the fraction of \p maximum it represents. Sign is ignored: the
 //! registers set a magnitude, direction comes from the position request.
-//! Truncates, as above.
-[[nodiscard]] inline uint8_t registerFromFractionOf(double value, double maximum)
+//! Truncates, as above. Nothing when the fraction cannot be computed —
+//! either side non-finite, or a \p maximum that is not positive.
+[[nodiscard]] inline std::optional<uint8_t> registerFromFractionOf(double value, double maximum)
 {
+   if(!std::isfinite(value) || !std::isfinite(maximum) || maximum <= 0.0)
+   {
+      return std::nullopt;
+   }
    const double fraction = std::clamp(std::fabs(value) / maximum, 0.0, 1.0);
    return static_cast<uint8_t>(fraction * 0xFF);
 }

--- a/grippers/robotiq_driver/include/robotiq_driver/gripper_scaling.hpp
+++ b/grippers/robotiq_driver/include/robotiq_driver/gripper_scaling.hpp
@@ -1,0 +1,82 @@
+// Copyright (c) 2022 PickNik, Inc.
+// Copyright (c) 2026 Robotiq, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+//! \brief Conversions between ros2_control's SI joint quantities and the
+//!        gripper's 0..255 register counts.
+//! Pulled out of the hardware interface so the arithmetic — the part that
+//! silently mis-commands a gripper when it is wrong — is unit-testable
+//! without a gripper, a serial port, or a controller manager.
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+namespace robotiq_driver {
+
+// The usable travel band of the 2F fingers in register counts. The gripper
+// reports and accepts 0..255, but the extremes are outside the mechanical
+// range, so the joint mapping is anchored on these two.
+inline constexpr uint8_t kGripperMinPos = 3;
+inline constexpr uint8_t kGripperMaxPos = 230;
+inline constexpr uint8_t kGripperRange = kGripperMaxPos - kGripperMinPos;
+
+//! Register count (gPO: 0 open .. 255 closed) -> joint position, linear over
+//! the usable travel band. \p closed_position is the joint value at a fully
+//! closed gripper and sets the unit: the mapping carries whatever the URDF
+//! uses. The shipped 2F descriptions model the knuckle as a revolute joint,
+//! so there it is radians.
+[[nodiscard]] inline double jointPositionFromRegister(uint8_t position, double closed_position)
+{
+   return closed_position * (position - kGripperMinPos) / kGripperRange;
+}
+
+//! Joint position -> register count (rPR), in the same unit as
+//! \p closed_position. Counts outside the byte are clamped; the caller is
+//! responsible for rejecting a NaN command.
+//!
+//! Truncates rather than rounds, so a position read off the gripper and
+//! commanded straight back can land one count below where it came from.
+[[nodiscard]] inline uint8_t registerFromJointPosition(double joint_position, double closed_position)
+{
+   const double counts = (joint_position / closed_position) * kGripperRange + kGripperMinPos;
+   return static_cast<uint8_t>(std::clamp(counts, 0.0, 255.0));
+}
+
+//! An SI speed or force command -> its 0x00..0xFF register (rSP / rFR),
+//! as the fraction of \p maximum it represents. Sign is ignored: the
+//! registers set a magnitude, direction comes from the position request.
+//! Truncates, as above.
+[[nodiscard]] inline uint8_t registerFromFractionOf(double value, double maximum)
+{
+   const double fraction = std::clamp(std::fabs(value) / maximum, 0.0, 1.0);
+   return static_cast<uint8_t>(fraction * 0xFF);
+}
+} // namespace robotiq_driver

--- a/grippers/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
+++ b/grippers/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
@@ -162,6 +162,10 @@ protected:
    double gripper_velocity_ = 0.0;
    double gripper_position_command_ = 0.0;
 
+   // The last command write() sent. A register the arithmetic cannot produce
+   // this cycle keeps the value it had rather than a made-up one.
+   Robotiq::GripperCommand command_ = Robotiq::GripperCommand::defaults();
+
    double reactivate_gripper_cmd_ = 0.0;
    double reactivate_gripper_response_ = 0.0;
    double gripper_force_ = 0.0;

--- a/grippers/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
+++ b/grippers/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
@@ -56,6 +56,12 @@
 #include <rclcpp/rclcpp.hpp>
 
 namespace robotiq_driver {
+//! ros2_control hardware interface for a Robotiq 2F gripper, driven through the
+//! gripper SDK.
+//! Member order carries an invariant: recovery_ is declared after gripper_ so
+//! that destruction, which runs in reverse, joins the recovery before the
+//! gripper it borrows goes away. Reordering compiles and then misbehaves at
+//! shutdown.
 class RobotiqGripperHardwareInterface : public hardware_interface::SystemInterface
 {
 public:
@@ -93,6 +99,15 @@ public:
     */
    ROBOTIQ_DRIVER_PUBLIC
    CallbackReturn on_cleanup(const rclcpp_lifecycle::State& previous_state) override;
+
+   /**
+    * on_shutdown and on_error have the same behavior as on_cleanup
+    */
+   ROBOTIQ_DRIVER_PUBLIC
+   CallbackReturn on_shutdown(const rclcpp_lifecycle::State& previous_state) override;
+
+   ROBOTIQ_DRIVER_PUBLIC
+   CallbackReturn on_error(const rclcpp_lifecycle::State& previous_state) override;
 
    /**
     * This method exposes position and velocity of joints for reading.

--- a/grippers/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
+++ b/grippers/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2022 PickNik, Inc.
+// Copyright (c) 2026 Robotiq, Inc.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -26,18 +27,25 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+//! \brief ros2_control system interface for Robotiq 2F grippers, wrapping the
+//!        Robotiq gripper SDK.
+//! The SDK owns the serial link and runs its own exchange cycle, keeping a
+//! process image that setCommand()/getStatus() reach without touching the bus.
+//! read() and write() are therefore pure memory operations against that image
+//! and never block the controller manager — this package runs no communication
+//! thread of its own.
+
 #pragma once
 
-#include <atomic>
+#include <future>
 #include <limits>
 #include <memory>
-#include <string>
 #include <vector>
 
+#include <robotiq_driver/hardware_parameters.hpp>
 #include <robotiq_driver/visibility_control.hpp>
 
-#include <robotiq_driver/driver.hpp>
-#include <robotiq_driver/driver_factory.hpp>
+#include <Robotiq/gripper.hpp>
 
 #include <hardware_interface/handle.hpp>
 #include <hardware_interface/hardware_info.hpp>
@@ -53,24 +61,15 @@ class RobotiqGripperHardwareInterface : public hardware_interface::SystemInterfa
 public:
    RCLCPP_SHARED_PTR_DEFINITIONS(RobotiqGripperHardwareInterface)
 
-   /**
-    * Default constructor.
-    */
    ROBOTIQ_DRIVER_PUBLIC
    RobotiqGripperHardwareInterface();
 
    ROBOTIQ_DRIVER_PUBLIC
-   ~RobotiqGripperHardwareInterface();
+   ~RobotiqGripperHardwareInterface() override;
 
    /**
-    * Constructor with a driver factory. This method is used for testing.
-    * @param driver_factory The driver that interact with the hardware.
-    */
-   explicit RobotiqGripperHardwareInterface(std::unique_ptr<DriverFactory> driver_factory);
-
-   /**
-    * Initialization of the hardware interface from data parsed from the
-    * robot's URDF.
+    * Read and validate the hardware parameters and the joint's interfaces.
+    * Performs no I/O — the link is opened in on_configure.
     * @param params Structure with parameters for initializing this hardware component.
     * @returns CallbackReturn::SUCCESS if required data are provided and can be
     * parsed or CallbackReturn::ERROR if any error happens or data are missing.
@@ -79,13 +78,21 @@ public:
    CallbackReturn on_init(const hardware_interface::HardwareComponentInterfaceParams& params) override;
 
    /**
-    * Connect to the hardware.
+    * Open the serial link and start the SDK exchange cycle. Constructing the
+    * gripper reads it once, so a gripper that is unpowered, unplugged or at
+    * another slave address fails here rather than at the first read().
     * @param previous_state The previous state.
-    * @returns CallbackReturn::SUCCESS if required data are provided and can be
-    * parsed or CallbackReturn::ERROR if any error happens or data are missing.
+    * @returns CallbackReturn::SUCCESS or CallbackReturn::ERROR.
     */
    ROBOTIQ_DRIVER_PUBLIC
    CallbackReturn on_configure(const rclcpp_lifecycle::State& previous_state) override;
+
+   /**
+    * Stop the exchange cycle and close the link. The gripper keeps its
+    * activation and its grip.
+    */
+   ROBOTIQ_DRIVER_PUBLIC
+   CallbackReturn on_cleanup(const rclcpp_lifecycle::State& previous_state) override;
 
    /**
     * This method exposes position and velocity of joints for reading.
@@ -100,7 +107,8 @@ public:
    std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
 
    /**
-    * This method is invoked when the hardware is connected.
+    * Reset and activate the gripper, blocking until it reports completion.
+    *
     * @param previous_state Unconfigured, Inactive, Active or Finalized.
     * @returns CallbackReturn::SUCCESS or CallbackReturn::ERROR.
     */
@@ -108,7 +116,6 @@ public:
    CallbackReturn on_activate(const rclcpp_lifecycle::State& previous_state) override;
 
    /**
-    * This method is invoked when the hardware is disconnected.
     * @param previous_state Unconfigured, Inactive, Active or Finalized.
     * @returns CallbackReturn::SUCCESS or CallbackReturn::ERROR.
     */
@@ -128,20 +135,26 @@ public:
    hardware_interface::return_type write(const rclcpp::Time& time, const rclcpp::Duration& period) override;
 
 protected:
-   // Interface to send binary data to the hardware using the serial port.
-   std::unique_ptr<Driver> driver_;
+   /**
+    * @throw Robotiq::SerialIOException, Robotiq::DriverException as the
+    *        Robotiq::Gripper constructor does.
+    */
+   virtual std::unique_ptr<Robotiq::Gripper> create_gripper();
 
-   // Factory to create the driver during the initialization step.
-   std::unique_ptr<DriverFactory> driver_factory_;
+   GripperParameters parameters_;
 
-   // We use a thread to read/write to the driver so that we dont block the hardware_interface read/write.
-   std::thread communication_thread_;
-   std::atomic<bool> communication_thread_is_running_;
-   void background_task();
+   // Log sink handed to the SDK, forwarding its diagnostics to /rosout.
+   std::shared_ptr<Robotiq::Logger> logger_;
 
-   double gripper_closed_pos_ = 0.0;
-   double gripper_max_speed_ = 0.0;
-   double gripper_max_force_ = 0.0;
+   // Owns the serial link and the exchange thread; null until on_configure.
+   std::unique_ptr<Robotiq::Gripper> gripper_;
+
+   // recoverFromFault() blocks for the length of a calibration sweep, so the
+   // reactivate_gripper GPIO runs it off the control loop.
+   // Declared after gripper_ on purpose: destruction runs in reverse, so an
+   // std::async future here is joined before the gripper it borrows is
+   // destroyed.
+   std::future<Robotiq::ActivationResult> recovery_;
 
    static constexpr double NO_NEW_CMD_ = std::numeric_limits<double>::quiet_NaN();
 
@@ -149,17 +162,10 @@ protected:
    double gripper_velocity_ = 0.0;
    double gripper_position_command_ = 0.0;
 
-   std::atomic<uint8_t> write_command_;
-   std::atomic<uint8_t> write_force_;
-   std::atomic<uint8_t> write_speed_;
-   std::atomic<uint8_t> gripper_current_state_;
-
    double reactivate_gripper_cmd_ = 0.0;
-   std::atomic<bool> reactivate_gripper_async_cmd_;
    double reactivate_gripper_response_ = 0.0;
    double gripper_force_ = 0.0;
    double gripper_speed_ = 0.0;
-   std::atomic<std::optional<bool>> reactivate_gripper_async_response_;
 };
 
 } // namespace robotiq_driver

--- a/grippers/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
+++ b/grippers/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
@@ -166,6 +166,10 @@ protected:
    // this cycle keeps the value it had rather than a made-up one.
    Robotiq::GripperCommand command_ = Robotiq::GripperCommand::defaults();
 
+   // Per instance, so one gripper's throttled diagnostics cannot silence
+   // another's in a multi-gripper cell.
+   rclcpp::Clock diagnostic_clock_{RCL_STEADY_TIME};
+
    double reactivate_gripper_cmd_ = 0.0;
    double reactivate_gripper_response_ = 0.0;
    double gripper_force_ = 0.0;

--- a/grippers/robotiq_driver/include/robotiq_driver/hardware_parameters.hpp
+++ b/grippers/robotiq_driver/include/robotiq_driver/hardware_parameters.hpp
@@ -50,7 +50,7 @@ namespace robotiq_driver {
 //! today, but are pinned here on purpose: a description that omits one of
 //! these parameters has to keep getting this value even if the SDK changes
 //! its own.
-inline constexpr auto kComPortDefault = "/dev/ttyUSB0";
+inline constexpr const char* kComPortDefault = "/dev/ttyUSB0";
 inline constexpr uint32_t kBaudrateDefault = 115200;
 inline constexpr auto kTimeoutDefault = std::chrono::milliseconds{500};
 inline constexpr uint8_t kSlaveAddressDefault = 0x09;

--- a/grippers/robotiq_driver/include/robotiq_driver/hardware_parameters.hpp
+++ b/grippers/robotiq_driver/include/robotiq_driver/hardware_parameters.hpp
@@ -1,0 +1,101 @@
+// Copyright (c) 2022 PickNik, Inc.
+// Copyright (c) 2026 Robotiq, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+//! \brief The URDF's <hardware> params, parsed into the SDK's
+//!        Robotiq::ConnectionConfig plus the joint-scaling constants the
+//!        wrapper needs on top of it.
+//! Parsing is a free function over HardwareInfo so it can be tested against a
+//! hand-built parameter map, with no controller manager in the way.
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+
+#include <Robotiq/gripper/connection_config.hpp>
+
+#include <hardware_interface/hardware_info.hpp>
+
+#include <rclcpp/logger.hpp>
+
+namespace robotiq_driver {
+
+//! Defaults for the connection parameters. They match Robotiq::ConnectionConfig
+//! today, but are pinned here on purpose: a description that omits one of
+//! these parameters has to keep getting this value even if the SDK changes
+//! its own.
+inline constexpr auto kComPortDefault = "/dev/ttyUSB0";
+inline constexpr uint32_t kBaudrateDefault = 115200;
+inline constexpr auto kTimeoutDefault = std::chrono::milliseconds{500};
+inline constexpr uint8_t kSlaveAddressDefault = 0x09;
+inline constexpr double kConnectionFrequencyDefault = 100.0;
+
+//! Full scale of the shipped 2F-85, and so the default for
+//! gripper_max_speed / gripper_max_force.
+inline constexpr double kMaxSpeedDefault = 0.150; // m/s
+inline constexpr double kMaxForceDefault = 235.0; // N
+
+struct GripperParameters
+{
+   //! Serial link + Modbus addressing, handed straight to Robotiq::Gripper.
+   Robotiq::ConnectionConfig connection;
+
+   //! Joint angle (rad) at a fully closed gripper — the scale of the
+   //! register-count-to-joint mapping. Model-specific, so it has no default
+   //! here: the URDF must supply it.
+   double closed_position = 0.0;
+
+   //! Full-scale speed and force, used to turn the SI values written to the
+   //! set_gripper_max_velocity / set_gripper_max_effort command interfaces
+   //! into rSP / rFR register fractions.
+   double max_speed = kMaxSpeedDefault;
+   double max_force = kMaxForceDefault;
+
+   //! Initial fractions of the above published on those command interfaces.
+   double speed_multiplier = 1.0;
+   double force_multiplier = 1.0;
+
+   //! Budget for the blocking activation and fault-recovery procedures; the
+   //! calibration sweep dominates it.
+   std::chrono::milliseconds activation_timeout{15000};
+
+   //! Drive a simulated gripper instead of a real one, for testing without
+   //! hardware. The serial settings above are then ignored.
+   bool use_dummy = false;
+};
+
+//! Parse \p info's hardware parameters. Missing parameters keep the defaults
+//! above; malformed ones are reported through \p logger and also keep the
+//! default, so one bad string cannot take the gripper down at startup.
+//! \throw std::out_of_range when gripper_closed_position is absent,
+//!        std::invalid_argument when it does not parse — the one parameter
+//!        with no sane default.
+[[nodiscard]] GripperParameters parseParameters(const hardware_interface::HardwareInfo& info,
+                                                const rclcpp::Logger& logger);
+} // namespace robotiq_driver

--- a/grippers/robotiq_driver/include/robotiq_driver/rclcpp_logger.hpp
+++ b/grippers/robotiq_driver/include/robotiq_driver/rclcpp_logger.hpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Robotiq, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+//! \brief Adapts the SDK's Robotiq::Logger onto an rclcpp logger.
+//! The SDK is deliberately framework-free — it has no rclcpp dependency and
+//! prints to stderr when nobody injects a sink. This adapter lives on the ROS
+//! side of that boundary so SDK diagnostics land in /rosout with the rest of
+//! the node's output, at the matching severity.
+
+#pragma once
+
+#include <string_view>
+
+#include <Robotiq/gripper/logger.hpp>
+
+#include <rclcpp/logger.hpp>
+
+namespace robotiq_driver {
+class RclcppLogger : public Robotiq::Logger
+{
+public:
+   explicit RclcppLogger(rclcpp::Logger logger);
+
+   void log(Level level, std::string_view message) override;
+
+private:
+   rclcpp::Logger logger_;
+};
+} // namespace robotiq_driver

--- a/grippers/robotiq_driver/package.xml
+++ b/grippers/robotiq_driver/package.xml
@@ -19,6 +19,11 @@
   <depend>rclcpp_lifecycle</depend>
   <depend>serial</depend>
 
+  <!-- Serial backend of the gripper SDK compiled in from extern/grippers.
+       No rosdep rule exists for the bare key; installed explicitly in
+       docker/Dockerfile and in CI. -->
+  <depend>libserialport</depend>
+
   <!-- Check code against style conventions using clang-format. -->
   <test_depend>ament_clang_format</test_depend>
   <!-- Check code against style conventions using clang-tidy. -->

--- a/grippers/robotiq_driver/src/hardware_interface.cpp
+++ b/grippers/robotiq_driver/src/hardware_interface.cpp
@@ -81,14 +81,6 @@ bool has_finished(const std::future<Robotiq::ActivationResult>& recovery)
 {
    return recovery.valid() && recovery.wait_for(std::chrono::seconds{0}) == std::future_status::ready;
 }
-
-// The throttled diagnostics below are wall-clock paced and independent of any
-// node, so they use their own clock rather than a lifecycle node's.
-rclcpp::Clock& diagnostic_clock()
-{
-   static rclcpp::Clock clock{RCL_STEADY_TIME};
-   return clock;
-}
 } // namespace
 
 RobotiqGripperHardwareInterface::RobotiqGripperHardwareInterface() = default;
@@ -363,18 +355,20 @@ hardware_interface::return_type RobotiqGripperHardwareInterface::read(const rclc
       connection != Robotiq::ConnectionState::Operational)
    {
       RCLCPP_WARN_THROTTLE(kLogger,
-                           diagnostic_clock(),
+                           diagnostic_clock_,
                            kDiagnosticThrottleMs,
-                           "The Robotiq gripper link is %s; the reported position may be stale.",
+                           "The Robotiq gripper on %s: link is %s; the reported position may be stale.",
+                           parameters_.connection.serial.port.c_str(),
                            to_string(connection));
    }
 
    if(status.faultStatus.gripperFault() != Robotiq::GripperFault::None)
    {
       RCLCPP_WARN_THROTTLE(kLogger,
-                           diagnostic_clock(),
+                           diagnostic_clock_,
                            kDiagnosticThrottleMs,
-                           "The Robotiq gripper reports fault status 0x%02X.",
+                           "The Robotiq gripper on %s reports fault status 0x%02X.",
+                           parameters_.connection.serial.port.c_str(),
                            status.faultStatus.raw());
    }
 
@@ -445,7 +439,7 @@ hardware_interface::return_type RobotiqGripperHardwareInterface::write(const rcl
    if(!position || !speed || !force)
    {
       RCLCPP_ERROR_THROTTLE(kLogger,
-                            diagnostic_clock(),
+                            diagnostic_clock_,
                             kDiagnosticThrottleMs,
                             "Cannot map position %f, speed %f, force %f onto gripper registers with "
                             "gripper_closed_position %f, gripper_max_speed %f, gripper_max_force %f; "

--- a/grippers/robotiq_driver/src/hardware_interface.cpp
+++ b/grippers/robotiq_driver/src/hardware_interface.cpp
@@ -91,7 +91,7 @@ std::unique_ptr<Robotiq::Gripper> RobotiqGripperHardwareInterface::create_grippe
 {
    if(parameters_.use_dummy)
    {
-      RCLCPP_INFO(kLogger, "You are connected to a dummy driver, not a real gripper.");
+      RCLCPP_WARN(kLogger, "You are connected to a dummy driver, not a real gripper.");
       return Robotiq::makeFakeGripper(parameters_.connection, logger_);
    }
    return std::make_unique<Robotiq::Gripper>(parameters_.connection, logger_);

--- a/grippers/robotiq_driver/src/hardware_interface.cpp
+++ b/grippers/robotiq_driver/src/hardware_interface.cpp
@@ -32,6 +32,7 @@
 #include <future>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include <robotiq_driver/gripper_scaling.hpp>
@@ -437,12 +438,31 @@ hardware_interface::return_type RobotiqGripperHardwareInterface::write(const rcl
       return hardware_interface::return_type::OK;
    }
 
-   Robotiq::GripperCommand command = Robotiq::GripperCommand::defaults();
-   command.action.set(Robotiq::ActionRequestBit::GoTo);
-   command.positionRequest = registerFromJointPosition(gripper_position_command_, parameters_.closed_position);
-   command.speed = registerFromFractionOf(gripper_speed_, parameters_.max_speed);
-   command.force = registerFromFractionOf(gripper_force_, parameters_.max_force);
-   gripper_->setCommand(command);
+   const std::optional<uint8_t> position =
+      registerFromJointPosition(gripper_position_command_, parameters_.closed_position);
+   const std::optional<uint8_t> speed = registerFromFractionOf(gripper_speed_, parameters_.max_speed);
+   const std::optional<uint8_t> force = registerFromFractionOf(gripper_force_, parameters_.max_force);
+   if(!position || !speed || !force)
+   {
+      RCLCPP_ERROR_THROTTLE(kLogger,
+                            diagnostic_clock(),
+                            kDiagnosticThrottleMs,
+                            "Cannot map position %f, speed %f, force %f onto gripper registers with "
+                            "gripper_closed_position %f, gripper_max_speed %f, gripper_max_force %f; "
+                            "keeping the previous command.",
+                            gripper_position_command_,
+                            gripper_speed_,
+                            gripper_force_,
+                            parameters_.closed_position,
+                            parameters_.max_speed,
+                            parameters_.max_force);
+   }
+
+   command_.action.set(Robotiq::ActionRequestBit::GoTo);
+   command_.positionRequest = position.value_or(command_.positionRequest);
+   command_.speed = speed.value_or(command_.speed);
+   command_.force = force.value_or(command_.force);
+   gripper_->setCommand(command_);
 
    return hardware_interface::return_type::OK;
 }

--- a/grippers/robotiq_driver/src/hardware_interface.cpp
+++ b/grippers/robotiq_driver/src/hardware_interface.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2022 PickNik, Inc.
+// Copyright (c) 2026 Robotiq, Inc.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -28,12 +29,16 @@
 
 #include <chrono>
 #include <cmath>
+#include <future>
 #include <limits>
 #include <memory>
 #include <vector>
 
-#include <robotiq_driver/default_driver_factory.hpp>
+#include <robotiq_driver/gripper_scaling.hpp>
 #include <robotiq_driver/hardware_interface.hpp>
+#include <robotiq_driver/rclcpp_logger.hpp>
+
+#include <Robotiq/fake/gripper_factory.hpp>
 
 #include <hardware_interface/actuator_interface.hpp>
 #include <hardware_interface/types/hardware_interface_type_values.hpp>
@@ -42,33 +47,61 @@
 
 const auto kLogger = rclcpp::get_logger("RobotiqGripperHardwareInterface");
 
-constexpr uint8_t kGripperMinPos = 3;
-constexpr uint8_t kGripperMaxPos = 230;
-constexpr double kGripperMaxSpeed = 0.150; // mm/s
-constexpr double kGripperMaxforce = 235; // N
-constexpr uint8_t kGripperRange = kGripperMaxPos - kGripperMinPos;
+// Link-health and fault messages would otherwise repeat every control cycle.
+constexpr auto kDiagnosticThrottleMs = 5000;
 
-constexpr auto kGripperCommsLoopPeriod = std::chrono::milliseconds{10};
+// How long on_deactivate waits for the gripper to acknowledge the reset. The
+// exchange cycle sends it within a cycle or two; this only has to outlast a
+// retry or a lost frame.
+constexpr auto kDeactivationTimeout = std::chrono::seconds{2};
 
 namespace robotiq_driver {
-RobotiqGripperHardwareInterface::RobotiqGripperHardwareInterface()
+namespace {
+const char* to_string(Robotiq::ConnectionState state)
 {
-   driver_factory_ = std::make_unique<DefaultDriverFactory>();
-}
-
-RobotiqGripperHardwareInterface::~RobotiqGripperHardwareInterface()
-{
-   communication_thread_is_running_.store(false);
-   if(communication_thread_.joinable())
+   switch(state)
    {
-      communication_thread_.join();
+   case Robotiq::ConnectionState::Disconnected:
+      return "Disconnected";
+   case Robotiq::ConnectionState::Connecting:
+      return "Connecting";
+   case Robotiq::ConnectionState::Operational:
+      return "Operational";
+   case Robotiq::ConnectionState::Faulted:
+      return "Faulted";
    }
+   return "Unknown";
 }
 
-// This constructor is use for testing only.
-RobotiqGripperHardwareInterface::RobotiqGripperHardwareInterface(std::unique_ptr<DriverFactory> driver_factory)
-   : driver_factory_{std::move(driver_factory)}
+// A recovery future stays valid from launch until read() consumes its result,
+// so `valid()` alone answers "is a recovery outstanding"; this answers the
+// narrower "has it finished".
+bool has_finished(const std::future<Robotiq::ActivationResult>& recovery)
 {
+   return recovery.valid() && recovery.wait_for(std::chrono::seconds{0}) == std::future_status::ready;
+}
+
+// The throttled diagnostics below are wall-clock paced and independent of any
+// node, so they use their own clock rather than a lifecycle node's.
+rclcpp::Clock& diagnostic_clock()
+{
+   static rclcpp::Clock clock{RCL_STEADY_TIME};
+   return clock;
+}
+} // namespace
+
+RobotiqGripperHardwareInterface::RobotiqGripperHardwareInterface() = default;
+
+RobotiqGripperHardwareInterface::~RobotiqGripperHardwareInterface() = default;
+
+std::unique_ptr<Robotiq::Gripper> RobotiqGripperHardwareInterface::create_gripper()
+{
+   if(parameters_.use_dummy)
+   {
+      RCLCPP_INFO(kLogger, "You are connected to a dummy driver, not a real gripper.");
+      return Robotiq::makeFakeGripper(parameters_.connection, logger_);
+   }
+   return std::make_unique<Robotiq::Gripper>(parameters_.connection, logger_);
 }
 
 hardware_interface::CallbackReturn RobotiqGripperHardwareInterface::on_init(
@@ -81,19 +114,23 @@ hardware_interface::CallbackReturn RobotiqGripperHardwareInterface::on_init(
       return CallbackReturn::ERROR;
    }
 
-   // Read parameters.
-   gripper_closed_pos_ = stod(info_.hardware_parameters.at("gripper_closed_position"));
-   gripper_max_speed_ = info_.hardware_parameters.count("gripper_max_speed")
-                         ? stod(info_.hardware_parameters.at("gripper_max_speed"))
-                         : kGripperMaxSpeed;
-   gripper_max_force_ = info_.hardware_parameters.count("gripper_max_force")
-                         ? stod(info_.hardware_parameters.at("gripper_max_force"))
-                         : kGripperMaxforce;
+   // The SDK prints to stderr unless a sink is injected; send it to /rosout.
+   logger_ = std::make_shared<RclcppLogger>(rclcpp::get_logger("RobotiqGripperSDK"));
+
+   try
+   {
+      parameters_ = parseParameters(info_, kLogger);
+   }
+   catch(const std::exception& e)
+   {
+      RCLCPP_FATAL(kLogger, "Failed to read the hardware parameters: %s", e.what());
+      return CallbackReturn::ERROR;
+   }
+
    gripper_position_ = std::numeric_limits<double>::quiet_NaN();
    gripper_velocity_ = std::numeric_limits<double>::quiet_NaN();
    gripper_position_command_ = std::numeric_limits<double>::quiet_NaN();
    reactivate_gripper_cmd_ = NO_NEW_CMD_;
-   reactivate_gripper_async_cmd_.store(false);
 
    const hardware_interface::ComponentInfo& joint = info_.joints.at(0);
 
@@ -142,16 +179,6 @@ hardware_interface::CallbackReturn RobotiqGripperHardwareInterface::on_init(
       }
    }
 
-   try
-   {
-      driver_ = driver_factory_->create(info_);
-   }
-   catch(const std::exception& e)
-   {
-      RCLCPP_FATAL(kLogger, "Failed to create a driver: %s", e.what());
-      return CallbackReturn::ERROR;
-   }
-
    return CallbackReturn::SUCCESS;
 }
 
@@ -159,26 +186,44 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Roboti
    const rclcpp_lifecycle::State& previous_state)
 {
    RCLCPP_DEBUG(kLogger, "on_configure");
+
+   if(hardware_interface::SystemInterface::on_configure(previous_state) != CallbackReturn::SUCCESS)
+   {
+      return CallbackReturn::ERROR;
+   }
+
    try
    {
-      if(hardware_interface::SystemInterface::on_configure(previous_state) != CallbackReturn::SUCCESS)
-      {
-         return CallbackReturn::ERROR;
-      }
-
-      // Open the serial port and handshake.
-      bool connected = driver_->connect();
-      if(!connected)
-      {
-         RCLCPP_ERROR(kLogger, "Cannot connect to the Robotiq gripper");
-         return CallbackReturn::ERROR;
-      }
+      gripper_ = create_gripper();
    }
    catch(const std::exception& e)
    {
-      RCLCPP_ERROR(kLogger, "Cannot configure the Robotiq gripper: %s", e.what());
+      RCLCPP_ERROR(kLogger, "Cannot connect to the Robotiq gripper: %s", e.what());
       return CallbackReturn::ERROR;
    }
+
+   RCLCPP_INFO(kLogger,
+               "Connected to the Robotiq gripper on %s at %u bps (slave address 0x%02X), exchanging at %.1f Hz.",
+               parameters_.connection.serial.port.c_str(),
+               parameters_.connection.serial.baudrate,
+               parameters_.connection.modbusSlaveAddress,
+               parameters_.connection.connectionFrequency);
+   return CallbackReturn::SUCCESS;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn RobotiqGripperHardwareInterface::on_cleanup(
+   const rclcpp_lifecycle::State& /*previous_state*/)
+{
+   RCLCPP_DEBUG(kLogger, "on_cleanup");
+
+   // An in-flight recovery borrows the gripper; let it finish first.
+   if(recovery_.valid())
+   {
+      recovery_.wait();
+      recovery_ = {};
+   }
+   gripper_.reset();
+
    return CallbackReturn::SUCCESS;
 }
 
@@ -208,17 +253,14 @@ std::vector<hardware_interface::CommandInterface> RobotiqGripperHardwareInterfac
 
    command_interfaces.emplace_back(
       hardware_interface::CommandInterface(info_.joints[0].name, "set_gripper_max_velocity", &gripper_speed_));
-   gripper_speed_ = kGripperMaxSpeed
-                  * (info_.hardware_parameters.count("gripper_speed_multiplier")
-                        ? std::stod(info_.hardware_parameters.at("gripper_speed_multiplier"))
-                        : 1.0);
+   // Seeded from the shipped full scale, not from parameters_.max_speed /
+   // max_force: a description that lowers those gets a seed above its own
+   // full scale, which write() then clamps to the top register value.
+   gripper_speed_ = kMaxSpeedDefault * parameters_.speed_multiplier;
 
    command_interfaces.emplace_back(
       hardware_interface::CommandInterface(info_.joints[0].name, "set_gripper_max_effort", &gripper_force_));
-   gripper_force_ = kGripperMaxforce
-                  * (info_.hardware_parameters.count("gripper_force_multiplier")
-                        ? std::stod(info_.hardware_parameters.at("gripper_force_multiplier"))
-                        : 1.0);
+   gripper_force_ = kMaxForceDefault * parameters_.force_multiplier;
 
    command_interfaces.emplace_back(
       hardware_interface::CommandInterface("reactivate_gripper", "reactivate_gripper_cmd", &reactivate_gripper_cmd_));
@@ -234,6 +276,12 @@ hardware_interface::CallbackReturn RobotiqGripperHardwareInterface::on_activate(
 {
    RCLCPP_DEBUG(kLogger, "on_activate");
 
+   if(!gripper_)
+   {
+      RCLCPP_FATAL(kLogger, "on_activate reached without a configured gripper.");
+      return CallbackReturn::ERROR;
+   }
+
    // set some default values for joints
    if(std::isnan(gripper_position_))
    {
@@ -242,18 +290,16 @@ hardware_interface::CallbackReturn RobotiqGripperHardwareInterface::on_activate(
       gripper_position_command_ = 0;
    }
 
-   // Activate the gripper.
-   try
+   // recoverFromFault(), not activate(): the manual's reset handshake, which
+   // clears a latched fault and runs the calibration sweep. Activating
+   // therefore releases any grip and sweeps the fingers.
+   const Robotiq::ActivationResult result = Robotiq::recoverFromFault(*gripper_, parameters_.activation_timeout);
+   if(result != Robotiq::ActivationResult::Activated)
    {
-      driver_->deactivate();
-      driver_->activate();
-
-      communication_thread_is_running_.store(true);
-      communication_thread_ = std::thread([this] { this->background_task(); });
-   }
-   catch(const std::exception& e)
-   {
-      RCLCPP_FATAL(kLogger, "Failed to communicate with the Robotiq gripper: %s", e.what());
+      // recoverFromFault() reports only Activated or Timeout.
+      RCLCPP_FATAL(kLogger,
+                   "Failed to communicate with the Robotiq gripper: activation did not complete within %d ms.",
+                   static_cast<int>(parameters_.activation_timeout.count()));
       return CallbackReturn::ERROR;
    }
 
@@ -266,22 +312,31 @@ hardware_interface::CallbackReturn RobotiqGripperHardwareInterface::on_deactivat
 {
    RCLCPP_DEBUG(kLogger, "on_deactivate");
 
-   communication_thread_is_running_.store(false);
-   communication_thread_.join();
-   if(communication_thread_.joinable())
+   // An in-flight GPIO recovery drives rACT itself: resetting over it races
+   // the handshake, which could re-assert rACT after the reset below and
+   // leave the gripper activated. Let it finish first — read() still
+   // reports its result.
+   if(recovery_.valid())
    {
-      communication_thread_.join();
+      recovery_.wait();
    }
 
-   try
+   if(gripper_)
    {
-      driver_->deactivate();
+      // Zeroing the whole command block clears rACT, which resets the
+      // gripper, so it releases any grip.
+      gripper_->setCommand(Robotiq::GripperCommand{});
+
+      // The exchange is asynchronous: without waiting for the gripper to
+      // report the reset, a cleanup following closely can stop the exchange
+      // cycle before the command goes out, leaving the gripper activated.
+      if(!Robotiq::waitFor([this] { return !gripper_->getStatus().gripperStatus.activated(); }, kDeactivationTimeout))
+      {
+         RCLCPP_ERROR(kLogger, "Failed to deactivate the Robotiq gripper: it did not clear its activation bit.");
+         return CallbackReturn::ERROR;
+      }
    }
-   catch(const std::exception& e)
-   {
-      RCLCPP_ERROR(kLogger, "Failed to deactivate the Robotiq gripper: %s", e.what());
-      return CallbackReturn::ERROR;
-   }
+
    RCLCPP_INFO(kLogger, "Robotiq Gripper successfully deactivated!");
    return CallbackReturn::SUCCESS;
 }
@@ -289,19 +344,72 @@ hardware_interface::CallbackReturn RobotiqGripperHardwareInterface::on_deactivat
 hardware_interface::return_type RobotiqGripperHardwareInterface::read(const rclcpp::Time& /*time*/,
                                                                       const rclcpp::Duration& /*period*/)
 {
-   gripper_position_ = gripper_closed_pos_ * (gripper_current_state_.load() - kGripperMinPos) / kGripperRange;
+   if(!gripper_)
+   {
+      return hardware_interface::return_type::ERROR;
+   }
+
+   const Robotiq::GripperStatus status = gripper_->getStatus();
+   gripper_position_ = jointPositionFromRegister(status.position, parameters_.closed_position);
+   // The status block carries no velocity — the gripper reports position and
+   // motor current only.
+   gripper_velocity_ = 0.0;
+
+   // A faulted link recovers by itself on the next successful exchange, so
+   // this warns rather than errors; the position above is the last good
+   // reading until it does.
+   if(const Robotiq::ConnectionState connection = gripper_->connectionState();
+      connection != Robotiq::ConnectionState::Operational)
+   {
+      RCLCPP_WARN_THROTTLE(kLogger,
+                           diagnostic_clock(),
+                           kDiagnosticThrottleMs,
+                           "The Robotiq gripper link is %s; the reported position may be stale.",
+                           to_string(connection));
+   }
+
+   if(status.faultStatus.gripperFault() != Robotiq::GripperFault::None)
+   {
+      RCLCPP_WARN_THROTTLE(kLogger,
+                           diagnostic_clock(),
+                           kDiagnosticThrottleMs,
+                           "The Robotiq gripper reports fault status 0x%02X.",
+                           status.faultStatus.raw());
+   }
 
    if(!std::isnan(reactivate_gripper_cmd_))
    {
-      RCLCPP_INFO(kLogger, "Sending gripper reactivation request.");
-      reactivate_gripper_async_cmd_.store(true);
       reactivate_gripper_cmd_ = NO_NEW_CMD_;
+      if(recovery_.valid())
+      {
+         RCLCPP_WARN(kLogger, "A gripper recovery is already running; ignoring the reactivation request.");
+      }
+      else
+      {
+         RCLCPP_INFO(kLogger,
+                     "Recovering the Robotiq gripper: the reset releases any grip and sweeps the fingers through "
+                     "their full range.");
+         recovery_ = std::async(std::launch::async, [this] {
+            return Robotiq::recoverFromFault(*gripper_, parameters_.activation_timeout);
+         });
+      }
    }
 
-   if(reactivate_gripper_async_response_.load().has_value())
+   if(has_finished(recovery_))
    {
-      reactivate_gripper_response_ = reactivate_gripper_async_response_.load().value();
-      reactivate_gripper_async_response_.store(std::nullopt);
+      const Robotiq::ActivationResult result = recovery_.get();
+      recovery_ = {};
+      if(result == Robotiq::ActivationResult::Activated)
+      {
+         reactivate_gripper_response_ = 1.0;
+         RCLCPP_INFO(kLogger, "The Robotiq gripper recovered and is activated.");
+      }
+      else
+      {
+         // The response interface only ever reports success; a failure leaves
+         // it as it was.
+         RCLCPP_ERROR(kLogger, "The Robotiq gripper failed to recover.");
+      }
    }
 
    return hardware_interface::return_type::OK;
@@ -310,48 +418,33 @@ hardware_interface::return_type RobotiqGripperHardwareInterface::read(const rclc
 hardware_interface::return_type RobotiqGripperHardwareInterface::write(const rclcpp::Time& /*time*/,
                                                                        const rclcpp::Duration& /*period*/)
 {
-   double gripper_pos = (gripper_position_command_ / gripper_closed_pos_) * kGripperRange + kGripperMinPos;
-   gripper_pos = std::max(std::min(gripper_pos, 255.0), 0.0);
-   write_command_.store(uint8_t(gripper_pos));
-   const auto gripper_speed_multiplier = std::clamp(fabs(gripper_speed_) / gripper_max_speed_, 0.0, 1.0);
-   write_speed_.store(uint8_t(gripper_speed_multiplier * 0xFF));
-   const auto gripper_force_multiplier = std::clamp(fabs(gripper_force_) / gripper_max_force_, 0.0, 1.0);
-   write_force_.store(uint8_t(gripper_force_multiplier * 0xFF));
+   if(!gripper_)
+   {
+      return hardware_interface::return_type::ERROR;
+   }
+
+   // The recovery handshake drives rACT itself; commanding over it would
+   // abort the reset half-way through.
+   if(recovery_.valid())
+   {
+      return hardware_interface::return_type::OK;
+   }
+
+   // Before a controller has written a setpoint there is nothing to command,
+   // and a NaN would convert to a garbage register value.
+   if(std::isnan(gripper_position_command_))
+   {
+      return hardware_interface::return_type::OK;
+   }
+
+   Robotiq::GripperCommand command = Robotiq::GripperCommand::defaults();
+   command.action.set(Robotiq::ActionRequestBit::GoTo);
+   command.positionRequest = registerFromJointPosition(gripper_position_command_, parameters_.closed_position);
+   command.speed = registerFromFractionOf(gripper_speed_, parameters_.max_speed);
+   command.force = registerFromFractionOf(gripper_force_, parameters_.max_force);
+   gripper_->setCommand(command);
 
    return hardware_interface::return_type::OK;
-}
-
-void RobotiqGripperHardwareInterface::background_task()
-{
-   while(communication_thread_is_running_.load())
-   {
-      try
-      {
-         // Re-activate the gripper
-         // (this can be used, for example, to re-run the auto-calibration).
-         if(reactivate_gripper_async_cmd_.load())
-         {
-            this->driver_->deactivate();
-            this->driver_->activate();
-            reactivate_gripper_async_cmd_.store(false);
-            reactivate_gripper_async_response_.store(true);
-         }
-
-         // Write the latest command to the gripper.
-         this->driver_->set_gripper_position(write_command_.load());
-         this->driver_->set_speed(write_speed_.load());
-         this->driver_->set_force(write_force_.load());
-
-         // Read the state of the gripper.
-         gripper_current_state_.store(this->driver_->get_gripper_position());
-      }
-      catch(std::exception& e)
-      {
-         RCLCPP_ERROR(kLogger, "Error: %s", e.what());
-      }
-
-      std::this_thread::sleep_for(kGripperCommsLoopPeriod);
-   }
 }
 
 } // namespace robotiq_driver

--- a/grippers/robotiq_driver/src/hardware_interface.cpp
+++ b/grippers/robotiq_driver/src/hardware_interface.cpp
@@ -220,6 +220,20 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Roboti
    return CallbackReturn::SUCCESS;
 }
 
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn RobotiqGripperHardwareInterface::on_shutdown(
+   const rclcpp_lifecycle::State& previous_state)
+{
+   RCLCPP_DEBUG(kLogger, "on_shutdown");
+   return on_cleanup(previous_state);
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn RobotiqGripperHardwareInterface::on_error(
+   const rclcpp_lifecycle::State& previous_state)
+{
+   RCLCPP_DEBUG(kLogger, "on_error");
+   return on_cleanup(previous_state);
+}
+
 std::vector<hardware_interface::StateInterface> RobotiqGripperHardwareInterface::export_state_interfaces()
 {
    RCLCPP_DEBUG(kLogger, "export_state_interfaces");

--- a/grippers/robotiq_driver/src/hardware_interface.cpp
+++ b/grippers/robotiq_driver/src/hardware_interface.cpp
@@ -39,7 +39,7 @@
 #include <robotiq_driver/hardware_interface.hpp>
 #include <robotiq_driver/rclcpp_logger.hpp>
 
-#include <Robotiq/fake/gripper_factory.hpp>
+#include <Robotiq/gripper/fake/gripper_factory.hpp>
 
 #include <hardware_interface/actuator_interface.hpp>
 #include <hardware_interface/types/hardware_interface_type_values.hpp>

--- a/grippers/robotiq_driver/src/hardware_parameters.cpp
+++ b/grippers/robotiq_driver/src/hardware_parameters.cpp
@@ -126,7 +126,13 @@ GripperParameters parseParameters(const hardware_interface::HardwareInfo& info, 
 
    // No default: the joint mapping is meaningless without the gripper's
    // closed angle, and guessing one would silently mis-scale every command.
+   // Zero and non-finite are the two it cannot divide by; negative is fine, and
+   // is how a joint that closes in the negative direction is described.
    parameters.closed_position = std::stod(info.hardware_parameters.at(kClosedPositionParam));
+   if(!std::isfinite(parameters.closed_position) || parameters.closed_position == 0.0)
+   {
+      throw std::invalid_argument("gripper_closed_position must be a non-zero, finite joint value");
+   }
 
    parameters.max_speed = parameterOr<double>(info, logger, kMaxSpeedParam, parameters.max_speed, asDouble);
    parameters.max_force = parameterOr<double>(info, logger, kMaxForceParam, parameters.max_force, asDouble);

--- a/grippers/robotiq_driver/src/hardware_parameters.cpp
+++ b/grippers/robotiq_driver/src/hardware_parameters.cpp
@@ -109,10 +109,17 @@ GripperParameters parseParameters(const hardware_interface::HardwareInfo& info, 
       parameterOr<std::chrono::milliseconds>(info, logger, kTimeoutParam, kTimeoutDefault, [](const std::string& text) {
          return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::duration<double>(std::stod(text)));
       });
-   // Base 16: the address is written as the manual prints it ("0x9").
+   // Base 0: "0x9" as the manual prints it, and a bare "9" as the decimal it
+   // looks like. Rejecting a value that does not fit the byte keeps a typo from
+   // quietly addressing a different device.
    parameters.connection.modbusSlaveAddress =
       parameterOr<uint8_t>(info, logger, kSlaveAddressParam, kSlaveAddressDefault, [](const std::string& text) {
-         return static_cast<uint8_t>(std::stoul(text, nullptr, 16));
+         const auto address = std::stoul(text, nullptr, 0);
+         if(address > 0xFF)
+         {
+            throw std::out_of_range("slave_address does not fit in a byte");
+         }
+         return static_cast<uint8_t>(address);
       });
    parameters.connection.connectionFrequency =
       parameterOr<double>(info, logger, kConnectionFrequencyParam, kConnectionFrequencyDefault, asDouble);

--- a/grippers/robotiq_driver/src/hardware_parameters.cpp
+++ b/grippers/robotiq_driver/src/hardware_parameters.cpp
@@ -37,18 +37,18 @@
 
 namespace robotiq_driver {
 namespace {
-constexpr auto kComPortParam = "COM_port";
-constexpr auto kBaudrateParam = "baudrate";
-constexpr auto kTimeoutParam = "timeout";
-constexpr auto kSlaveAddressParam = "slave_address";
-constexpr auto kConnectionFrequencyParam = "connection_frequency";
-constexpr auto kClosedPositionParam = "gripper_closed_position";
-constexpr auto kMaxSpeedParam = "gripper_max_speed";
-constexpr auto kMaxForceParam = "gripper_max_force";
-constexpr auto kSpeedMultiplierParam = "gripper_speed_multiplier";
-constexpr auto kForceMultiplierParam = "gripper_force_multiplier";
-constexpr auto kActivationTimeoutParam = "activation_timeout";
-constexpr auto kUseDummyParam = "use_dummy";
+constexpr const char* kComPortParam = "COM_port";
+constexpr const char* kBaudrateParam = "baudrate";
+constexpr const char* kTimeoutParam = "timeout";
+constexpr const char* kSlaveAddressParam = "slave_address";
+constexpr const char* kConnectionFrequencyParam = "connection_frequency";
+constexpr const char* kClosedPositionParam = "gripper_closed_position";
+constexpr const char* kMaxSpeedParam = "gripper_max_speed";
+constexpr const char* kMaxForceParam = "gripper_max_force";
+constexpr const char* kSpeedMultiplierParam = "gripper_speed_multiplier";
+constexpr const char* kForceMultiplierParam = "gripper_force_multiplier";
+constexpr const char* kActivationTimeoutParam = "activation_timeout";
+constexpr const char* kUseDummyParam = "use_dummy";
 
 //! Whether \p text reads as "no". Anything else — including a bare "true" or
 //! any typo — selects the fake gripper, so the spellings people actually write

--- a/grippers/robotiq_driver/src/hardware_parameters.cpp
+++ b/grippers/robotiq_driver/src/hardware_parameters.cpp
@@ -50,8 +50,16 @@ constexpr auto kForceMultiplierParam = "gripper_force_multiplier";
 constexpr auto kActivationTimeoutParam = "activation_timeout";
 constexpr auto kUseDummyParam = "use_dummy";
 
-// The dummy is off unless the parameter reads as anything other than this.
-constexpr auto kUseDummyDefault = "false";
+//! Whether \p text reads as "no". Anything else — including a bare "true" or
+//! any typo — selects the fake gripper, so the spellings people actually write
+//! have to be recognised here.
+bool isFalsey(std::string text)
+{
+   std::transform(text.begin(), text.end(), text.begin(), [](unsigned char letter) {
+      return static_cast<char>(std::tolower(letter));
+   });
+   return text.empty() || text == "0" || text == "false" || text == "no" || text == "off";
+}
 
 //! Look a parameter up and convert it with \p parse. An absent parameter
 //! keeps \p fallback silently; a present but unparsable one keeps it loudly.
@@ -128,9 +136,8 @@ GripperParameters parseParameters(const hardware_interface::HardwareInfo& info, 
          return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::duration<double>(std::stod(text)));
       });
 
-   // Anything but the literal "false" enables the dummy, "0" included.
-   parameters.use_dummy = info.hardware_parameters.count(kUseDummyParam) != 0
-                       && info.hardware_parameters.at(kUseDummyParam) != kUseDummyDefault;
+   const auto use_dummy = info.hardware_parameters.find(kUseDummyParam);
+   parameters.use_dummy = use_dummy != info.hardware_parameters.end() && !isFalsey(use_dummy->second);
 
    return parameters;
 }

--- a/grippers/robotiq_driver/src/hardware_parameters.cpp
+++ b/grippers/robotiq_driver/src/hardware_parameters.cpp
@@ -1,0 +1,137 @@
+// Copyright (c) 2022 PickNik, Inc.
+// Copyright (c) 2026 Robotiq, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <robotiq_driver/hardware_parameters.hpp>
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+#include <rclcpp/logging.hpp>
+
+namespace robotiq_driver {
+namespace {
+constexpr auto kComPortParam = "COM_port";
+constexpr auto kBaudrateParam = "baudrate";
+constexpr auto kTimeoutParam = "timeout";
+constexpr auto kSlaveAddressParam = "slave_address";
+constexpr auto kConnectionFrequencyParam = "connection_frequency";
+constexpr auto kClosedPositionParam = "gripper_closed_position";
+constexpr auto kMaxSpeedParam = "gripper_max_speed";
+constexpr auto kMaxForceParam = "gripper_max_force";
+constexpr auto kSpeedMultiplierParam = "gripper_speed_multiplier";
+constexpr auto kForceMultiplierParam = "gripper_force_multiplier";
+constexpr auto kActivationTimeoutParam = "activation_timeout";
+constexpr auto kUseDummyParam = "use_dummy";
+
+// The dummy is off unless the parameter reads as anything other than this.
+constexpr auto kUseDummyDefault = "false";
+
+//! Look a parameter up and convert it with \p parse. An absent parameter
+//! keeps \p fallback silently; a present but unparsable one keeps it loudly.
+template <typename T, typename Parse>
+T parameterOr(const hardware_interface::HardwareInfo& info,
+              const rclcpp::Logger& logger,
+              const char* name,
+              T fallback,
+              Parse parse)
+{
+   const auto entry = info.hardware_parameters.find(name);
+   if(entry == info.hardware_parameters.end())
+   {
+      return fallback;
+   }
+   try
+   {
+      return parse(entry->second);
+   }
+   catch(const std::exception& e)
+   {
+      RCLCPP_ERROR(logger, "Ignoring malformed '%s' parameter '%s': %s", name, entry->second.c_str(), e.what());
+      return fallback;
+   }
+}
+
+double asDouble(const std::string& text)
+{
+   return std::stod(text);
+}
+} // namespace
+
+GripperParameters parseParameters(const hardware_interface::HardwareInfo& info, const rclcpp::Logger& logger)
+{
+   GripperParameters parameters;
+
+   parameters.connection.serial.port =
+      parameterOr<std::string>(info, logger, kComPortParam, kComPortDefault, [](const std::string& text) {
+         return text;
+      });
+   parameters.connection.serial.baudrate =
+      parameterOr<uint32_t>(info, logger, kBaudrateParam, kBaudrateDefault, [](const std::string& text) {
+         return static_cast<uint32_t>(std::stoul(text));
+      });
+   // The URDF spells the timeout in seconds; SerialConfig wants milliseconds.
+   parameters.connection.serial.timeout =
+      parameterOr<std::chrono::milliseconds>(info, logger, kTimeoutParam, kTimeoutDefault, [](const std::string& text) {
+         return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::duration<double>(std::stod(text)));
+      });
+   // Base 16: the address is written as the manual prints it ("0x9").
+   parameters.connection.modbusSlaveAddress =
+      parameterOr<uint8_t>(info, logger, kSlaveAddressParam, kSlaveAddressDefault, [](const std::string& text) {
+         return static_cast<uint8_t>(std::stoul(text, nullptr, 16));
+      });
+   parameters.connection.connectionFrequency =
+      parameterOr<double>(info, logger, kConnectionFrequencyParam, kConnectionFrequencyDefault, asDouble);
+
+   // No default: the joint mapping is meaningless without the gripper's
+   // closed angle, and guessing one would silently mis-scale every command.
+   parameters.closed_position = std::stod(info.hardware_parameters.at(kClosedPositionParam));
+
+   parameters.max_speed = parameterOr<double>(info, logger, kMaxSpeedParam, parameters.max_speed, asDouble);
+   parameters.max_force = parameterOr<double>(info, logger, kMaxForceParam, parameters.max_force, asDouble);
+   parameters.speed_multiplier =
+      parameterOr<double>(info, logger, kSpeedMultiplierParam, parameters.speed_multiplier, asDouble);
+   parameters.force_multiplier =
+      parameterOr<double>(info, logger, kForceMultiplierParam, parameters.force_multiplier, asDouble);
+   parameters.activation_timeout = parameterOr<std::chrono::milliseconds>(
+      info,
+      logger,
+      kActivationTimeoutParam,
+      parameters.activation_timeout,
+      [](const std::string& text) {
+         return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::duration<double>(std::stod(text)));
+      });
+
+   // Anything but the literal "false" enables the dummy, "0" included.
+   parameters.use_dummy = info.hardware_parameters.count(kUseDummyParam) != 0
+                       && info.hardware_parameters.at(kUseDummyParam) != kUseDummyDefault;
+
+   return parameters;
+}
+} // namespace robotiq_driver

--- a/grippers/robotiq_driver/src/rclcpp_logger.cpp
+++ b/grippers/robotiq_driver/src/rclcpp_logger.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Robotiq, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <robotiq_driver/rclcpp_logger.hpp>
+
+#include <utility>
+
+#include <rclcpp/logging.hpp>
+
+namespace robotiq_driver {
+RclcppLogger::RclcppLogger(rclcpp::Logger logger)
+   : logger_{std::move(logger)}
+{
+}
+
+void RclcppLogger::log(Level level, std::string_view message)
+{
+   // The SDK hands over a string_view, which need not be null-terminated;
+   // "%.*s" prints exactly its extent without copying it into a std::string.
+   const auto width = static_cast<int>(message.size());
+   const char* text = message.data();
+
+   switch(level)
+   {
+   case Level::Debug:
+      RCLCPP_DEBUG(logger_, "%.*s", width, text);
+      return;
+   case Level::Info:
+      RCLCPP_INFO(logger_, "%.*s", width, text);
+      return;
+   case Level::Warn:
+      RCLCPP_WARN(logger_, "%.*s", width, text);
+      return;
+   case Level::Error:
+      RCLCPP_ERROR(logger_, "%.*s", width, text);
+      return;
+   }
+   // An unknown level must not be dropped silently: report it, loudly.
+   RCLCPP_ERROR(logger_, "%.*s", width, text);
+}
+} // namespace robotiq_driver

--- a/grippers/robotiq_driver/tests/CMakeLists.txt
+++ b/grippers/robotiq_driver/tests/CMakeLists.txt
@@ -70,3 +70,18 @@ target_include_directories(test_data_utils
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
 )
 target_link_libraries(test_data_utils robotiq_driver)
+
+###############################################################################
+# robotiq_driver_tests
+
+# One gmock binary for the whole package, so the suite runs — and debugs — as a
+# single target. Pick a subset with --gtest_filter.
+ament_add_gmock(${PROJECT_NAME}_tests
+    test_gripper_scaling.cpp      # register <-> joint arithmetic
+    test_hardware_parameters.cpp  # HardwareInfo -> ConnectionConfig
+    test_rclcpp_logger.cpp        # SDK log sink -> /rosout
+)
+target_include_directories(${PROJECT_NAME}_tests
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(${PROJECT_NAME}_tests robotiq_driver)

--- a/grippers/robotiq_driver/tests/test_gripper_scaling.cpp
+++ b/grippers/robotiq_driver/tests/test_gripper_scaling.cpp
@@ -29,6 +29,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <limits>
+#include <optional>
+
 #include <robotiq_driver/gripper_scaling.hpp>
 
 namespace robotiq_driver::test {
@@ -58,9 +61,10 @@ TEST(GripperScaling, RegisterRoundTripLosesAtMostOneCount)
    // is a visible decision rather than a side effect of some later edit.
    for(uint8_t counts = kGripperMinPos; counts <= kGripperMaxPos; ++counts)
    {
-      const uint8_t round_tripped =
+      const std::optional<uint8_t> round_tripped =
          registerFromJointPosition(jointPositionFromRegister(counts, kClosedPosition), kClosedPosition);
-      EXPECT_THAT(round_tripped, testing::AnyOf(counts, counts - 1))
+      ASSERT_TRUE(round_tripped.has_value());
+      EXPECT_THAT(*round_tripped, testing::AnyOf(counts, counts - 1))
          << "round trip drifted more than a count at " << static_cast<int>(counts) << " counts";
    }
 }
@@ -76,6 +80,35 @@ TEST(GripperScaling, PositionsBelowTheTravelBandStayReachable)
    // The band starts at 3 counts, but 0..2 are still commandable: clamping is
    // to the byte, not to the band.
    EXPECT_LT(registerFromJointPosition(-0.005, kClosedPosition), kGripperMinPos);
+}
+
+TEST(GripperScaling, AnUnusableClosedPositionCommandsNothing)
+{
+   // 0/0 and x/0 have no register to land on. Answering "nothing" keeps the
+   // caller from moving the fingers on a made-up count.
+   EXPECT_FALSE(registerFromJointPosition(0.0, 0.0).has_value());
+   EXPECT_FALSE(registerFromJointPosition(0.5, 0.0).has_value());
+   EXPECT_FALSE(registerFromJointPosition(std::numeric_limits<double>::quiet_NaN(), kClosedPosition).has_value());
+   EXPECT_FALSE(registerFromJointPosition(0.5, std::numeric_limits<double>::quiet_NaN()).has_value());
+}
+
+TEST(GripperScaling, AClosedPositionThatClosesNegativeStillMaps)
+{
+   // A joint whose closed direction is negative is a supported description:
+   // the ratio inverts and the mapping still lands in the travel band.
+   EXPECT_EQ(kGripperMinPos, registerFromJointPosition(0.0, -kClosedPosition));
+   EXPECT_EQ(kGripperMaxPos, registerFromJointPosition(-kClosedPosition, -kClosedPosition));
+}
+
+TEST(GripperScaling, AnUnusableMaximumCommandsNothing)
+{
+   // As above: no fraction, so no register, rather than a guessed speed or
+   // force. A maximum that is not positive is a broken description, not a
+   // direction the way a negative closed position is.
+   EXPECT_FALSE(registerFromFractionOf(0.1, 0.0).has_value());
+   EXPECT_FALSE(registerFromFractionOf(0.1, -0.15).has_value());
+   EXPECT_FALSE(registerFromFractionOf(std::numeric_limits<double>::quiet_NaN(), 0.15).has_value());
+   EXPECT_FALSE(registerFromFractionOf(0.1, std::numeric_limits<double>::quiet_NaN()).has_value());
 }
 
 TEST(GripperScaling, FractionOfSpansTheWholeByte)

--- a/grippers/robotiq_driver/tests/test_gripper_scaling.cpp
+++ b/grippers/robotiq_driver/tests/test_gripper_scaling.cpp
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Robotiq, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <robotiq_driver/gripper_scaling.hpp>
+
+namespace robotiq_driver::test {
+namespace {
+// The 2F-85's fully-closed joint angle, as the shipped description sets it.
+constexpr double kClosedPosition = 0.7929;
+} // namespace
+
+TEST(GripperScaling, TravelEndpointsMapToTheJointLimits)
+{
+   EXPECT_DOUBLE_EQ(0.0, jointPositionFromRegister(kGripperMinPos, kClosedPosition));
+   EXPECT_DOUBLE_EQ(kClosedPosition, jointPositionFromRegister(kGripperMaxPos, kClosedPosition));
+}
+
+TEST(GripperScaling, JointLimitsMapBackToTheTravelEndpoints)
+{
+   EXPECT_EQ(kGripperMinPos, registerFromJointPosition(0.0, kClosedPosition));
+   EXPECT_EQ(kGripperMaxPos, registerFromJointPosition(kClosedPosition, kClosedPosition));
+}
+
+TEST(GripperScaling, RegisterRoundTripLosesAtMostOneCount)
+{
+   // counts -> radians -> counts does not always land back on the same count:
+   // the reverse mapping truncates, so a position read off the gripper and
+   // commanded straight back can come out one low. That is the behaviour the
+   // driver has always had, pinned here rather than fixed, so that changing it
+   // is a visible decision rather than a side effect of some later edit.
+   for(uint8_t counts = kGripperMinPos; counts <= kGripperMaxPos; ++counts)
+   {
+      const uint8_t round_tripped =
+         registerFromJointPosition(jointPositionFromRegister(counts, kClosedPosition), kClosedPosition);
+      EXPECT_THAT(round_tripped, testing::AnyOf(counts, counts - 1))
+         << "round trip drifted more than a count at " << static_cast<int>(counts) << " counts";
+   }
+}
+
+TEST(GripperScaling, PositionsOutsideTheJointRangeClampIntoTheByte)
+{
+   EXPECT_EQ(0, registerFromJointPosition(-1.0, kClosedPosition));
+   EXPECT_EQ(255, registerFromJointPosition(10.0 * kClosedPosition, kClosedPosition));
+}
+
+TEST(GripperScaling, PositionsBelowTheTravelBandStayReachable)
+{
+   // The band starts at 3 counts, but 0..2 are still commandable: clamping is
+   // to the byte, not to the band.
+   EXPECT_LT(registerFromJointPosition(-0.005, kClosedPosition), kGripperMinPos);
+}
+
+TEST(GripperScaling, FractionOfSpansTheWholeByte)
+{
+   EXPECT_EQ(0, registerFromFractionOf(0.0, 0.15));
+   EXPECT_EQ(255, registerFromFractionOf(0.15, 0.15));
+   // 0.5 * 0xFF is 127.5, truncated to 127 — see the round-trip test above.
+   EXPECT_EQ(127, registerFromFractionOf(0.075, 0.15));
+}
+
+TEST(GripperScaling, FractionOfSaturatesRatherThanWrapping)
+{
+   // A request beyond full scale must pin at 0xFF; truncating the product
+   // would wrap it to a near-zero speed or force.
+   EXPECT_EQ(255, registerFromFractionOf(10.0, 0.15));
+}
+
+TEST(GripperScaling, FractionOfIgnoresSign)
+{
+   // The registers carry a magnitude; direction comes from the position
+   // request, so a negative speed is still a speed.
+   EXPECT_EQ(registerFromFractionOf(0.1, 0.15), registerFromFractionOf(-0.1, 0.15));
+}
+} // namespace robotiq_driver::test

--- a/grippers/robotiq_driver/tests/test_gripper_scaling.cpp
+++ b/grippers/robotiq_driver/tests/test_gripper_scaling.cpp
@@ -100,15 +100,18 @@ TEST(GripperScaling, AClosedPositionThatClosesNegativeStillMaps)
    EXPECT_EQ(kGripperMaxPos, registerFromJointPosition(-kClosedPosition, -kClosedPosition));
 }
 
-TEST(GripperScaling, AnUnusableMaximumCommandsNothing)
+TEST(GripperScaling, AFractionOutsideTheRangeCommandsNothing)
 {
    // As above: no fraction, so no register, rather than a guessed speed or
-   // force. A maximum that is not positive is a broken description, not a
-   // direction the way a negative closed position is.
+   // force. A negative speed and a maximum that is not positive are both broken
+   // descriptions, not directions the way a negative closed position is.
    EXPECT_FALSE(registerFromFractionOf(0.1, 0.0).has_value());
    EXPECT_FALSE(registerFromFractionOf(0.1, -0.15).has_value());
+   EXPECT_FALSE(registerFromFractionOf(-0.1, 0.15).has_value());
    EXPECT_FALSE(registerFromFractionOf(std::numeric_limits<double>::quiet_NaN(), 0.15).has_value());
    EXPECT_FALSE(registerFromFractionOf(0.1, std::numeric_limits<double>::quiet_NaN()).has_value());
+   EXPECT_FALSE(registerFromFractionOf(std::numeric_limits<double>::infinity(), 0.15).has_value());
+   EXPECT_FALSE(registerFromFractionOf(0.1, std::numeric_limits<double>::infinity()).has_value());
 }
 
 TEST(GripperScaling, FractionOfSpansTheWholeByte)
@@ -126,10 +129,8 @@ TEST(GripperScaling, FractionOfSaturatesRatherThanWrapping)
    EXPECT_EQ(255, registerFromFractionOf(10.0, 0.15));
 }
 
-TEST(GripperScaling, FractionOfIgnoresSign)
+TEST(GripperScaling, whenTheMaximumIsNearZero_theRegisterIsTheMaxAllowedValue)
 {
-   // The registers carry a magnitude; direction comes from the position
-   // request, so a negative speed is still a speed.
-   EXPECT_EQ(registerFromFractionOf(0.1, 0.15), registerFromFractionOf(-0.1, 0.15));
+   EXPECT_EQ(255, registerFromFractionOf(0.15, std::numeric_limits<double>::denorm_min()));
 }
 } // namespace robotiq_driver::test

--- a/grippers/robotiq_driver/tests/test_hardware_parameters.cpp
+++ b/grippers/robotiq_driver/tests/test_hardware_parameters.cpp
@@ -85,13 +85,20 @@ TEST(HardwareParameters, ReadsTheConnectionParameters)
    EXPECT_DOUBLE_EQ(50.0, parameters.connection.connectionFrequency);
 }
 
-TEST(HardwareParameters, SlaveAddressIsReadAsHexadecimal)
+TEST(HardwareParameters, SlaveAddressTakesTheManualsHexOrPlainDecimal)
 {
-   // The manual prints the address in hex, and the description passes it
-   // through verbatim — reading it as decimal would silently target the
-   // wrong device.
+   // The manual prints the address in hex and a description may pass it through
+   // verbatim; a bare number is the decimal it looks like. PickNik read
+   // everything as hex, so "10" meant 16.
    EXPECT_EQ(0x12, parseParameters(info_with({{"slave_address", "0x12"}}), logger()).connection.modbusSlaveAddress);
-   EXPECT_EQ(0x09, parseParameters(info_with({{"slave_address", "9"}}), logger()).connection.modbusSlaveAddress);
+   EXPECT_EQ(9, parseParameters(info_with({{"slave_address", "9"}}), logger()).connection.modbusSlaveAddress);
+   EXPECT_EQ(10, parseParameters(info_with({{"slave_address", "10"}}), logger()).connection.modbusSlaveAddress);
+}
+
+TEST(HardwareParameters, ASlaveAddressBeyondAByteKeepsTheDefault)
+{
+   EXPECT_EQ(kSlaveAddressDefault,
+             parseParameters(info_with({{"slave_address", "0x1FF"}}), logger()).connection.modbusSlaveAddress);
 }
 
 TEST(HardwareParameters, TimeoutsAreSecondsInTheUrdfAndMillisecondsInTheConfig)

--- a/grippers/robotiq_driver/tests/test_hardware_parameters.cpp
+++ b/grippers/robotiq_driver/tests/test_hardware_parameters.cpp
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 Robotiq, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <map>
+#include <stdexcept>
+#include <string>
+
+#include <robotiq_driver/hardware_parameters.hpp>
+
+#include <rclcpp/logger.hpp>
+
+namespace robotiq_driver::test {
+namespace {
+const rclcpp::Logger& logger()
+{
+   static const rclcpp::Logger instance = rclcpp::get_logger("test_hardware_parameters");
+   return instance;
+}
+
+//! A HardwareInfo carrying only the mandatory closed position, plus whatever
+//! the test adds on top.
+hardware_interface::HardwareInfo info_with(std::map<std::string, std::string> parameters = {})
+{
+   hardware_interface::HardwareInfo info;
+   info.hardware_parameters.emplace("gripper_closed_position", "0.7929");
+   for(auto& [name, value] : parameters)
+   {
+      info.hardware_parameters.insert_or_assign(name, value);
+   }
+   return info;
+}
+} // namespace
+
+TEST(HardwareParameters, DefaultsMatchTheSdkConnectionDefaults)
+{
+   const GripperParameters parameters = parseParameters(info_with(), logger());
+
+   // Spelled out rather than compared against the kDefault constants: this
+   // test pins the values themselves, and against the constants it would pass
+   // whatever they drifted to.
+   EXPECT_EQ("/dev/ttyUSB0", parameters.connection.serial.port);
+   EXPECT_EQ(115200u, parameters.connection.serial.baudrate);
+   EXPECT_EQ(std::chrono::milliseconds{500}, parameters.connection.serial.timeout);
+   EXPECT_EQ(0x09, parameters.connection.modbusSlaveAddress);
+   EXPECT_DOUBLE_EQ(100.0, parameters.connection.connectionFrequency);
+   EXPECT_EQ(std::chrono::milliseconds{15000}, parameters.activation_timeout);
+}
+
+TEST(HardwareParameters, ReadsTheConnectionParameters)
+{
+   const GripperParameters parameters =
+      parseParameters(info_with({{"COM_port", "/dev/ttyUSB7"}, {"baudrate", "57600"}, {"connection_frequency", "50"}}),
+                      logger());
+
+   EXPECT_EQ("/dev/ttyUSB7", parameters.connection.serial.port);
+   EXPECT_EQ(57600u, parameters.connection.serial.baudrate);
+   EXPECT_DOUBLE_EQ(50.0, parameters.connection.connectionFrequency);
+}
+
+TEST(HardwareParameters, SlaveAddressIsReadAsHexadecimal)
+{
+   // The manual prints the address in hex, and the description passes it
+   // through verbatim — reading it as decimal would silently target the
+   // wrong device.
+   EXPECT_EQ(0x12, parseParameters(info_with({{"slave_address", "0x12"}}), logger()).connection.modbusSlaveAddress);
+   EXPECT_EQ(0x09, parseParameters(info_with({{"slave_address", "9"}}), logger()).connection.modbusSlaveAddress);
+}
+
+TEST(HardwareParameters, TimeoutsAreSecondsInTheUrdfAndMillisecondsInTheConfig)
+{
+   const GripperParameters parameters =
+      parseParameters(info_with({{"timeout", "0.25"}, {"activation_timeout", "30"}}), logger());
+
+   EXPECT_EQ(std::chrono::milliseconds{250}, parameters.connection.serial.timeout);
+   EXPECT_EQ(std::chrono::milliseconds{30000}, parameters.activation_timeout);
+}
+
+TEST(HardwareParameters, ReadsTheScalingParameters)
+{
+   const GripperParameters parameters = parseParameters(info_with({{"gripper_max_speed", "0.2"},
+                                                                   {"gripper_max_force", "185"},
+                                                                   {"gripper_speed_multiplier", "0.75"},
+                                                                   {"gripper_force_multiplier", "0.5"}}),
+                                                        logger());
+
+   EXPECT_DOUBLE_EQ(0.7929, parameters.closed_position);
+   EXPECT_DOUBLE_EQ(0.2, parameters.max_speed);
+   EXPECT_DOUBLE_EQ(185.0, parameters.max_force);
+   EXPECT_DOUBLE_EQ(0.75, parameters.speed_multiplier);
+   EXPECT_DOUBLE_EQ(0.5, parameters.force_multiplier);
+}
+
+TEST(HardwareParameters, AMalformedParameterFallsBackToItsDefault)
+{
+   // One unparsable string in the description must not take the gripper
+   // down at startup — it is reported and the default stands.
+   const GripperParameters parameters =
+      parseParameters(info_with({{"baudrate", "fast"}, {"gripper_max_force", ""}}), logger());
+
+   EXPECT_EQ(kBaudrateDefault, parameters.connection.serial.baudrate);
+   EXPECT_DOUBLE_EQ(kMaxForceDefault, parameters.max_force);
+}
+
+TEST(HardwareParameters, AMissingClosedPositionIsFatal)
+{
+   // Unlike every other parameter this one has no defensible default: a
+   // guessed value mis-scales every position the gripper is ever given.
+   hardware_interface::HardwareInfo info;
+   EXPECT_THROW(GripperParameters parameters = parseParameters(info, logger()), std::out_of_range);
+}
+
+TEST(HardwareParameters, UseDummyDefaultsOff)
+{
+   EXPECT_FALSE(parseParameters(info_with(), logger()).use_dummy);
+   EXPECT_FALSE(parseParameters(info_with({{"use_dummy", "false"}}), logger()).use_dummy);
+}
+
+TEST(HardwareParameters, AnythingButFalseEnablesTheDummy)
+{
+   EXPECT_TRUE(parseParameters(info_with({{"use_dummy", "true"}}), logger()).use_dummy);
+   EXPECT_TRUE(parseParameters(info_with({{"use_dummy", "True"}}), logger()).use_dummy);
+   EXPECT_TRUE(parseParameters(info_with({{"use_dummy", "0"}}), logger()).use_dummy);
+   EXPECT_TRUE(parseParameters(info_with({{"use_dummy", ""}}), logger()).use_dummy);
+}
+} // namespace robotiq_driver::test

--- a/grippers/robotiq_driver/tests/test_hardware_parameters.cpp
+++ b/grippers/robotiq_driver/tests/test_hardware_parameters.cpp
@@ -143,11 +143,20 @@ TEST(HardwareParameters, UseDummyDefaultsOff)
    EXPECT_FALSE(parseParameters(info_with({{"use_dummy", "false"}}), logger()).use_dummy);
 }
 
-TEST(HardwareParameters, AnythingButFalseEnablesTheDummy)
+TEST(HardwareParameters, WhenUseDummyIsFalseLike_thenTheRealGripperIsUsed)
+{
+   for(const char* spelling : {"false", "False", "FALSE", "0", "no", "off", ""})
+   {
+      EXPECT_FALSE(parseParameters(info_with({{"use_dummy", spelling}}), logger()).use_dummy)
+         << "'" << spelling << "' should not select the fake gripper";
+   }
+}
+
+TEST(HardwareParameters, WhenUseDummyIsNotFalseLike_thenTheDummyIsUsed)
 {
    EXPECT_TRUE(parseParameters(info_with({{"use_dummy", "true"}}), logger()).use_dummy);
    EXPECT_TRUE(parseParameters(info_with({{"use_dummy", "True"}}), logger()).use_dummy);
-   EXPECT_TRUE(parseParameters(info_with({{"use_dummy", "0"}}), logger()).use_dummy);
-   EXPECT_TRUE(parseParameters(info_with({{"use_dummy", ""}}), logger()).use_dummy);
+   EXPECT_TRUE(parseParameters(info_with({{"use_dummy", "1"}}), logger()).use_dummy);
+   EXPECT_TRUE(parseParameters(info_with({{"use_dummy", "yes"}}), logger()).use_dummy);
 }
 } // namespace robotiq_driver::test

--- a/grippers/robotiq_driver/tests/test_hardware_parameters.cpp
+++ b/grippers/robotiq_driver/tests/test_hardware_parameters.cpp
@@ -85,6 +85,23 @@ TEST(HardwareParameters, ReadsTheConnectionParameters)
    EXPECT_DOUBLE_EQ(50.0, parameters.connection.connectionFrequency);
 }
 
+TEST(HardwareParameters, AClosedPositionItCannotDivideByIsFatal)
+{
+   // on_init turns this into CallbackReturn::ERROR. PickNik accepted it and
+   // then produced an undefined register from the division.
+   EXPECT_THROW(parseParameters(info_with({{"gripper_closed_position", "0"}}), logger()), std::invalid_argument);
+   EXPECT_THROW(parseParameters(info_with({{"gripper_closed_position", "nan"}}), logger()), std::invalid_argument);
+   EXPECT_THROW(parseParameters(info_with({{"gripper_closed_position", "inf"}}), logger()), std::invalid_argument);
+}
+
+TEST(HardwareParameters, ANegativeClosedPositionIsSupported)
+{
+   // A joint whose closed direction is negative: the mapping inverts and works,
+   // as it did under PickNik.
+   EXPECT_DOUBLE_EQ(-0.7929,
+                    parseParameters(info_with({{"gripper_closed_position", "-0.7929"}}), logger()).closed_position);
+}
+
 TEST(HardwareParameters, SlaveAddressTakesTheManualsHexOrPlainDecimal)
 {
    // The manual prints the address in hex and a description may pass it through

--- a/grippers/robotiq_driver/tests/test_rclcpp_logger.cpp
+++ b/grippers/robotiq_driver/tests/test_rclcpp_logger.cpp
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 Robotiq, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <rcutils/logging.h>
+
+#include <cstdarg>
+#include <cstdio>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <robotiq_driver/rclcpp_logger.hpp>
+
+#include <rclcpp/logger.hpp>
+#include <rclcpp/logging.hpp>
+
+namespace robotiq_driver::test {
+namespace {
+struct CapturedLine
+{
+   int severity = 0;
+   std::string message;
+};
+
+std::vector<CapturedLine>& captured()
+{
+   static std::vector<CapturedLine> lines;
+   return lines;
+}
+
+// rcutils hands the formatted line to a C callback with no user data, hence
+// the file-scope sink above.
+void capture(const rcutils_log_location_t* /*location*/,
+             int severity,
+             const char* /*name*/,
+             rcutils_time_point_value_t /*timestamp*/,
+             const char* format,
+             va_list* args)
+{
+   char buffer[1024];
+   va_list copy;
+   va_copy(copy, *args);
+   vsnprintf(buffer, sizeof(buffer), format, copy);
+   va_end(copy);
+   captured().push_back({severity, buffer});
+}
+
+//! Installs the capturing sink for the duration of a test and restores the
+//! previous sink afterwards.
+class LogCapture
+{
+public:
+   LogCapture()
+      : previous_{rcutils_logging_get_output_handler()}
+   {
+      captured().clear();
+      // Debug lines are filtered out before the sink unless the logger asks
+      // for them, which would make the Debug case untestable.
+      EXPECT_EQ(RCUTILS_RET_OK, rcutils_logging_set_logger_level(kLoggerName, RCUTILS_LOG_SEVERITY_DEBUG));
+      rcutils_logging_set_output_handler(&capture);
+   }
+
+   ~LogCapture() { rcutils_logging_set_output_handler(previous_); }
+
+   LogCapture(const LogCapture&) = delete;
+   LogCapture& operator=(const LogCapture&) = delete;
+
+   static constexpr const char* kLoggerName = "test_rclcpp_logger";
+
+private:
+   rcutils_logging_output_handler_t previous_;
+};
+
+RclcppLogger make_logger()
+{
+   return RclcppLogger{rclcpp::get_logger(LogCapture::kLoggerName)};
+}
+} // namespace
+
+TEST(RclcppLoggerTest, ForwardsEachLevelAtTheMatchingSeverity)
+{
+   const LogCapture capture;
+   RclcppLogger logger = make_logger();
+
+   logger.log(Robotiq::Logger::Level::Debug, "a debug line");
+   logger.log(Robotiq::Logger::Level::Info, "an info line");
+   logger.log(Robotiq::Logger::Level::Warn, "a warn line");
+   logger.log(Robotiq::Logger::Level::Error, "an error line");
+
+   ASSERT_THAT(captured(), testing::SizeIs(4));
+   EXPECT_EQ(RCUTILS_LOG_SEVERITY_DEBUG, captured()[0].severity);
+   EXPECT_EQ(RCUTILS_LOG_SEVERITY_INFO, captured()[1].severity);
+   EXPECT_EQ(RCUTILS_LOG_SEVERITY_WARN, captured()[2].severity);
+   EXPECT_EQ(RCUTILS_LOG_SEVERITY_ERROR, captured()[3].severity);
+}
+
+TEST(RclcppLoggerTest, ForwardsTheMessageVerbatim)
+{
+   const LogCapture capture;
+   RclcppLogger logger = make_logger();
+   const std::string msg = "exchange cycle failed: timed out";
+
+   logger.log(Robotiq::Logger::Level::Info, msg);
+
+   ASSERT_THAT(captured(), testing::SizeIs(1));
+   EXPECT_EQ(msg, captured()[0].message);
+}
+
+TEST(RclcppLoggerTest, TreatsTheMessageAsTextRatherThanAFormatString)
+{
+   // SDK messages quote wire data and error strings; a stray %s in one must
+   // not be interpreted as a conversion and read off the end of the varargs.
+   const LogCapture capture;
+   RclcppLogger logger = make_logger();
+
+   logger.log(Robotiq::Logger::Level::Warn, "unexpected response: %s %d %n");
+
+   ASSERT_THAT(captured(), testing::SizeIs(1));
+   EXPECT_EQ("unexpected response: %s %d %n", captured()[0].message);
+}
+
+TEST(RclcppLoggerTest, HonoursTheExtentOfANonTerminatedView)
+{
+   // Robotiq::Logger takes a string_view, which need not be null-terminated;
+   // only its extent may be printed.
+   const LogCapture capture;
+   RclcppLogger logger = make_logger();
+
+   const std::string backing = "activated and holding";
+   logger.log(Robotiq::Logger::Level::Info, std::string_view{backing}.substr(0, 9));
+
+   ASSERT_THAT(captured(), testing::SizeIs(1));
+   EXPECT_EQ("activated", captured()[0].message);
+}
+} // namespace robotiq_driver::test

--- a/grippers/robotiq_driver/tests/test_robotiq_gripper_hardware_interface.cpp
+++ b/grippers/robotiq_driver/tests/test_robotiq_gripper_hardware_interface.cpp
@@ -55,7 +55,7 @@
 namespace robotiq_driver::test {
 
 namespace {
-constexpr auto kComponentName = "robotiq_driver_ros2_control";
+constexpr const char* kComponentName = "robotiq_driver_ros2_control";
 
 //! \p extra_hardware_params is spliced into the <hardware> block, so a test
 //! can select a backend without restating the whole description.

--- a/grippers/robotiq_driver/tests/test_robotiq_gripper_hardware_interface.cpp
+++ b/grippers/robotiq_driver/tests/test_robotiq_gripper_hardware_interface.cpp
@@ -29,7 +29,16 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <cmath>
+#include <future>
+#include <string>
+#include <thread>
+
 #include <hardware_interface/resource_manager.hpp>
+#include <hardware_interface/types/lifecycle_state_names.hpp>
+#include <lifecycle_msgs/msg/state.hpp>
+#include <rclcpp_lifecycle/state.hpp>
 #if __has_include(<hardware_interface/hardware_interface/version.h>)
 #include <hardware_interface/hardware_interface/version.h>
 #else
@@ -38,13 +47,20 @@
 
 #include <rclcpp/node.hpp>
 
+#include <robotiq_driver/hardware_interface.hpp>
+
+#include <Robotiq/gripper/wait.hpp>
+
 namespace robotiq_driver::test {
 
 namespace {
-std::string minimal_robot_urdf()
+constexpr auto kComponentName = "robotiq_driver_ros2_control";
+
+//! \p extra_hardware_params is spliced into the <hardware> block, so a test
+//! can select a backend without restating the whole description.
+std::string minimal_robot_urdf(const std::string& extra_hardware_params = "")
 {
-   return
-      R"(
+   return std::string(R"(
         <?xml version="1.0" encoding="utf-8"?>
         <robot name="test_robot">
           <link name="robotiq_85_base_link"/>
@@ -63,6 +79,8 @@ std::string minimal_robot_urdf()
               <param name="gripper_force_multiplier">0.5</param>
               <param name="COM_port">/dev/ttyUSB0</param>
               <param name="gripper_closed_position">0.7929</param>
+              )")
+        + extra_hardware_params + R"(
             </hardware>
             <joint name="robotiq_85_left_knuckle_joint">
               <command_interface name="position" />
@@ -71,6 +89,10 @@ std::string minimal_robot_urdf()
               </state_interface>
               <state_interface name="velocity"/>
             </joint>
+            <gpio name="reactivate_gripper">
+              <command_interface name="reactivate_gripper_cmd" />
+              <command_interface name="reactivate_gripper_response" />
+            </gpio>
           </ros2_control>
         </robot>
         )";
@@ -120,7 +142,111 @@ TEST(TestRobotiqGripperHardwareInterface, exports_expected_command_interfaces)
    EXPECT_THAT(keys,
                testing::IsSupersetOf({"robotiq_85_left_knuckle_joint/position",
                                       "robotiq_85_left_knuckle_joint/set_gripper_max_velocity",
-                                      "robotiq_85_left_knuckle_joint/set_gripper_max_effort"}));
+                                      "robotiq_85_left_knuckle_joint/set_gripper_max_effort",
+                                      "reactivate_gripper/reactivate_gripper_cmd",
+                                      "reactivate_gripper/reactivate_gripper_response"}));
+}
+
+/**
+ * use_dummy brings the component all the way up with no gripper and no serial
+ * port, and the joint position then follows the commanded position. It is the
+ * only hardware-free path that exercises the real plugin — and therefore the
+ * gripper and activation controllers, which bind to interfaces the
+ * ros2_control mock does not export.
+ */
+TEST(TestRobotiqGripperHardwareInterface, use_dummy_activates_and_follows_commands)
+{
+   const std::string urdf = minimal_robot_urdf(R"(<param name="use_dummy">true</param>)");
+
+   rclcpp::Node node{"test_robotiq_gripper_hardware_interface"};
+
+#if HARDWARE_INTERFACE_VERSION_GTE(4, 13, 0)
+   hardware_interface::ResourceManager rm(urdf, node.get_node_clock_interface(), node.get_node_logging_interface());
+#else
+   hardware_interface::ResourceManager rm(urdf);
+#endif
+
+   rclcpp_lifecycle::State active{lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+                                  hardware_interface::lifecycle_state_names::ACTIVE};
+   ASSERT_EQ(hardware_interface::return_type::OK, rm.set_component_state(kComponentName, active))
+      << "the dummy backend failed to configure and activate";
+
+   const rclcpp::Time time{0};
+   const rclcpp::Duration period = rclcpp::Duration::from_seconds(0.01);
+
+   auto position = rm.claim_state_interface("robotiq_85_left_knuckle_joint/position");
+   auto command = rm.claim_command_interface("robotiq_85_left_knuckle_joint/position");
+
+   // Half closed, in joint radians against the 0.7929 closed position.
+   constexpr double kTarget = 0.4;
+   const bool success = command.set_value(kTarget);
+   ASSERT_TRUE(success);
+   ASSERT_EQ(hardware_interface::return_type::OK, rm.write(time, period).result);
+
+   // The simulated gripper teleports, but the SDK's exchange cycle still has
+   // to carry the command and bring the status back.
+   const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds{5};
+   bool reached = false;
+   while(!reached && std::chrono::steady_clock::now() < deadline)
+   {
+      ASSERT_EQ(hardware_interface::return_type::OK, rm.read(time, period).result);
+      reached = std::abs(position.get_optional().value_or(0.0) - kTarget) < 0.01;
+      std::this_thread::sleep_for(std::chrono::milliseconds{5});
+   }
+   EXPECT_TRUE(reached) << "joint position never followed the command; last read "
+                        << position.get_optional().value_or(0.0);
+}
+
+namespace {
+//! White-box handle on the plugin: drives the lifecycle callbacks directly
+//! over the SDK's fake gripper, with the exchange slowed down so the recovery
+//! handshake spans many control cycles.
+class RecoveringGripper : public RobotiqGripperHardwareInterface
+{
+public:
+   RecoveringGripper()
+   {
+      parameters_.use_dummy = true;
+      parameters_.closed_position = 0.7929;
+      parameters_.connection.connectionFrequency = 20.0;
+   }
+
+   void request_recovery() { reactivate_gripper_cmd_ = 1.0; }
+   bool recovery_in_flight() const { return recovery_.valid(); }
+   bool recovery_has_finished() const
+   {
+      return recovery_.valid() && recovery_.wait_for(std::chrono::seconds{0}) == std::future_status::ready;
+   }
+   bool gripper_activated() const { return gripper_->getStatus().gripperStatus.activated(); }
+};
+} // namespace
+
+/**
+ * A GPIO recovery runs the reset handshake on a background thread. A
+ * deactivation arriving while it is in flight must wait for it: both drive
+ * rACT, and racing them lets the recovery re-assert rACT after the reset,
+ * leaving the gripper activated after on_deactivate reported success.
+ */
+TEST(TestRobotiqGripperHardwareInterface, deactivation_waits_for_an_in_flight_recovery)
+{
+   RecoveringGripper gripper;
+   const rclcpp_lifecycle::State state;
+   using CallbackReturn = RobotiqGripperHardwareInterface::CallbackReturn;
+
+   ASSERT_EQ(CallbackReturn::SUCCESS, gripper.on_configure(state));
+   ASSERT_EQ(CallbackReturn::SUCCESS, gripper.on_activate(state));
+
+   gripper.request_recovery();
+   ASSERT_EQ(hardware_interface::return_type::OK, gripper.read(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)));
+   ASSERT_TRUE(gripper.recovery_in_flight());
+
+   EXPECT_EQ(CallbackReturn::SUCCESS, gripper.on_deactivate(state));
+   EXPECT_TRUE(gripper.recovery_has_finished()) << "on_deactivate returned while the recovery was still running";
+   // The gripper must end deactivated and stay there: unserialized, the
+   // recovery re-asserts rACT a few exchange cycles after the reset.
+   EXPECT_FALSE(Robotiq::waitFor([&] { return gripper.gripper_activated(); }, std::chrono::milliseconds{500}));
+
+   EXPECT_EQ(CallbackReturn::SUCCESS, gripper.on_cleanup(state));
 }
 
 } // namespace robotiq_driver::test

--- a/grippers/robotiq_driver/tests/test_robotiq_gripper_hardware_interface.cpp
+++ b/grippers/robotiq_driver/tests/test_robotiq_gripper_hardware_interface.cpp
@@ -32,6 +32,7 @@
 #include <chrono>
 #include <cmath>
 #include <future>
+#include <limits>
 #include <string>
 #include <thread>
 
@@ -45,11 +46,11 @@
 #include <hardware_interface/version.h>
 #endif
 
+#include <robotiq_driver/rclcpp_logger.hpp>
+
 #include <rclcpp/node.hpp>
 
 #include <robotiq_driver/hardware_interface.hpp>
-
-#include <Robotiq/gripper/wait.hpp>
 
 namespace robotiq_driver::test {
 
@@ -206,12 +207,17 @@ class RecoveringGripper : public RobotiqGripperHardwareInterface
 public:
    RecoveringGripper()
    {
+      logger_ = std::make_shared<RclcppLogger>(rclcpp::get_logger("RecoveringGripperTest"));
       parameters_.use_dummy = true;
       parameters_.closed_position = 0.7929;
       parameters_.connection.connectionFrequency = 20.0;
    }
 
    void request_recovery() { reactivate_gripper_cmd_ = 1.0; }
+   void command_position(double position) { gripper_position_command_ = position; }
+   void command_speed(double speed) { gripper_speed_ = speed; }
+   uint8_t commanded_position_register() const { return gripper_->getCommand().positionRequest; }
+   uint8_t commanded_speed_register() const { return gripper_->getCommand().speed; }
    bool recovery_in_flight() const { return recovery_.valid(); }
    bool recovery_has_finished() const
    {
@@ -242,11 +248,115 @@ TEST(TestRobotiqGripperHardwareInterface, deactivation_waits_for_an_in_flight_re
 
    EXPECT_EQ(CallbackReturn::SUCCESS, gripper.on_deactivate(state));
    EXPECT_TRUE(gripper.recovery_has_finished()) << "on_deactivate returned while the recovery was still running";
-   // The gripper must end deactivated and stay there: unserialized, the
-   // recovery re-asserts rACT a few exchange cycles after the reset.
-   EXPECT_FALSE(Robotiq::waitFor([&] { return gripper.gripper_activated(); }, std::chrono::milliseconds{500}));
+   // on_deactivate does not return until the gripper reports the bit cleared,
+   // and the recovery that could re-assert it has been awaited above.
+   EXPECT_FALSE(gripper.gripper_activated());
 
    EXPECT_EQ(CallbackReturn::SUCCESS, gripper.on_cleanup(state));
+}
+
+/**
+ * write() is suppressed while a recovery is in flight: the handshake drives
+ * rACT itself, and a position command landing mid-reset aborts it.
+ */
+TEST(TestRobotiqGripperHardwareInterface, write_is_suppressed_during_a_recovery)
+{
+   RecoveringGripper gripper;
+   const rclcpp_lifecycle::State state;
+   using CallbackReturn = RobotiqGripperHardwareInterface::CallbackReturn;
+
+   ASSERT_EQ(CallbackReturn::SUCCESS, gripper.on_configure(state));
+   ASSERT_EQ(CallbackReturn::SUCCESS, gripper.on_activate(state));
+
+   gripper.command_position(0.0);
+   ASSERT_EQ(hardware_interface::return_type::OK, gripper.write(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)));
+   const uint8_t before = gripper.commanded_position_register();
+
+   gripper.request_recovery();
+   ASSERT_EQ(hardware_interface::return_type::OK, gripper.read(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)));
+   ASSERT_TRUE(gripper.recovery_in_flight());
+
+   gripper.command_position(0.7929);
+   EXPECT_EQ(hardware_interface::return_type::OK, gripper.write(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)));
+   EXPECT_EQ(before, gripper.commanded_position_register()) << "write() reached the gripper during a recovery";
+
+   EXPECT_EQ(CallbackReturn::SUCCESS, gripper.on_deactivate(state));
+   EXPECT_EQ(CallbackReturn::SUCCESS, gripper.on_cleanup(state));
+}
+
+/**
+ * A controller can write a NaN to set_gripper_max_velocity. That register then
+ * has no value to compute, so it keeps the one it had while the position it
+ * could compute goes through.
+ */
+TEST(TestRobotiqGripperHardwareInterface, an_unmappable_speed_keeps_the_previous_one)
+{
+   RecoveringGripper gripper;
+   const rclcpp_lifecycle::State state;
+   using CallbackReturn = RobotiqGripperHardwareInterface::CallbackReturn;
+
+   ASSERT_EQ(CallbackReturn::SUCCESS, gripper.on_configure(state));
+   ASSERT_EQ(CallbackReturn::SUCCESS, gripper.on_activate(state));
+
+   gripper.command_position(0.0);
+   gripper.command_speed(0.05);
+   ASSERT_EQ(hardware_interface::return_type::OK, gripper.write(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)));
+   const uint8_t speed = gripper.commanded_speed_register();
+   const uint8_t position = gripper.commanded_position_register();
+   ASSERT_GT(speed, 0);
+
+   gripper.command_speed(std::numeric_limits<double>::quiet_NaN());
+   gripper.command_position(0.7929);
+   EXPECT_EQ(hardware_interface::return_type::OK, gripper.write(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)));
+   EXPECT_EQ(speed, gripper.commanded_speed_register()) << "a NaN speed reached the gripper as a register";
+   EXPECT_NE(position, gripper.commanded_position_register()) << "the position command stopped following";
+
+   EXPECT_EQ(CallbackReturn::SUCCESS, gripper.on_deactivate(state));
+   EXPECT_EQ(CallbackReturn::SUCCESS, gripper.on_cleanup(state));
+}
+
+/**
+ * on_cleanup with a recovery still in flight has to await it: the recovery
+ * borrows the gripper it is about to destroy.
+ */
+TEST(TestRobotiqGripperHardwareInterface, cleanup_awaits_an_in_flight_recovery)
+{
+   RecoveringGripper gripper;
+   const rclcpp_lifecycle::State state;
+   using CallbackReturn = RobotiqGripperHardwareInterface::CallbackReturn;
+
+   ASSERT_EQ(CallbackReturn::SUCCESS, gripper.on_configure(state));
+   ASSERT_EQ(CallbackReturn::SUCCESS, gripper.on_activate(state));
+
+   gripper.request_recovery();
+   ASSERT_EQ(hardware_interface::return_type::OK, gripper.read(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)));
+   ASSERT_TRUE(gripper.recovery_in_flight());
+
+   EXPECT_EQ(CallbackReturn::SUCCESS, gripper.on_cleanup(state));
+   EXPECT_FALSE(gripper.recovery_in_flight()) << "on_cleanup returned with the recovery still outstanding";
+}
+
+/**
+ * on_shutdown and on_error take the same path as on_cleanup, so an error
+ * transition does not leave the exchange thread running.
+ */
+TEST(TestRobotiqGripperHardwareInterface, shutdown_and_error_release_the_gripper)
+{
+   const rclcpp_lifecycle::State state;
+   using CallbackReturn = RobotiqGripperHardwareInterface::CallbackReturn;
+
+   for(const bool via_error : {false, true})
+   {
+      RecoveringGripper gripper;
+      ASSERT_EQ(CallbackReturn::SUCCESS, gripper.on_configure(state));
+      ASSERT_EQ(CallbackReturn::SUCCESS, gripper.on_activate(state));
+
+      EXPECT_EQ(CallbackReturn::SUCCESS, via_error ? gripper.on_error(state) : gripper.on_shutdown(state));
+      // read() reports ERROR once the gripper is gone, which is how we know it
+      // was released rather than left running.
+      EXPECT_EQ(hardware_interface::return_type::ERROR,
+                gripper.read(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)));
+   }
 }
 
 } // namespace robotiq_driver::test

--- a/grippers/robotiq_hardware_tests/CMakeLists.txt
+++ b/grippers/robotiq_hardware_tests/CMakeLists.txt
@@ -14,7 +14,6 @@ find_package(ament_cmake REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(serial REQUIRED)
 find_package(robotiq_driver REQUIRED)
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
@@ -23,7 +22,6 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   pluginlib
   rclcpp
   rclcpp_lifecycle
-  serial
 )
 
 add_executable(full_test
@@ -31,6 +29,9 @@ add_executable(full_test
     src/command_line_utility.hpp
     src/command_line_utility.cpp
 )
+# The gripper SDK is compiled into librobotiq_driver.so and its headers are
+# installed alongside that package's own, so linking the driver is enough to
+# reach Robotiq::Gripper — there is no second package to find.
 target_link_libraries(full_test robotiq_driver::robotiq_driver)
 
 ament_package()

--- a/grippers/robotiq_hardware_tests/src/gripper_interface_test.cpp
+++ b/grippers/robotiq_hardware_tests/src/gripper_interface_test.cpp
@@ -1,4 +1,5 @@
-// Copyright (c) 2022 PickNik, Inc.
+// Copyright (c) 2023 PickNik, Inc.
+// Copyright (c) 2026 Robotiq, Inc.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -26,23 +27,86 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <chrono>
-#include <thread>
-#include <iostream>
-#include <memory>
+//! Manual bench exercise for a real gripper: connect, activate, then drive the
+//! fingers through a few open/close cycles at two speeds. Not a unit test —
+//! it needs hardware on a serial port, so nothing in CI runs it.
 
-#include <robotiq_driver/default_driver.hpp>
-#include <robotiq_driver/default_serial.hpp>
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <string>
+
+#include <Robotiq/gripper.hpp>
+#include <Robotiq/gripper/command.hpp>
+#include <Robotiq/gripper/connection_config.hpp>
+#include <Robotiq/gripper/status.hpp>
+#include <Robotiq/gripper/wait.hpp>
 
 #include "command_line_utility.hpp"
 
-constexpr auto kComPort = "/dev/ttyUSB0";
-constexpr auto kBaudRate = 115200;
-constexpr auto kTimeout = 1;
-constexpr auto kSlaveAddress = 0x09;
+namespace {
+constexpr const char* kComPort = "/dev/ttyUSB0";
+constexpr int kBaudRate = 115200;
+constexpr double kTimeout = 1.0;
+constexpr int kSlaveAddress = 0x09;
 
-using robotiq_driver::DefaultDriver;
-using robotiq_driver::DefaultSerial;
+// Generous: a full open-to-close sweep at the slowest speed still lands well
+// inside it, and overshooting only costs a failed run its error message.
+constexpr auto kMotionTimeout = std::chrono::seconds{10};
+
+const char* to_string(Robotiq::ActivationResult result)
+{
+   switch(result)
+   {
+   case Robotiq::ActivationResult::Activated:
+      return "activated";
+   case Robotiq::ActivationResult::AlreadyActive:
+      return "already active";
+   case Robotiq::ActivationResult::FaultLatched:
+      return "refused: a major fault is latched";
+   case Robotiq::ActivationResult::Timeout:
+      return "timed out";
+   }
+   return "unknown";
+}
+
+//! Command a position and block until the gripper stops moving — either it
+//! arrived, or it closed on something.
+bool move_to(Robotiq::Gripper& gripper, uint8_t position, uint8_t speed, uint8_t force)
+{
+   Robotiq::GripperCommand command = Robotiq::GripperCommand::defaults();
+   command.action.set(Robotiq::ActionRequestBit::GoTo);
+   command.positionRequest = position;
+   command.speed = speed;
+   command.force = force;
+   gripper.setCommand(command);
+
+   // The gripper needs a cycle or two to acknowledge the request before
+   // gOBJ leaves Moving; wait for the echo first so this does not read the
+   // previous move's "stopped" and return immediately.
+   const auto deadline = std::chrono::steady_clock::now() + kMotionTimeout;
+   if(!Robotiq::waitUntil([&] { return gripper.getStatus().positionRequestEcho == position; }, deadline))
+   {
+      std::cout << "  the gripper never echoed the position request" << std::endl;
+      return false;
+   }
+   if(!Robotiq::waitUntil(
+         [&] { return gripper.getStatus().gripperStatus.objectDetection() != Robotiq::ObjectDetection::Moving; },
+         deadline))
+   {
+      std::cout << "  the gripper is still moving after " << kMotionTimeout.count() << " s" << std::endl;
+      return false;
+   }
+
+   const Robotiq::GripperStatus status = gripper.getStatus();
+   std::cout << "  stopped at " << static_cast<int>(status.position) << " counts"
+             << (status.gripperStatus.objectDetection() == Robotiq::ObjectDetection::AtRequestedPosition
+                    ? ""
+                    : " (object detected)")
+             << std::endl;
+   return true;
+}
+} // namespace
 
 int main(int argc, char* argv[])
 {
@@ -60,15 +124,15 @@ int main(int argc, char* argv[])
    int slave_address = kSlaveAddress;
    cli.registerHandler(
       "--slave-address",
-      [&slave_address](const char* value) { slave_address = std::stoi(value); },
+      [&slave_address](const char* value) { slave_address = std::stoi(value, nullptr, 0); },
       false);
 
    cli.registerHandler("-h", [&]() {
-      std::cout << "Usage: ./set_relative_pressure [OPTIONS]\n"
+      std::cout << "Usage: ./full_test [OPTIONS]\n"
                 << "Options:\n"
                 << "  --port VALUE                      Set the com port (default " << kComPort << ")\n"
                 << "  --baudrate VALUE                  Set the baudrate (default " << kBaudRate << "bps)\n"
-                << "  --timeout VALUE                   Set the read/write timeout (default " << kTimeout << "ms)\n"
+                << "  --timeout VALUE                   Set the read/write timeout (default " << kTimeout << "s)\n"
                 << "  --slave-address VALUE             Set the slave address (default " << kSlaveAddress << ")\n"
                 << "  -h                                Show this help message\n";
       exit(0);
@@ -79,95 +143,67 @@ int main(int argc, char* argv[])
       return 1;
    }
 
+   Robotiq::ConnectionConfig config;
+   config.serial.port = port;
+   config.serial.baudrate = static_cast<uint32_t>(baudrate);
+   config.serial.timeout =
+      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::duration<double>(timeout));
+   config.modbusSlaveAddress = static_cast<uint8_t>(slave_address);
+
+   std::cout << "Using the following parameters: " << std::endl;
+   std::cout << " - port: " << config.serial.port << std::endl;
+   std::cout << " - baudrate: " << config.serial.baudrate << "bps" << std::endl;
+   std::cout << " - read/write timeout: " << config.serial.timeout.count() << "ms" << std::endl;
+   std::cout << " - slave address: " << static_cast<int>(config.modbusSlaveAddress) << std::endl;
+
    try
    {
-      auto serial = std::make_unique<DefaultSerial>();
-      serial->set_port(port);
-      serial->set_baudrate(baudrate);
-      serial->set_timeout(
-         std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::duration<double>(timeout)));
+      // Construction opens the link, reads the gripper and starts the
+      // exchange cycle; it throws if the gripper does not answer.
+      Robotiq::Gripper gripper{config};
+      std::cout << "The gripper is connected." << std::endl;
 
-      auto driver = std::make_unique<DefaultDriver>(std::move(serial));
-      driver->set_slave_address(slave_address);
-
-      std::cout << "Using the following parameters: " << std::endl;
-      std::cout << " - port: " << port << std::endl;
-      std::cout << " - baudrate: " << baudrate << "bps" << std::endl;
-      std::cout << " - read/write timeout: " << timeout << "s" << std::endl;
-      std::cout << " - slave address: " << slave_address << std::endl;
-
-      const bool connected = driver->connect();
-      if(!connected)
+      std::cout << "Activating the gripper..." << std::endl;
+      const Robotiq::ActivationResult activation = Robotiq::activate(gripper);
+      std::cout << "  " << to_string(activation) << std::endl;
+      if(activation != Robotiq::ActivationResult::Activated && activation != Robotiq::ActivationResult::AlreadyActive)
       {
-         std::cout << "The gripper is not connected" << std::endl;
+         // A latched fault is deliberately not cleared here: the recovery
+         // reset releases any grip and sweeps the fingers.
+         std::cout << "Cannot continue without an activated gripper." << std::endl;
          return 1;
       }
 
-      std::cout << "The gripper is connected." << std::endl;
-      std::cout << "Deactivating the gripper..." << std::endl;
-      ;
+      constexpr uint8_t kFullSpeed = 0xFF;
+      constexpr uint8_t kSlowSpeed = 0x0F;
+      constexpr uint8_t kFullForce = 0xFF;
 
-      driver->deactivate();
-
-      std::cout << "The gripper is deactivated." << std::endl;
-      std::cout << "Activating gripper..." << std::endl;
-      ;
-
-      driver->activate();
-
-      std::cout << "The gripper is activated." << std::endl;
-      std::cout << "Closing the gripper..." << std::endl;
-
-      driver->set_gripper_position(0xFF);
-      while(driver->gripper_is_moving())
+      const struct
       {
-         std::this_thread::sleep_for(std::chrono::milliseconds(500));
-      }
+         const char* description;
+         uint8_t position;
+         uint8_t speed;
+      } steps[] = {
+         {"Closing the gripper...", 0xFF, kFullSpeed},
+         {"Opening the gripper...", 0x00, kFullSpeed},
+         {"Half closing the gripper...", 0x80, kFullSpeed},
+         {"Opening the gripper...", 0x00, kFullSpeed},
+         {"Closing the gripper slowly...", 0xFF, kSlowSpeed},
+         {"Opening the gripper...", 0x00, kFullSpeed},
+      };
 
-      std::cout << "Opening the gripper..." << std::endl;
-      driver->set_gripper_position(0x00);
-      while(driver->gripper_is_moving())
+      for(const auto& step : steps)
       {
-         std::this_thread::sleep_for(std::chrono::milliseconds(500));
-      }
-
-      std::cout << "Half closing the gripper..." << std::endl;
-      driver->set_gripper_position(0x80);
-      while(driver->gripper_is_moving())
-      {
-         std::this_thread::sleep_for(std::chrono::milliseconds(500));
-      }
-
-      std::cout << "Opening gripper..." << std::endl;
-      driver->set_gripper_position(0x00);
-      while(driver->gripper_is_moving())
-      {
-         std::this_thread::sleep_for(std::chrono::milliseconds(500));
-      }
-
-      std::cout << "Decreasing gripper speed..." << std::endl;
-      driver->set_speed(0x0F);
-
-      std::cout << "Closing gripper...\n";
-      driver->set_gripper_position(0xFF);
-      while(driver->gripper_is_moving())
-      {
-         std::this_thread::sleep_for(std::chrono::milliseconds(500));
-      }
-
-      std::cout << "Increasing gripper speed..." << std::endl;
-      driver->set_speed(0xFF);
-
-      std::cout << "Opening gripper..." << std::endl;
-      driver->set_gripper_position(0x00);
-      while(driver->gripper_is_moving())
-      {
-         std::this_thread::sleep_for(std::chrono::milliseconds(500));
+         std::cout << step.description << std::endl;
+         if(!move_to(gripper, step.position, step.speed, kFullForce))
+         {
+            return 1;
+         }
       }
    }
    catch(const std::exception& e)
    {
-      std::cout << "Failed to communicating with the gripper: " << e.what() << std::endl;
+      std::cout << "Failed to communicate with the gripper: " << e.what() << std::endl;
       return 1;
    }
 


### PR DESCRIPTION
Corresponding PR in the grippers repo: https://github.com/robotiq/grippers/pull/7

PR 1 of 2

`robotiq_driver` stops running its own Modbus stack and drives
`Robotiq::Gripper` from a new `extern/grippers` submodule. Two commits: 

1. The SDK arrives unused (submodule, build wiring, adapters)
2. The hardware interface switches over

The SDK is compiled into `librobotiq_driver.so` rather than built as a second
workspace package. Its headers
ship with the package, so a consumer may call SDK entry points the wrapper
itself never references. Docker and CI build the submodule exactly as they do
the tactile SDK. The gripper  package's `format`/`tidy` convenience targets are
dropped: they collided with the SDK's, and pre-commit is this repository's
formatting authority anyway.

Three small adapters land with the wiring, each testable without a gripper, a
serial port or a controller manager, sharing one `robotiq_driver_tests`
binary: 

- `rclcpp_logger` (SDK diagnostics → `/rosout` at matching severity, format-string-safe), 
- `hardware_parameters` (`HardwareInfo` →`Robotiq::ConnectionConfig`, with the
   defaults pinned here so the SDK changing its own cannot break an existing description)
- `gripper_scaling` (the register/joint arithmetic — the part that silently mis-commands a
   gripper when it is wrong).

The switch itself collapses the wrapper to unit conversion and lifecycle. The
SDK keeps a whole-snapshot process image behind a mutex, refreshed by its own
exchange thread, so `read()` and `write()` are pure memory operations that can
no longer stall the controller manager; the hand-rolled framing layer, CRC
table, serial abstraction, factories and `background_task()` thread all become
dead code (deleted in PR 2). `FakeDriver` becomes the SDK's
`makeFakeGripper()`, and link health is logged through `connectionState()`
instead of being swallowed.

## Follow-ups

Deliberately held back so the migration stays a migration; the first four pair
with the *Deliberately preserved bugs* table in the break analysis.

1. Conservative activation/deactivation behind a parameter — today either
   transition **drops whatever the gripper is holding**; the highest-value item.
2. Round the register mapping instead of truncating (one count low, 1 in 227).
3. Report recovery failure on `reactivate_gripper_response`.
4. Populate the `velocity` state interface (has always read 0), or expose gCU.
5. Decide what a faulted link does to the component once SDK reconnection lands.
6. Plumb `connection_frequency`/`activation_timeout` through the xacro macros.
7. Move the SI → register conversion into the SDK (SGRIP-872).
8. Non-blocking forms of the SDK's blocking procedures (SGRIP-873).
9. Move the ROS-free tests into the SDK (SGRIP-874).
10. Re-pin the submodule to a release tag once the SDK train lands.