### PR TITLE
Slim docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,4 +238,23 @@ git submodule update --init
 
 > `Dockerfile_TSF85_ROS2` and `build_launch_docker_ros2.sh` are kept as deprecation shims pointing to `Dockerfile` / `run.sh sensor`.
 
-The single-image build (`Dockerfile`) is distro-flexible — `--build-arg ROS_DISTRO=…` (default `jazzy`).
+The `Dockerfile` is a multi-stage build: a `builder` stage compiles the workspace, and a slim `runtime` stage (the default) ships only the built workspace plus runtime deps — no compiler, no colcon/rosdep, no test deps.
+
+Build it directly (the context **must** be the repo root — the Dockerfile `COPY`s `robotiq_tsf/`, `grippers/` and `extern/tactile_sensors/sdk_cpp`):
+
+```bash
+docker build -f docker/Dockerfile -t robotiq_ros2:jazzy .
+```
+
+Build options:
+
+- `--build-arg ROS_DISTRO=…` (default `jazzy`) — parameterized, but `jazzy` is the only distro the workspace is built and tested against; CI covers `jazzy` alone.
+- `--build-arg WITH_GUI=false` — **headless**: drop rviz2/rqt/joint-state-publisher-gui (and their mesa/Qt/VTK), for a much smaller image on robots that don't visualize.
+- `--target builder` — a **dev** image with the full toolchain, for building inside the container.
+
+```bash
+docker build --build-arg WITH_GUI=false -f docker/Dockerfile -t robotiq_ros2:jazzy-headless .
+docker build --target builder -f docker/Dockerfile -t robotiq_ros2:dev .
+```
+
+Then run it with the sensor/gripper devices mapped via `./docker/run.sh [gripper|sensor|both]`.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,38 +1,34 @@
-# Single ROS 2 image for the whole robotiq ros workspace:
+# Multi-stage ROS 2 image for the whole robotiq ros workspace:
 #   - robotiq_tsf   (TSF-85 tactile sensor driver)
 #   - grippers/*    (Robotiq gripper driver, forked from PickNik)
 #
-# Self-contained: the image COPYs the workspace sources, pulls the gripper's
-# external `serial` dependency, and builds — so a reviewer can build and test
-# the branch with nothing but this repo.
+# Stage 1 (builder): full toolchain, compiles the workspace.
+# Stage 2 (runtime, default): slim — only runtime deps + the built install/, no
+#   compiler / colcon / test deps. GUI (rviz2, rqt, …) is optional.
 #
-# Distro is a build-arg flip:
-#   docker build -f docker/Dockerfile -t robotiq_ros2:jazzy .
-#   docker build --build-arg ROS_DISTRO=rolling -f docker/Dockerfile -t robotiq_ros2:rolling .
-# Build context MUST be the repo root (it COPYs robotiq_tsf/ and grippers/).
+# Build options, examples and the build-context requirement: see the Docker
+# section in README.md.
 
 ARG ROS_DISTRO=jazzy
-FROM ros:${ROS_DISTRO}-ros-base
+
+##############################  builder  ##############################
+FROM ros:${ROS_DISTRO}-ros-base AS builder
 ARG ROS_DISTRO
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 
-# Build tooling + sensor deps (OpenCV/cv_bridge/libserialport) + gripper deps (ros2_control stack).
+# Build tooling + sensor build deps (libserialport, via pkg-config) + gripper
+# build deps (ros2_control stack).
 RUN apt-get update && apt-get install -y \
-        tzdata terminator pkg-config \
+        pkg-config \
         python3-colcon-common-extensions python3-vcstool python3-rosdep \
-        libopencv-dev libserialport-dev \
-        ros-${ROS_DISTRO}-cv-bridge \
+        libserialport-dev \
         ros-${ROS_DISTRO}-ros2-control \
         ros-${ROS_DISTRO}-ros2-controllers \
         ros-${ROS_DISTRO}-controller-manager \
         ros-${ROS_DISTRO}-xacro \
