### PR TITLE
Make repo more ide friendly

### DIFF
--- a/dev/CMakeLists.txt
+++ b/dev/CMakeLists.txt
@@ -1,0 +1,43 @@
+# Developer-only aggregate: opens every C++ package in the workspace as a
+# single CMake project, for IDEs that take one CMakeLists as their entry point.
+#
+# Not a build product. colcon never sees this directory — the COLCON_IGNORE
+# beside this file stops it descending — and the real build is still colcon
+# building each ament package on its own. Nothing here affects CI or Docker.
+#
+#   cmake --preset ide && cmake --build --preset ide-install && ctest --preset ide
+#
+# or point the IDE at dev/CMakeLists.txt and pick the "ide" preset (Qt Creator:
+# Open File or Project). See CMakePresets.json beside this file.
+
+cmake_minimum_required(VERSION 3.16)
+project(robotiq_ros_ide LANGUAGES CXX)
+
+find_package(ament_cmake REQUIRED)
+
+# Each package keeps its own project() and ament_package(); they are pulled in
+# side by side purely so the code model sees them together. A package must come
+# after the ones it depends on — see the alias below.
+set(ROBOTIQ_IDE_PACKAGES
+  ../robotiq_tsf
+  ../grippers/robotiq_driver          # brings extern/grippers (the SDK) with it
+  ../grippers/robotiq_controllers
+  ../grippers/robotiq_hardware_tests
+)
+
+foreach(package IN LISTS ROBOTIQ_IDE_PACKAGES)
+  get_filename_component(name ${package} NAME)
+  add_subdirectory(${package} ${CMAKE_CURRENT_BINARY_DIR}/${name})
+
+  # Packages reach each other through the namespaced target their config file
+  # exports. There is no config file in-tree, so publish the same name as an
+  # alias for the package that follows to link against.
+  if(TARGET ${name} AND NOT TARGET ${name}::${name})
+    # A package name can also belong to an executable or to a utility target
+    # generated for its messages; only a library can be aliased.
+    get_target_property(target_type ${name} TYPE)
+    if(target_type MATCHES "LIBRARY$")
+      add_library(${name}::${name} ALIAS ${name})
+    endif()
+  endif()
+endforeach()

--- a/dev/CMakePresets.json
+++ b/dev/CMakePresets.json
@@ -1,0 +1,42 @@
+{
+  "version": 4,
+  "configurePresets": [
+    {
+      "name": "ide",
+      "displayName": "Workspace (all C++ packages)",
+      "description": "Every C++ package as one project, installed into build/ide/prefix so plugins and tests resolve.",
+      "binaryDir": "${sourceDir}/../build/ide",
+      "installDir": "${sourceDir}/../build/ide/prefix",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "ide",
+      "configurePreset": "ide"
+    },
+    {
+      "name": "ide-install",
+      "displayName": "Build and install",
+      "description": "Tests that load the ros2_control plugin by name need the install tree, not the build tree.",
+      "configurePreset": "ide",
+      "targets": ["install"]
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "ide",
+      "configurePreset": "ide",
+      "environment": {
+        "LD_LIBRARY_PATH": "${sourceDir}/../build/ide/prefix/lib:$penv{LD_LIBRARY_PATH}",
+        "PYTHONPATH": "${sourceDir}/../build/ide/prefix/lib/python3.12/site-packages:$penv{PYTHONPATH}"
+      },
+      "output": {
+        "outputOnFailure": true
+      }
+    }
+  ]
+}

--- a/grippers/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
+++ b/grippers/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
@@ -154,7 +154,7 @@ protected:
     * @throw Robotiq::SerialIOException, Robotiq::DriverException as the
     *        Robotiq::Gripper constructor does.
     */
-   virtual std::unique_ptr<Robotiq::Gripper> create_gripper();
+   virtual std::unique_ptr<Robotiq::Gripper> createGripper();
 
    GripperParameters parameters_;
 

--- a/grippers/robotiq_driver/src/hardware_interface.cpp
+++ b/grippers/robotiq_driver/src/hardware_interface.cpp
@@ -58,7 +58,7 @@ constexpr auto kDeactivationTimeout = std::chrono::seconds{2};
 
 namespace robotiq_driver {
 namespace {
-const char* to_string(Robotiq::ConnectionState state)
+const char* toString(Robotiq::ConnectionState state)
 {
    switch(state)
    {
@@ -77,7 +77,7 @@ const char* to_string(Robotiq::ConnectionState state)
 // A recovery future stays valid from launch until read() consumes its result,
 // so `valid()` alone answers "is a recovery outstanding"; this answers the
 // narrower "has it finished".
-bool has_finished(const std::future<Robotiq::ActivationResult>& recovery)
+bool hasFinished(const std::future<Robotiq::ActivationResult>& recovery)
 {
    return recovery.valid() && recovery.wait_for(std::chrono::seconds{0}) == std::future_status::ready;
 }
@@ -87,7 +87,7 @@ RobotiqGripperHardwareInterface::RobotiqGripperHardwareInterface() = default;
 
 RobotiqGripperHardwareInterface::~RobotiqGripperHardwareInterface() = default;
 
-std::unique_ptr<Robotiq::Gripper> RobotiqGripperHardwareInterface::create_gripper()
+std::unique_ptr<Robotiq::Gripper> RobotiqGripperHardwareInterface::createGripper()
 {
    if(parameters_.use_dummy)
    {
@@ -187,7 +187,7 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Roboti
 
    try
    {
-      gripper_ = create_gripper();
+      gripper_ = createGripper();
    }
    catch(const std::exception& e)
    {
@@ -373,7 +373,7 @@ hardware_interface::return_type RobotiqGripperHardwareInterface::read(const rclc
                            kDiagnosticThrottleMs,
                            "The Robotiq gripper on %s: link is %s; the reported position may be stale.",
                            parameters_.connection.serial.port.c_str(),
-                           to_string(connection));
+                           toString(connection));
    }
 
    if(status.faultStatus.gripperFault() != Robotiq::GripperFault::None)
@@ -404,7 +404,7 @@ hardware_interface::return_type RobotiqGripperHardwareInterface::read(const rclc
       }
    }
 
-   if(has_finished(recovery_))
+   if(hasFinished(recovery_))
    {
       const Robotiq::ActivationResult result = recovery_.get();
       recovery_ = {};

--- a/grippers/robotiq_driver/tests/CMakeLists.txt
+++ b/grippers/robotiq_driver/tests/CMakeLists.txt
@@ -21,6 +21,10 @@ ament_add_gmock(${PROJECT_NAME}_tests
 target_include_directories(${PROJECT_NAME}_tests
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
 )
+# Where this build installs the plugin, for the tests that load it by name.
+target_compile_definitions(${PROJECT_NAME}_tests
+    PRIVATE ROBOTIQ_DRIVER_INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}"
+)
 target_link_libraries(
     ${PROJECT_NAME}_tests
     robotiq_driver

--- a/grippers/robotiq_driver/tests/test_robotiq_gripper_hardware_interface.cpp
+++ b/grippers/robotiq_driver/tests/test_robotiq_gripper_hardware_interface.cpp
@@ -31,6 +31,7 @@
 
 #include <chrono>
 #include <cmath>
+#include <cstdlib>
 #include <future>
 #include <limits>
 #include <string>
@@ -359,12 +360,25 @@ TEST(TestRobotiqGripperHardwareInterface, shutdown_and_error_release_the_gripper
    }
 }
 
+namespace {
+// pluginlib finds the hardware interface through the ament index in the install
+// tree, so the tests that load it by name need this build's install prefix on
+// AMENT_PREFIX_PATH. Nothing else provides it — not ctest, not an IDE, not a
+// shell — and prepending a prefix that is already there costs nothing.
+void announceTheInstalledPlugin()
+{
+   const char* const search_path = std::getenv("AMENT_PREFIX_PATH");
+   const std::string prefix = ROBOTIQ_DRIVER_INSTALL_PREFIX;
+   setenv("AMENT_PREFIX_PATH", (search_path ? prefix + ":" + search_path : prefix).c_str(), 1);
+}
+} // namespace
 } // namespace robotiq_driver::test
 
 // main() for the whole package suite: the test files link into one binary, and
 // rclcpp has to be up before any node is constructed.
 int main(int argc, char** argv)
 {
+   robotiq_driver::test::announceTheInstalledPlugin();
    rclcpp::init(argc, argv);
    testing::InitGoogleTest(&argc, argv);
    return RUN_ALL_TESTS();

--- a/grippers/robotiq_driver/tests/test_robotiq_gripper_hardware_interface.cpp
+++ b/grippers/robotiq_driver/tests/test_robotiq_gripper_hardware_interface.cpp
@@ -60,7 +60,7 @@ constexpr const char* kComponentName = "robotiq_driver_ros2_control";
 
 //! \p extra_hardware_params is spliced into the <hardware> block, so a test
 //! can select a backend without restating the whole description.
-std::string minimal_robot_urdf(const std::string& extra_hardware_params = "")
+std::string minimalRobotUrdf(const std::string& extra_hardware_params = "")
 {
    return std::string(R"(
         <?xml version="1.0" encoding="utf-8"?>
@@ -105,9 +105,9 @@ std::string minimal_robot_urdf(const std::string& extra_hardware_params = "")
  * This test generates a minimal xacro robot configuration and loads the
  * hardware interface plugin.
  */
-TEST(TestRobotiqGripperHardwareInterface, load_urdf)
+TEST(TestRobotiqGripperHardwareInterface, LoadsThePluginFromUrdf)
 {
-   const std::string urdf = minimal_robot_urdf();
+   const std::string urdf = minimalRobotUrdf();
 
    rclcpp::Node node{"test_robotiq_gripper_hardware_interface"};
 
@@ -128,9 +128,9 @@ TEST(TestRobotiqGripperHardwareInterface, load_urdf)
  * hardware stops exporting them under these exact names the gripper controller
  * fails to activate at runtime.
  */
-TEST(TestRobotiqGripperHardwareInterface, exports_expected_command_interfaces)
+TEST(TestRobotiqGripperHardwareInterface, ExportsExpectedCommandInterfaces)
 {
-   const std::string urdf = minimal_robot_urdf();
+   const std::string urdf = minimalRobotUrdf();
 
    rclcpp::Node node{"test_robotiq_gripper_hardware_interface"};
 
@@ -156,9 +156,9 @@ TEST(TestRobotiqGripperHardwareInterface, exports_expected_command_interfaces)
  * gripper and activation controllers, which bind to interfaces the
  * ros2_control mock does not export.
  */
-TEST(TestRobotiqGripperHardwareInterface, use_dummy_activates_and_follows_commands)
+TEST(TestRobotiqGripperHardwareInterface, UseDummyActivatesAndFollowsCommands)
 {
-   const std::string urdf = minimal_robot_urdf(R"(<param name="use_dummy">true</param>)");
+   const std::string urdf = minimalRobotUrdf(R"(<param name="use_dummy">true</param>)");
 
    rclcpp::Node node{"test_robotiq_gripper_hardware_interface"};
 
@@ -214,17 +214,17 @@ public:
       parameters_.connection.connectionFrequency = 20.0;
    }
 
-   void request_recovery() { reactivate_gripper_cmd_ = 1.0; }
-   void command_position(double position) { gripper_position_command_ = position; }
-   void command_speed(double speed) { gripper_speed_ = speed; }
-   uint8_t commanded_position_register() const { return gripper_->getCommand().positionRequest; }
-   uint8_t commanded_speed_register() const { return gripper_->getCommand().speed; }
-   bool recovery_in_flight() const { return recovery_.valid(); }
-   bool recovery_has_finished() const
+   void requestRecovery() { reactivate_gripper_cmd_ = 1.0; }
+   void commandPosition(double position) { gripper_position_command_ = position; }
+   void commandSpeed(double speed) { gripper_speed_ = speed; }
+   uint8_t commandedPositionRegister() const { return gripper_->getCommand().positionRequest; }
+   uint8_t commandedSpeedRegister() const { return gripper_->getCommand().speed; }
+   bool recoveryInFlight() const { return recovery_.valid(); }
+   bool recoveryHasFinished() const
    {
       return recovery_.valid() && recovery_.wait_for(std::chrono::seconds{0}) == std::future_status::ready;
    }
-   bool gripper_activated() const { return gripper_->getStatus().gripperStatus.activated(); }
+   bool gripperActivated() const { return gripper_->getStatus().gripperStatus.activated(); }
 };
 } // namespace
 
@@ -234,7 +234,7 @@ public:
  * rACT, and racing them lets the recovery re-assert rACT after the reset,
  * leaving the gripper activated after on_deactivate reported success.
  */
-TEST(TestRobotiqGripperHardwareInterface, deactivation_waits_for_an_in_flight_recovery)
+TEST(TestRobotiqGripperHardwareInterface, DeactivationWaitsForAnInFlightRecovery)
 {
    RecoveringGripper gripper;
    const rclcpp_lifecycle::State state;
@@ -243,15 +243,15 @@ TEST(TestRobotiqGripperHardwareInterface, deactivation_waits_for_an_in_flight_re
    ASSERT_EQ(CallbackReturn::SUCCESS, gripper.on_configure(state));
    ASSERT_EQ(CallbackReturn::SUCCESS, gripper.on_activate(state));
 
-   gripper.request_recovery();
+   gripper.requestRecovery();
    ASSERT_EQ(hardware_interface::return_type::OK, gripper.read(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)));
-   ASSERT_TRUE(gripper.recovery_in_flight());
+   ASSERT_TRUE(gripper.recoveryInFlight());
 
    EXPECT_EQ(CallbackReturn::SUCCESS, gripper.on_deactivate(state));
-   EXPECT_TRUE(gripper.recovery_has_finished()) << "on_deactivate returned while the recovery was still running";
+   EXPECT_TRUE(gripper.recoveryHasFinished()) << "on_deactivate returned while the recovery was still running";
    // on_deactivate does not return until the gripper reports the bit cleared,
    // and the recovery that could re-assert it has been awaited above.
-   EXPECT_FALSE(gripper.gripper_activated());
+   EXPECT_FALSE(gripper.gripperActivated());
 
    EXPECT_EQ(CallbackReturn::SUCCESS, gripper.on_cleanup(state));
 }
@@ -260,7 +260,7 @@ TEST(TestRobotiqGripperHardwareInterface, deactivation_waits_for_an_in_flight_re
  * write() is suppressed while a recovery is in flight: the handshake drives
  * rACT itself, and a position command landing mid-reset aborts it.
  */
-TEST(TestRobotiqGripperHardwareInterface, write_is_suppressed_during_a_recovery)
+TEST(TestRobotiqGripperHardwareInterface, WriteIsSuppressedDuringARecovery)
 {
    RecoveringGripper gripper;
    const rclcpp_lifecycle::State state;
@@ -269,17 +269,17 @@ TEST(TestRobotiqGripperHardwareInterface, write_is_suppressed_during_a_recovery)
    ASSERT_EQ(CallbackReturn::SUCCESS, gripper.on_configure(state));
    ASSERT_EQ(CallbackReturn::SUCCESS, gripper.on_activate(state));
 
-   gripper.command_position(0.0);
+   gripper.commandPosition(0.0);
    ASSERT_EQ(hardware_interface::return_type::OK, gripper.write(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)));
-   const uint8_t before = gripper.commanded_position_register();
+   const uint8_t before = gripper.commandedPositionRegister();
 
-   gripper.request_recovery();
+   gripper.requestRecovery();
    ASSERT_EQ(hardware_interface::return_type::OK, gripper.read(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)));
-   ASSERT_TRUE(gripper.recovery_in_flight());
+   ASSERT_TRUE(gripper.recoveryInFlight());
 
-   gripper.command_position(0.7929);
+   gripper.commandPosition(0.7929);
    EXPECT_EQ(hardware_interface::return_type::OK, gripper.write(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)));
-   EXPECT_EQ(before, gripper.commanded_position_register()) << "write() reached the gripper during a recovery";
+   EXPECT_EQ(before, gripper.commandedPositionRegister()) << "write() reached the gripper during a recovery";
 
    EXPECT_EQ(CallbackReturn::SUCCESS, gripper.on_deactivate(state));
    EXPECT_EQ(CallbackReturn::SUCCESS, gripper.on_cleanup(state));
@@ -290,7 +290,7 @@ TEST(TestRobotiqGripperHardwareInterface, write_is_suppressed_during_a_recovery)
  * has no value to compute, so it keeps the one it had while the position it
  * could compute goes through.
  */
-TEST(TestRobotiqGripperHardwareInterface, an_unmappable_speed_keeps_the_previous_one)
+TEST(TestRobotiqGripperHardwareInterface, AnUnmappableSpeedKeepsThePreviousOne)
 {
    RecoveringGripper gripper;
    const rclcpp_lifecycle::State state;
@@ -299,18 +299,18 @@ TEST(TestRobotiqGripperHardwareInterface, an_unmappable_speed_keeps_the_previous
    ASSERT_EQ(CallbackReturn::SUCCESS, gripper.on_configure(state));
    ASSERT_EQ(CallbackReturn::SUCCESS, gripper.on_activate(state));
 
-   gripper.command_position(0.0);
-   gripper.command_speed(0.05);
+   gripper.commandPosition(0.0);
+   gripper.commandSpeed(0.05);
    ASSERT_EQ(hardware_interface::return_type::OK, gripper.write(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)));
-   const uint8_t speed = gripper.commanded_speed_register();
-   const uint8_t position = gripper.commanded_position_register();
+   const uint8_t speed = gripper.commandedSpeedRegister();
+   const uint8_t position = gripper.commandedPositionRegister();
    ASSERT_GT(speed, 0);
 
-   gripper.command_speed(std::numeric_limits<double>::quiet_NaN());
-   gripper.command_position(0.7929);
+   gripper.commandSpeed(std::numeric_limits<double>::quiet_NaN());
+   gripper.commandPosition(0.7929);
    EXPECT_EQ(hardware_interface::return_type::OK, gripper.write(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)));
-   EXPECT_EQ(speed, gripper.commanded_speed_register()) << "a NaN speed reached the gripper as a register";
-   EXPECT_NE(position, gripper.commanded_position_register()) << "the position command stopped following";
+   EXPECT_EQ(speed, gripper.commandedSpeedRegister()) << "a NaN speed reached the gripper as a register";
+   EXPECT_NE(position, gripper.commandedPositionRegister()) << "the position command stopped following";
 
    EXPECT_EQ(CallbackReturn::SUCCESS, gripper.on_deactivate(state));
    EXPECT_EQ(CallbackReturn::SUCCESS, gripper.on_cleanup(state));
@@ -320,7 +320,7 @@ TEST(TestRobotiqGripperHardwareInterface, an_unmappable_speed_keeps_the_previous
  * on_cleanup with a recovery still in flight has to await it: the recovery
  * borrows the gripper it is about to destroy.
  */
-TEST(TestRobotiqGripperHardwareInterface, cleanup_awaits_an_in_flight_recovery)
+TEST(TestRobotiqGripperHardwareInterface, CleanupAwaitsAnInFlightRecovery)
 {
    RecoveringGripper gripper;
    const rclcpp_lifecycle::State state;
@@ -329,19 +329,19 @@ TEST(TestRobotiqGripperHardwareInterface, cleanup_awaits_an_in_flight_recovery)
    ASSERT_EQ(CallbackReturn::SUCCESS, gripper.on_configure(state));
    ASSERT_EQ(CallbackReturn::SUCCESS, gripper.on_activate(state));
 
-   gripper.request_recovery();
+   gripper.requestRecovery();
    ASSERT_EQ(hardware_interface::return_type::OK, gripper.read(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)));
-   ASSERT_TRUE(gripper.recovery_in_flight());
+   ASSERT_TRUE(gripper.recoveryInFlight());
 
    EXPECT_EQ(CallbackReturn::SUCCESS, gripper.on_cleanup(state));
-   EXPECT_FALSE(gripper.recovery_in_flight()) << "on_cleanup returned with the recovery still outstanding";
+   EXPECT_FALSE(gripper.recoveryInFlight()) << "on_cleanup returned with the recovery still outstanding";
 }
 
 /**
  * on_shutdown and on_error take the same path as on_cleanup, so an error
  * transition does not leave the exchange thread running.
  */
-TEST(TestRobotiqGripperHardwareInterface, shutdown_and_error_release_the_gripper)
+TEST(TestRobotiqGripperHardwareInterface, ShutdownAndErrorReleaseTheGripper)
 {
    const rclcpp_lifecycle::State state;
    using CallbackReturn = RobotiqGripperHardwareInterface::CallbackReturn;

--- a/grippers/robotiq_hardware_tests/CMakeLists.txt
+++ b/grippers/robotiq_hardware_tests/CMakeLists.txt
@@ -14,7 +14,11 @@ find_package(ament_cmake REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(robotiq_driver REQUIRED)
+# Already present when this package is configured as part of a larger project
+# (the dev/ IDE aggregate); found through its install prefix otherwise.
+if(NOT TARGET robotiq_driver::robotiq_driver)
+  find_package(robotiq_driver REQUIRED)
+endif()
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   ament_cmake

--- a/grippers/robotiq_hardware_tests/src/gripper_interface_test.cpp
+++ b/grippers/robotiq_hardware_tests/src/gripper_interface_test.cpp
@@ -54,7 +54,7 @@ constexpr int kSlaveAddress = 0x09;
 // inside it, and overshooting only costs a failed run its error message.
 constexpr auto kMotionTimeout = std::chrono::seconds{10};
 
-const char* to_string(Robotiq::ActivationResult result)
+const char* toString(Robotiq::ActivationResult result)
 {
    switch(result)
    {
@@ -72,7 +72,7 @@ const char* to_string(Robotiq::ActivationResult result)
 
 //! Command a position and block until the gripper stops moving — either it
 //! arrived, or it closed on something.
-bool move_to(Robotiq::Gripper& gripper, uint8_t position, uint8_t speed, uint8_t force)
+bool moveTo(Robotiq::Gripper& gripper, uint8_t position, uint8_t speed, uint8_t force)
 {
    Robotiq::GripperCommand command = Robotiq::GripperCommand::defaults();
    command.action.set(Robotiq::ActionRequestBit::GoTo);
@@ -165,7 +165,7 @@ int main(int argc, char* argv[])
 
       std::cout << "Activating the gripper..." << std::endl;
       const Robotiq::ActivationResult activation = Robotiq::activate(gripper);
-      std::cout << "  " << to_string(activation) << std::endl;
+      std::cout << "  " << toString(activation) << std::endl;
       if(activation != Robotiq::ActivationResult::Activated && activation != Robotiq::ActivationResult::AlreadyActive)
       {
          // A latched fault is deliberately not cleared here: the recovery
@@ -195,7 +195,7 @@ int main(int argc, char* argv[])
       for(const auto& step : steps)
       {
          std::cout << step.description << std::endl;
-         if(!move_to(gripper, step.position, step.speed, kFullForce))
+         if(!moveTo(gripper, step.position, step.speed, kFullForce))
          {
             return 1;
          }

--- a/robotiq_tsf/test/CMakeLists.txt
+++ b/robotiq_tsf/test/CMakeLists.txt
@@ -1,28 +1,19 @@
 find_package(ament_cmake_gtest REQUIRED)
 find_package(ament_cmake_pytest REQUIRED)
 
-# Each gtest links the compiled libraries (poll_data_sdk_lib / _algorithms)
-# rather than recompiling the sources; header include paths come with them.
-
-# MadgwickAHRS math helpers.
-ament_add_gtest(test_madgwick_ahrs test_madgwick_ahrs.cpp)
-target_link_libraries(test_madgwick_ahrs ${PROJECT_NAME}_algorithms)
-
-# Device autodetect (udev symlink / sysfs-tty descriptor scanning).
-ament_add_gtest(test_device_autodetect test_device_autodetect.cpp)
-target_link_libraries(test_device_autodetect poll_data_sdk_lib)
-
-# SDK Fingers -> ROS message mapping.
-ament_add_gtest(test_sdk_bridge test_sdk_bridge.cpp)
-target_link_libraries(test_sdk_bridge poll_data_sdk_lib)
-
-# AHRS fusion helpers (dt derivation + clamp, still-detection, bias trim).
-ament_add_gtest(test_fusion test_fusion.cpp)
-target_link_libraries(test_fusion poll_data_sdk_lib)
-
-# Pins the node's advertised topic/service set (constructor-only; no hardware).
-ament_add_gtest(test_poll_data_sdk_node test_poll_data_sdk_node.cpp)
-target_link_libraries(test_poll_data_sdk_node poll_data_sdk_lib)
+# One gtest binary for the whole package, so the suite runs — and debugs — as a
+# single target instead of five. Pick a subset with --gtest_filter.
+#
+# poll_data_sdk_lib already links ${PROJECT_NAME}_algorithms, so linking it
+# covers the MadgwickAHRS helpers too; header include paths come with it.
+ament_add_gtest(${PROJECT_NAME}_tests
+  test_madgwick_ahrs.cpp        # MadgwickAHRS math helpers
+  test_device_autodetect.cpp    # udev symlink / sysfs-tty descriptor scanning
+  test_sdk_bridge.cpp           # SDK Fingers -> ROS message mapping
+  test_fusion.cpp               # dt derivation + clamp, still-detection, bias trim
+  test_poll_data_sdk_node.cpp   # pins the node's advertised topic/service set
+)
+target_link_libraries(${PROJECT_NAME}_tests poll_data_sdk_lib)
 
 # Unit tests for scripts/tactile_viz_node (drives the node callbacks directly;
 # needs this package's generated Python messages, hence the deferred import


### PR DESCRIPTION
Developer tooling only — nothing here changes what colcon, CI or Docker build.
Three commits, independent of each other.

## One CMake project for the whole workspace

`dev/CMakeLists.txt` pulls every C++ package into a single CMake project, for
IDEs that take one CMakeLists as their entry point (Qt Creator: Open File or
Project, pick the `ide` preset). A root-level file is not possible: colcon
treats a directory holding a CMakeLists as a plain CMake package and stops
descending, which would hide the ament packages under it — so the aggregate
lives in `dev/` behind a `COLCON_IGNORE`, and the real build is untouched.

## One gtest binary for robotiq_tsf

The per-file test executables fold into a single `robotiq_tsf_tests` target,
as `robotiq_driver` already has: the suite runs — and debugs — as one binary,
and `--gtest_filter` picks a subset.

## camelCase style pass

The surviving PickNik functions move to the convention the rest of the repo
follows (functions camelCase, members snake_case, types PascalCase). Only
functions this repo owns are renamed; the ros2_control overrides keep the
names the framework defines.