-        ros-${ROS_DISTRO}-joint-state-publisher \
-        ros-${ROS_DISTRO}-joint-state-publisher-gui \
         ros-${ROS_DISTRO}-robot-state-publisher \
-        ros-${ROS_DISTRO}-rviz2 \
-        ros-${ROS_DISTRO}-rqt \
-        ros-${ROS_DISTRO}-rqt-controller-manager \
+        ros-${ROS_DISTRO}-joint-state-publisher \
     && rm -rf /var/lib/apt/lists/*
 
 RUN rosdep init 2>/dev/null || true; rosdep update
@@ -49,13 +45,52 @@ RUN touch /ws/src/extern/tactile_sensors/sdk_cpp/COLCON_IGNORE
 # Gripper's external `serial` dep (tylerjw/serial), via the upstream .repos file.
 RUN cd /ws/src && vcs import < grippers/ros2_robotiq_gripper.rolling.repos
 
-# Resolve any remaining rosdeps from the package manifests, then build Release.
+# Resolve remaining rosdeps (build + exec only — NOT test deps, e.g.
+# ament_clang_tidy → clang-tools), then build Release. No --symlink-install, so
+# install/ is self-contained and can be copied into the runtime stage.
+# BUILD_TESTING=OFF: this is a deployment image; tests are not run here.
 RUN apt-get update \
     && rosdep install --from-paths /ws/src --ignore-src -y --rosdistro ${ROS_DISTRO} \
-         --skip-keys "OpenCV libserialport" \
+         --skip-keys "libserialport" \
+         --dependency-types buildtool --dependency-types build \
+         --dependency-types build_export --dependency-types buildtool_export \
+         --dependency-types exec \
     && rm -rf /var/lib/apt/lists/* \
-    && /bin/bash -lc "source /opt/ros/${ROS_DISTRO}/setup.bash \
-        && cd /ws && colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release"
+    && bash -lc "source /opt/ros/${ROS_DISTRO}/setup.bash \
+        && cd /ws && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF"
+
+##########################  runtime (default)  ########################
+# ros-core (not ros-base): the minimal ROS layer, without build-essential /
+# colcon / rosdep. Runtime deps are apt-installed explicitly below.
+FROM ros:${ROS_DISTRO}-ros-core AS runtime
+ARG ROS_DISTRO
+ARG DEBIAN_FRONTEND=noninteractive
+ARG WITH_GUI=true
+ENV TZ=Etc/UTC
+
+# Runtime deps only — no compiler, no colcon/rosdep, no test deps. Some -dev
+# packages still arrive anyway (~350 MB): ROS binary debs hard-depend on them,
+# e.g. ros-*-tf2-eigen -> libeigen3-dev, rviz-rendering -> mesa -dev. They are
+# inert with no compiler present, and unavoidable short of unbundling those debs.
+# GUI tools (rviz2/rqt/joint-state-publisher-gui/terminator) are optional; drop
+# them for headless robots with --build-arg WITH_GUI=false.
+RUN apt-get update && apt-get install -y \
+        libserialport0 \
+        ros-${ROS_DISTRO}-ros2-control \
+        ros-${ROS_DISTRO}-ros2-controllers \
+        ros-${ROS_DISTRO}-controller-manager \
+        ros-${ROS_DISTRO}-xacro \
+        ros-${ROS_DISTRO}-robot-state-publisher \
+        ros-${ROS_DISTRO}-joint-state-publisher \
+    && if [ "${WITH_GUI}" = "true" ]; then apt-get install -y \
+        terminator \
+        ros-${ROS_DISTRO}-rviz2 \
+        ros-${ROS_DISTRO}-joint-state-publisher-gui \
+        ros-${ROS_DISTRO}-rqt \
+        ros-${ROS_DISTRO}-rqt-controller-manager ; fi \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /ws/install /ws/install
 
 RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> /root/.bashrc \
  && echo "source /ws/install/setup.bash"            >> /root/.bashrc

--- a/grippers/robotiq_description/launch/robotiq_control.launch.py
+++ b/grippers/robotiq_description/launch/robotiq_control.launch.py
@@ -104,14 +104,6 @@ def generate_launch_description():
         )
     }
 
-    update_rate_config_file = PathJoinSubstitution(
-        [
-            description_pkg_share,
-            "config",
-            "robotiq_update_rate.yaml",
-        ]
-    )
-
     controllers_file = "robotiq_controllers.yaml"
     initial_joint_controllers = PathJoinSubstitution(
         [description_pkg_share, "config", controllers_file]
@@ -122,7 +114,6 @@ def generate_launch_description():
         executable="ros2_control_node",
         parameters=[
             robot_description_param,
-            update_rate_config_file,
             initial_joint_controllers,
         ],
     )

--- a/robotiq_tsf/CMakeLists.txt
+++ b/robotiq_tsf/CMakeLists.txt
@@ -8,7 +8,6 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 find_package(ament_cmake REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(Eigen3 REQUIRED)
-find_package(OpenCV REQUIRED)
 find_package(PkgConfig REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
@@ -69,7 +68,6 @@ list(APPEND interface_targets_installed ${PROJECT_NAME}__rosidl_generator_py)
 include_directories(
   include
   include/robotiq_tsf
-  ${OpenCV_INCLUDE_DIRS}
 )
 
 add_library(${PROJECT_NAME}_algorithms
@@ -84,7 +82,6 @@ target_include_directories(${PROJECT_NAME}_algorithms
 
 target_link_libraries(${PROJECT_NAME}_algorithms
   PUBLIC
-    ${OpenCV_LIBRARIES}
     Eigen3::Eigen
 )
 
@@ -124,7 +121,6 @@ target_include_directories(tactile_total_sum_node
 target_link_libraries(tactile_total_sum_node
   ${PROJECT_NAME}_algorithms
   ${cpp_typesupport_target}
-  ${OpenCV_LIBRARIES}
   Threads::Threads
 )
 
@@ -166,7 +162,6 @@ install(DIRECTORY resource/
 
 ament_export_dependencies(
   Eigen3
-  OpenCV
   ament_index_cpp
   rclcpp
   rosidl_default_runtime

--- a/robotiq_tsf/package.xml
+++ b/robotiq_tsf/package.xml
@@ -30,7 +30,6 @@
 
   <!-- Quaternion algebra in the AHRS/algorithms library (header-only). -->
   <depend>eigen</depend>
-  <depend>libopencv-dev</depend>
   <!-- SDK-backed poller (poll_data_sdk_node) links the tactile_sensors SDK,
        which uses libserialport. Installed explicitly in docker/Dockerfile. -->
   <depend>libserialport</depend>


### PR DESCRIPTION
## Summary

Splits `docker/Dockerfile` into a `builder` stage with the full toolchain and a slim `runtime` stage (the default) that ships only the built `install/` plus runtime deps. Adds a `WITH_GUI` build-arg for headless robots. OpenCV, which was a very heavy unused dependency, is removed.

| Image | Before | After |
|---|---|---|
| With GUI | 5.28 GB | **2.59 GB** |
| Headless (`WITH_GUI=false`) | — | **1.36 GB** |

No functional change to any node, topic, or launch argument.

## Testing

- **Hardware** (`./docker/run.sh both`): gripper bringup activates `RobotiqGripperHardwareInterface` and all three controllers, and `gripper_cmd` velocity/effort reach the gripper; the sensor node auto-detects the TSF-85 and opens it over libserialport.
- **Build/test**: all six workspace packages compile with no `libopencv-dev` present anywhere. `robotiq_tsf` builds with `BUILD_TESTING=ON` in the `builder` image and passes 61/61.
- **Runtime image**: no missing shared libraries across the whole `install/` tree; `tactile_total_sum_node` (one of the two previously OpenCV-linked targets) runs and exits cleanly; no compiler, colcon, or rosdep present.
- **Launch fix**: verified with `use_fake_hardware:=true` — warning gone, no `robotiq_update_rate` references remain in `install/`, rate still reported as 500 Hz.

FYI @mbegin-robotiq  @JonathanBeaudoinRq 