### PR TITLE
Support humble lyrical rolling

### DIFF
--- a/.github/workflows/ci-ros-build-test.yml
+++ b/.github/workflows/ci-ros-build-test.yml
@@ -5,8 +5,12 @@
 # incomplete ROS install (missing ament_package / rosidl_typesupport_c /
 # librcl_action.so), which flaked this job; the container removes that class of
 # failure.
-# Distro policy: LTS only — matrix is [jazzy] now, add lyrical when it ships
-# (see ros-driver distro-compat policy; distro pairs with its Ubuntu LTS).
+# Distro policy: the three live LTS distros are what we support, and their jobs
+# gate merges (see ros-driver distro-compat policy; each distro pairs with its
+# Ubuntu LTS). Rolling is built too, but non-blocking: it is a moving target that
+# goes red for upstream reasons unrelated to the PR under review, so it buys early
+# warning without putting someone on triage duty. Kilted and other non-LTS
+# releases are deliberately not built.
 name: ROS Build & Test
 
 on:
@@ -20,15 +24,27 @@ on:
 jobs:
   build_and_test:
     name: colcon test (${{ matrix.ros_distro }})
-    runs-on: ${{ matrix.os }}
+    # The distro comes entirely from the container image (humble = jammy,
+    # jazzy = noble, lyrical and rolling = resolute), so the host runner only has
+    # to provide Docker. Pinning every job to one current runner label keeps the
+    # matrix off the retirement schedule of the older ubuntu-* images.
+    runs-on: ubuntu-24.04
     container:
       image: ros:${{ matrix.ros_distro }}-ros-base
+    # Only the supported (LTS) distros gate the merge; see the header comment.
+    continue-on-error: ${{ !matrix.blocking }}
     strategy:
       fail-fast: false
       matrix:
         include:
+          - ros_distro: humble
+            blocking: true
           - ros_distro: jazzy
-            os: ubuntu-24.04
+            blocking: true
+          - ros_distro: lyrical
+            blocking: true
+          - ros_distro: rolling
+            blocking: false
     steps:
       # ros-base is minimal: it lacks git (needed by actions/checkout) and the
       # colcon coverage plugins that action-ros-ci invokes by default

--- a/.github/workflows/ci-ros-lint.yml
+++ b/.github/workflows/ci-ros-lint.yml
@@ -1,6 +1,11 @@
 # ament linters for the C++ packages: the vendored gripper tree (grippers/) and
 # robotiq_tsf. Adapted from PickNik's ros2_robotiq_gripper CI: distribution ->
 # jazzy, runner -> ubuntu-24.04 (Noble).
+#
+# Deliberately not matrixed over humble/jazzy/lyrical like ci-ros-build-test:
+# these linters check style, not API, so a second and third distro would only
+# re-run the same checks against different linter versions. Jazzy is the
+# reference; .pre-commit-config.yaml (ci-format) is the formatting authority.
 name: ROS Lint
 
 on:

--- a/README.md
+++ b/README.md
@@ -4,8 +4,33 @@ ROS packages for Robotiq grippers and sensors.
 
 | Package | Description | ROS Version |
 |---|---|---|
-| [robotiq_tsf](robotiq_tsf/) | TSF-85 tactile sensor driver | ROS 2 Jazzy ([main](https://github.com/robotiq/ros/tree/main)) / ROS 1 Noetic ([noetic](https://github.com/robotiq/ros/tree/noetic)) |
-| [grippers](grippers/) | ROS 2 driver for Robotiq grippers (2F-85/140, Hand-E) — vendored from [PickNik](https://github.com/PickNikRobotics/ros2_robotiq_gripper) | ROS 2 Jazzy |
+| [robotiq_tsf](robotiq_tsf/) | TSF-85 tactile sensor driver | ROS 2 Humble / Jazzy / Lyrical ([main](https://github.com/robotiq/ros/tree/main)) / ROS 1 Noetic ([noetic](https://github.com/robotiq/ros/tree/noetic)) |
+| [grippers](grippers/) | ROS 2 driver for Robotiq grippers (2F-85/140, Hand-E) — vendored from [PickNik](https://github.com/PickNikRobotics/ros2_robotiq_gripper) | ROS 2 Humble / Jazzy / Lyrical |
+
+## Supported ROS 2 distros
+
+`main` supports the three live LTS distros from one branch — build it on whichever
+one your robot already runs.
+
+| Distro | Ubuntu | Gripper action | `gripper_cmd` action type |
+|---|---|---|---|
+| Humble | 22.04 Jammy | `position_controllers/GripperActionController` | `control_msgs/action/GripperCommand` |
+| Jazzy | 24.04 Noble | `parallel_gripper_action_controller/GripperActionController` | `control_msgs/action/ParallelGripperCommand` |
+| Lyrical | 26.04 Resolute | `parallel_gripper_action_controller/GripperActionController` | `control_msgs/action/ParallelGripperCommand` |
+
+Rolling builds and passes the full suite as well, and CI watches it, but it is not
+a supported target: it is a moving development branch, so a break there is a
+heads-up rather than a release blocker. Its job does not gate merges. Kilted and
+other non-LTS releases are not built.
+
+The action type differs because `parallel_gripper_controller` does not exist on
+Humble — ROS itself only gained it in Jazzy. `robotiq_control.launch.py` picks the
+matching controller config automatically from `$ROS_DISTRO`, and everything else
+(package names, launch files, controller names, topics, the
+`/robotiq_gripper_controller/gripper_cmd` namespace, the xacro macro arguments)
+is identical across all three. On Humble that makes this repo a drop-in
+replacement for PickNik's `humble` branch — see
+[Migrating from PickNik's ros2_robotiq_gripper](#migrating-from-picknik-ros2_robotiq_gripper).
 
 ## Legacy
 
@@ -89,7 +114,7 @@ git clone --recurse-submodules https://github.com/robotiq/ros.git
 cd ros && ./docker/run.sh gripper
 ```
 
-**Existing ROS 2 Jazzy workspace:**
+**Existing ROS 2 workspace** (Humble, Jazzy or Lyrical — same steps on all three):
 
 ```bash
 cd ~/ws/src
@@ -105,7 +130,8 @@ colcon build
 
 There is no `vcs import` step any more: the driver's transport comes from the
 `extern/grippers` submodule instead of the external `serial` package, so a
-`--recurse-submodules` clone is the whole dependency story.
+`--recurse-submodules` clone is the whole dependency story. `rosdep` resolves
+the right gripper action controller for your distro on its own.
 
 This repository also contains the TSF-85 sensor stack. To build only the gripper packages and their dependencies, replace the last step with:
 
@@ -115,26 +141,38 @@ colcon build --packages-up-to robotiq_description robotiq_controllers robotiq_ha
 
 #### Coming from the `humble` branch
 
-The `main`/`rolling` line (which this repo continues) has breaking changes relative to PickNik's `humble` branch — all made upstream by PickNik, before the import into this repository:
+**Staying on Humble: nothing to change.** This repository builds on Humble and
+keeps PickNik's Humble controller and action surface, so your existing action
+clients, launch overrides and xacro arguments work untouched:
 
-| | PickNik `humble` | This repository |
+| | PickNik `humble` | This repository on Humble |
 |---|---|---|
-| ROS distro | Humble | Jazzy |
+| ROS distro | Humble | Humble |
 | Serial transport | `serial` package, `vcs import`ed | the `extern/grippers` SDK submodule (libserialport) |
-| `robotiq_gripper_controller` type | `position_controllers/GripperActionController` | `parallel_gripper_action_controller/GripperActionController` |
-| `gripper_cmd` action type | `control_msgs/action/GripperCommand` | `control_msgs/action/ParallelGripperCommand` |
+| `robotiq_gripper_controller` type | `position_controllers/GripperActionController` | `position_controllers/GripperActionController` |
+| `gripper_cmd` action type | `control_msgs/action/GripperCommand` | `control_msgs/action/GripperCommand` |
 
-The controller switch tracks ROS itself: `gripper_controllers` is removed in Kilted+, and `parallel_gripper_controller` is its replacement available from Jazzy on (upstream [PickNik PR #103](https://github.com/PickNikRobotics/ros2_robotiq_gripper/pull/103)).
+As on PickNik's `humble`, the Humble controller cannot claim the hardware's
+`set_gripper_max_effort` / `set_gripper_max_velocity` interfaces — Humble's
+`gripper_controllers` has no parameters for them (PickNik's
+`use_effort_interface` / `use_speed_interface` entries were silently ignored
+there). Per-goal speed and force therefore come from the xacro's
+`gripper_speed_multiplier` / `gripper_force_multiplier`, exactly as before.
 
-Action clients must switch to the `ParallelGripperCommand` goal — a `sensor_msgs/JointState` naming the knuckle joint:
+**Moving to Jazzy or Lyrical at the same time** is the one breaking step, and the
+break is upstream ROS's, not this repository's — `gripper_controllers` is gone in
+Kilted+, and `parallel_gripper_controller` is its replacement from Jazzy on
+(upstream [PickNik PR #103](https://github.com/PickNikRobotics/ros2_robotiq_gripper/pull/103)).
+Action clients then switch to the `ParallelGripperCommand` goal — a
+`sensor_msgs/JointState` naming the knuckle joint:
 
 ```bash
-# PickNik humble (old)
+# Humble (PickNik humble, and this repo on Humble)
 ros2 action send_goal /robotiq_gripper_controller/gripper_cmd \
   control_msgs/action/GripperCommand \
   "{command: {position: 0.4, max_effort: 50.0}}"
 
-# This repository (new)
+# Jazzy / Lyrical
 ros2 action send_goal /robotiq_gripper_controller/gripper_cmd \
   control_msgs/action/ParallelGripperCommand \
   "{command: {name: ['robotiq_85_left_knuckle_joint'], position: [0.4], effort: [40.0]}}"
@@ -168,21 +206,26 @@ This activates `joint_state_broadcaster`, `robotiq_gripper_controller`, and `rob
 
 ### Commanding the gripper
 
-`robotiq_gripper_controller` is a `parallel_gripper_action_controller/GripperActionController`, so its action `/robotiq_gripper_controller/gripper_cmd` takes a `control_msgs/action/ParallelGripperCommand` — a `sensor_msgs/JointState` goal (not the older `GripperCommand`).
+On **Jazzy and Lyrical**, `robotiq_gripper_controller` is a `parallel_gripper_action_controller/GripperActionController`, so its action `/robotiq_gripper_controller/gripper_cmd` takes a `control_msgs/action/ParallelGripperCommand` — a `sensor_msgs/JointState` goal (not the older `GripperCommand`). On **Humble** it is `position_controllers/GripperActionController` taking `control_msgs/action/GripperCommand`; see [Supported ROS 2 distros](#supported-ros-2-distros).
 
 The bringup above holds its terminal, so open a **second terminal**, exec into the running container, then send a goal:
 
 ```bash
-# host: open a second shell into the running container
-docker exec -it robotiq_ros2 bash
+# host: open a second shell into the running container (per-distro container name)
+docker exec -it robotiq_ros2_jazzy bash
 
-# inside the container:
+# inside the container — Jazzy / Lyrical:
 ros2 action send_goal /robotiq_gripper_controller/gripper_cmd \
   control_msgs/action/ParallelGripperCommand \
   "{command: {name: ['robotiq_85_left_knuckle_joint'], position: [0.4], effort: [40.0]}}"
+
+# inside the container — Humble:
+ros2 action send_goal /robotiq_gripper_controller/gripper_cmd \
+  control_msgs/action/GripperCommand \
+  "{command: {position: 0.4, max_effort: 50.0}}"
 ```
 
-`position` is the joint angle in radians (≈ `0.0` open → ~`0.8` closed on a 2F-85); `effort` and `velocity` are optional max limits, mapped to the controller's `set_gripper_max_effort` / `set_gripper_max_velocity` interfaces.
+`position` is the joint angle in radians (≈ `0.0` open → ~`0.8` closed on a 2F-85); on Jazzy/Lyrical `effort` and `velocity` are optional max limits, mapped to the controller's `set_gripper_max_effort` / `set_gripper_max_velocity` interfaces.
 
 ### Hardware parameters
 
@@ -227,14 +270,16 @@ ros2 launch robotiq_description view_gripper.launch.py
 
 Drag the `robotiq_85_left_knuckle_joint` slider; the five finger joints follow it via URDF `mimic` (≈ `0.0` open → ~`0.8` closed).
 
-> Known limitation: the `gripper_cmd` action controller does not drive the model under `use_fake_hardware:=true` (the mock does not expose the gripper's effort/velocity command interfaces), so goal-based commanding in simulation is not yet available. Use the slider above for hardware-free visualization.
+Goal-based commanding also works without hardware: `robotiq_control.launch.py use_fake_hardware:=true launch_rviz:=true` brings up all three controllers against `mock_components/GenericSystem`, and `gripper_cmd` goals drive the model — the five finger joints follow the knuckle via URDF `mimic`, exactly as on hardware. Use the slider above when you want to pose the model by hand instead.
+
+Mock and hardware publish the same `/joint_states` contract on every distro: the knuckle joint alone, with `robot_state_publisher` deriving the mimicked finger joints from the URDF. Only the Gazebo and Isaac paths declare the mimicked joints to `ros2_control`, since those simulators supply their own joint state.
 
 ## Testing
 
 Unit tests live in each package's `test/` directory and run without hardware. Build and run all tests from the repository root:
 
 ```bash
-source /opt/ros/jazzy/setup.bash
+source /opt/ros/jazzy/setup.bash    # or humble / lyrical
 colcon build
 colcon test
 colcon test-result --verbose
@@ -248,7 +293,7 @@ Test executables land under `build/<package>/`, mirroring the package's test-dir
 ./build/<package>/test/<test_executable> --gtest_filter='<TestSuite>.*'
 ```
 
-CI builds the packages and runs their unit tests on pull requests ([`ci-ros-build-test.yml`](.github/workflows/ci-ros-build-test.yml)).
+CI builds the packages and runs their unit tests on pull requests, once per supported distro — Humble, Jazzy and Lyrical ([`ci-ros-build-test.yml`](.github/workflows/ci-ros-build-test.yml)).
 
 ## Docker
 
@@ -277,7 +322,7 @@ in-tree.
 
 | Script | Description |
 |---|---|
-| `run.sh` | Builds a single ROS 2 Jazzy image with the **whole workspace** (sensor + grippers) and launches a shell with that product's devices mapped: `./run.sh [gripper\|sensor\|both]`. |
+| `run.sh` | Builds a single ROS 2 image with the **whole workspace** (sensor + grippers) and launches a shell with that product's devices mapped: `./run.sh [gripper\|sensor\|both]`. |
 | `sensor_install.sh` | Sets up udev rules and permissions for bare-metal (non-Docker) use |
 
 > `Dockerfile_TSF85_ROS2` and `build_launch_docker_ros2.sh` are kept as deprecation shims pointing to `Dockerfile` / `run.sh sensor`.
@@ -292,7 +337,7 @@ docker build -f docker/Dockerfile -t robotiq_ros2:jazzy .
 
 Build options:
 
-- `--build-arg ROS_DISTRO=…` (default `jazzy`) — parameterized, but `jazzy` is the only distro the workspace is built and tested against; CI covers `jazzy` alone.
+- `--build-arg ROS_DISTRO=…` (default `jazzy`) — `humble`, `jazzy` and `lyrical` are all built in CI.
 - `--build-arg WITH_GUI=false` — **headless**: drop rviz2/rqt/joint-state-publisher-gui (and their mesa/Qt/VTK), for a much smaller image on robots that don't visualize.
 - `--target builder` — a **dev** image with the full toolchain, for building inside the container.
 
@@ -302,3 +347,12 @@ docker build --target builder -f docker/Dockerfile -t robotiq_ros2:dev .
 ```
 
 Then run it with the sensor/gripper devices mapped via `./docker/run.sh [gripper|sensor|both]`.
+
+Pick the distro with `ROS_DISTRO` (default `jazzy`); each one gets its own image
+tag and container name, so switching does not reuse the other's build:
+
+```bash
+./docker/run.sh gripper                      # robotiq_ros2:jazzy   / robotiq_ros2_jazzy
+ROS_DISTRO=humble  ./docker/run.sh gripper   # robotiq_ros2:humble  / robotiq_ros2_humble
+ROS_DISTRO=lyrical ./docker/run.sh both      # robotiq_ros2:lyrical / robotiq_ros2_lyrical
+```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@
 #   compiler / colcon / test deps. GUI (rviz2, rqt, …) is optional.
 #
 # Build options, examples and the build-context requirement: see the Docker
-# section in README.md.
+# section in README.md. ROS_DISTRO is a build arg: humble, jazzy and lyrical.
 
 ARG ROS_DISTRO=jazzy
 
@@ -19,7 +19,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 
 # Build tooling + sensor build deps (libserialport, via pkg-config) + gripper
-# build deps (ros2_control stack).
+# build deps (ros2_control stack). ros2-controllers brings the distro's gripper
+# action controller: gripper_controllers on Humble, parallel_gripper_controller
+# on Jazzy and newer.
 RUN apt-get update && apt-get install -y \
         pkg-config \
         python3-colcon-common-extensions python3-rosdep \

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
-# Build and run the single ROS 2 Jazzy image for the robotiq ros workspace
+# Build and run the single ROS 2 image for the robotiq ros workspace
 # (robotiq_tsf sensor + grippers).
 #
 # Usage:
 #   ./run.sh build                  # build the image only
 #   ./run.sh [gripper|sensor|both]  # build if needed, then launch a shell with
 #                                   # that product's devices mapped (default: gripper)
+#
+# Distro defaults to jazzy; humble and lyrical are equally supported:
+#   ROS_DISTRO=humble ./run.sh gripper
 #
 # Inside the container the workspace is already built and sourced:
 #   gripper bringup : ros2 launch robotiq_description robotiq_control.launch.py
@@ -15,8 +18,11 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-IMG="${IMG:-robotiq_ros2:jazzy}"
-CONTAINER="${CONTAINER:-robotiq_ros2}"
+DISTRO="${ROS_DISTRO:-jazzy}"
+# One image and one container name per distro, so switching distros does not
+# silently reuse the other one's build.
+IMG="${IMG:-robotiq_ros2:${DISTRO}}"
+CONTAINER="${CONTAINER:-robotiq_ros2_${DISTRO}}"
 PRODUCT="${1:-gripper}"
 HELPERS="${ROOT}/extern/tactile_sensors/utils/scripts"
 
@@ -34,8 +40,9 @@ log() { echo "[${1}] ${*:2}"; }   # log <tag> <message...>  e.g. log gripper "..
 # Our unified sensor+grippers image is built from this repo's docker/Dockerfile,
 # so we provision it locally below.
 build_image() {
-  log "${PRODUCT}" "building image ${IMG} (context: ${ROOT}) ..."
-  docker build -f "${SCRIPT_DIR}/Dockerfile" -t "${IMG}" "${ROOT}"
+  log "${PRODUCT}" "building image ${IMG} for ROS ${DISTRO} (context: ${ROOT}) ..."
+  docker build --build-arg "ROS_DISTRO=${DISTRO}" \
+    -f "${SCRIPT_DIR}/Dockerfile" -t "${IMG}" "${ROOT}"
 }
 
 log "${PRODUCT}" "checking Docker installation ..."

--- a/grippers/robotiq_controllers/CMakeLists.txt
+++ b/grippers/robotiq_controllers/CMakeLists.txt
@@ -66,6 +66,8 @@ if(BUILD_TESTING)
   set(ament_cmake_xmllint_FOUND TRUE)
 
   ament_lint_auto_find_test_dependencies()
+
+  add_subdirectory(test)
 endif()
 
 # # EXPORTS

--- a/grippers/robotiq_controllers/include/robotiq_controllers/ros2_control_compat.hpp
+++ b/grippers/robotiq_controllers/include/robotiq_controllers/ros2_control_compat.hpp
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Robotiq
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <optional>
+#include <type_traits>
+#include <utility>
+
+// ros2_control command-handle API differences across the ROS 2 distros this
+// package supports (Humble, Jazzy, Lyrical).
+//
+// Humble (ros2_control 2.x) exposes `void set_value(double)` and
+// `double get_value()`. From Jazzy's 4.x line on, writes report success
+// (`bool set_value(double)`) and reads can fail (`std::optional<double>
+// get_optional()`), because the handles took a lock internally.
+//
+// Each shim keys off the shape of the operation it wraps rather than a
+// HARDWARE_INTERFACE_VERSION_GTE threshold — Jazzy's 4.x line keeps moving, so
+// there is no stable version number to compare against.
+
+namespace robotiq_controllers::compat {
+namespace detail {
+template <typename HandleT, typename = void>
+struct HasGetOptional : std::false_type
+{
+};
+
+template <typename HandleT>
+struct HasGetOptional<HandleT, std::void_t<decltype(std::declval<const HandleT&>().get_optional())>> : std::true_type
+{
+};
+
+template <typename HandleT>
+struct SetValueReturnsBool : std::is_same<decltype(std::declval<HandleT&>().set_value(0.0)), bool>
+{
+};
+} // namespace detail
+
+/// Write `value` to `handle`.
+/// @returns whether the write succeeded; always true where the API cannot report failure.
+template <typename HandleT>
+bool setValue(HandleT& handle, double value)
+{
+   if constexpr(detail::SetValueReturnsBool<HandleT>::value)
+   {
+      return handle.set_value(value);
+   }
+   else
+   {
+      handle.set_value(value);
+      return true;
+   }
+}
+
+/// Read `handle`.
+/// @returns the value, or std::nullopt where the API can report a failed read.
+template <typename HandleT>
+std::optional<double> getValue(const HandleT& handle)
+{
+   if constexpr(detail::HasGetOptional<HandleT>::value)
+   {
+      return handle.get_optional();
+   }
+   else
+   {
+      return handle.get_value();
+   }
+}
+} // namespace robotiq_controllers::compat

--- a/grippers/robotiq_controllers/package.xml
+++ b/grippers/robotiq_controllers/package.xml
@@ -15,6 +15,7 @@
   <depend>controller_interface</depend>
   <depend>std_srvs</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/grippers/robotiq_controllers/src/robotiq_activation_controller.cpp
+++ b/grippers/robotiq_controllers/src/robotiq_activation_controller.cpp
@@ -28,6 +28,8 @@
 
 #include "robotiq_controllers/robotiq_activation_controller.hpp"
 
+#include "robotiq_controllers/ros2_control_compat.hpp"
+
 namespace robotiq_controllers {
 controller_interface::InterfaceConfiguration RobotiqActivationController::command_interface_configuration() const
 {
@@ -106,12 +108,12 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Roboti
 bool RobotiqActivationController::reactivateGripper(std_srvs::srv::Trigger::Request::SharedPtr /*req*/,
                                                     std_srvs::srv::Trigger::Response::SharedPtr resp)
 {
-   resp->success = command_interfaces_[REACTIVATE_GRIPPER_RESPONSE].set_value(ASYNC_WAITING);
-   resp->success &= command_interfaces_[REACTIVATE_GRIPPER_CMD].set_value(1.0);
+   resp->success = compat::setValue(command_interfaces_[REACTIVATE_GRIPPER_RESPONSE], ASYNC_WAITING);
+   resp->success &= compat::setValue(command_interfaces_[REACTIVATE_GRIPPER_CMD], 1.0);
 
    while(true)
    {
-      const auto maybe_value = command_interfaces_[REACTIVATE_GRIPPER_RESPONSE].get_optional();
+      const auto maybe_value = compat::getValue(command_interfaces_[REACTIVATE_GRIPPER_RESPONSE]);
       if(maybe_value && maybe_value.value() != ASYNC_WAITING)
       {
          break;
@@ -120,7 +122,8 @@ bool RobotiqActivationController::reactivateGripper(std_srvs::srv::Trigger::Requ
    }
    // NOTE: This was previously using get_value() and implicitly casting to bool, so keeping the old behavior.
    // However, note that the value of this result is actually a double, so this should be revised in the future.
-   resp->success &= static_cast<bool>(command_interfaces_[REACTIVATE_GRIPPER_RESPONSE].get_optional().value_or(false));
+   resp->success &=
+      static_cast<bool>(compat::getValue(command_interfaces_[REACTIVATE_GRIPPER_RESPONSE]).value_or(false));
 
    return resp->success;
 }

--- a/grippers/robotiq_controllers/test/CMakeLists.txt
+++ b/grippers/robotiq_controllers/test/CMakeLists.txt
@@ -1,0 +1,8 @@
+find_package(ament_cmake_gtest REQUIRED)
+
+# Compat shims over the ros2_control command-handle API. Header-only, so the
+# test needs the include path but nothing to link against.
+ament_add_gtest(test_ros2_control_compat test_ros2_control_compat.cpp)
+target_include_directories(test_ros2_control_compat
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include
+)

--- a/grippers/robotiq_controllers/test/test_ros2_control_compat.cpp
+++ b/grippers/robotiq_controllers/test/test_ros2_control_compat.cpp
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Robotiq
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// The activation controller only ever compiles against the handle API of the
+// distro it is built on, so the branch that distro does not use would otherwise
+// go untested. These fakes stand in for both LoanedCommandInterface shapes so
+// that every distro exercises both.
+
+#include <gtest/gtest.h>
+
+#include <optional>
+
+#include <robotiq_controllers/ros2_control_compat.hpp>
+
+namespace robotiq_controllers::test {
+
+/// Humble (ros2_control 2.x): writes cannot fail, reads always yield a value.
+class OldApiHandle
+{
+public:
+   void set_value(double value) { value_ = value; }
+   double get_value() const { return value_; }
+
+private:
+   double value_ = 0.0;
+};
+
+/// Jazzy 4.x and later: writes report success, reads may come back empty.
+class NewApiHandle
+{
+public:
+   bool set_value(double value)
+   {
+      if(!writable_)
+      {
+         return false;
+      }
+      value_ = value;
+      return true;
+   }
+
+   std::optional<double> get_optional() const { return readable_ ? std::optional<double>{value_} : std::nullopt; }
+
+   void setWritable(bool writable) { writable_ = writable; }
+   void setReadable(bool readable) { readable_ = readable; }
+
+private:
+   double value_ = 0.0;
+   bool writable_ = true;
+   bool readable_ = true;
+};
+
+TEST(TestRos2ControlCompat, detects_each_handle_shape)
+{
+   EXPECT_FALSE(compat::detail::HasGetOptional<OldApiHandle>::value);
+   EXPECT_FALSE(compat::detail::SetValueReturnsBool<OldApiHandle>::value);
+   EXPECT_TRUE(compat::detail::HasGetOptional<NewApiHandle>::value);
+   EXPECT_TRUE(compat::detail::SetValueReturnsBool<NewApiHandle>::value);
+}
+
+TEST(TestRos2ControlCompat, old_api_round_trips_and_always_reports_success)
+{
+   OldApiHandle handle;
+
+   EXPECT_TRUE(compat::setValue(handle, 4.25));
+   EXPECT_EQ(compat::getValue(handle), std::optional<double>{4.25});
+}
+
+TEST(TestRos2ControlCompat, new_api_round_trips)
+{
+   NewApiHandle handle;
+
+   EXPECT_TRUE(compat::setValue(handle, 4.25));
+   EXPECT_EQ(compat::getValue(handle), std::optional<double>{4.25});
+}
+
+TEST(TestRos2ControlCompat, new_api_propagates_write_failure)
+{
+   NewApiHandle handle;
+   handle.setWritable(false);
+
+   EXPECT_FALSE(compat::setValue(handle, 4.25));
+}
+
+TEST(TestRos2ControlCompat, new_api_propagates_empty_read)
+{
+   NewApiHandle handle;
+   handle.setReadable(false);
+
+   EXPECT_EQ(compat::getValue(handle), std::nullopt);
+}
+
+} // namespace robotiq_controllers::test

--- a/grippers/robotiq_description/CMakeLists.txt
+++ b/grippers/robotiq_description/CMakeLists.txt
@@ -22,6 +22,8 @@ install(
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
   ament_add_pytest_test(test_controller_config test/test_controller_config.py)
+  # Expands the xacro, so it needs the package's own share dir on the ament index.
+  ament_add_pytest_test(test_ros2_control_urdf test/test_ros2_control_urdf.py TIMEOUT 120)
 endif()
 
 ament_package()

--- a/grippers/robotiq_description/config/robotiq_controllers.humble.yaml
+++ b/grippers/robotiq_description/config/robotiq_controllers.humble.yaml
@@ -1,0 +1,40 @@
+# Humble controller configuration.
+#
+# Humble has no `parallel_gripper_controller` package — it arrived in Jazzy — so
+# the gripper controller here is Humble's stock
+# `position_controllers/GripperActionController` from `gripper_controllers`,
+# taking a `control_msgs/action/GripperCommand` goal. This is what PickNik's
+# `humble` branch shipped, so a PickNik/Humble workspace keeps its action clients
+# unchanged. See config/robotiq_controllers.yaml for the Jazzy/Lyrical config,
+# which is selected by launch/robotiq_control.launch.py per $ROS_DISTRO.
+#
+# Consequence, matching PickNik/Humble exactly: this controller cannot claim the
+# hardware's `set_gripper_max_effort` / `set_gripper_max_velocity` command
+# interfaces (it has no `max_effort_interface` / `max_velocity_interface`
+# parameters), so per-goal speed and force come from the xacro's
+# `gripper_speed_multiplier` / `gripper_force_multiplier` instead. PickNik's
+# `use_effort_interface` / `use_speed_interface` entries are omitted because
+# Humble's controller never declared them — they were silently ignored.
+controller_manager:
+  ros__parameters:
+    update_rate: 500  # Hz
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+    robotiq_gripper_controller:
+      type: position_controllers/GripperActionController
+    robotiq_activation_controller:
+      type: robotiq_controllers/RobotiqActivationController
+
+robotiq_gripper_controller:
+  ros__parameters:
+    joint: robotiq_85_left_knuckle_joint
+
+    max_effort: 50.0   # TODO tune
+
+    allow_stalling: true
+    stall_timeout: 0.05
+    goal_tolerance: 0.02
+
+robotiq_activation_controller:
+  ros__parameters:
+    default: true

--- a/grippers/robotiq_description/config/robotiq_controllers.yaml
+++ b/grippers/robotiq_description/config/robotiq_controllers.yaml
@@ -1,3 +1,6 @@
+# Jazzy / Lyrical controller configuration. Humble uses
+# config/robotiq_controllers.humble.yaml instead (no parallel_gripper_controller
+# package there); launch/robotiq_control.launch.py selects per $ROS_DISTRO.
 controller_manager:
   ros__parameters:
     update_rate: 500  # Hz

--- a/grippers/robotiq_description/launch/robotiq_control.launch.py
+++ b/grippers/robotiq_description/launch/robotiq_control.launch.py
@@ -37,6 +37,16 @@ from launch.conditions import IfCondition
 import launch_ros
 import os
 
+# Humble has no parallel_gripper_controller package, so it needs its own
+# controller config. See both config/robotiq_controllers*.yaml.
+JAZZY_CONTROLLERS_FILE = "robotiq_controllers.yaml"
+HUMBLE_CONTROLLERS_FILE = "robotiq_controllers.humble.yaml"
+
+
+def controllers_file_for_distro(distro):
+    """Return the controller config file name to load on ROS distro `distro`."""
+    return HUMBLE_CONTROLLERS_FILE if distro == "humble" else JAZZY_CONTROLLERS_FILE
+
 
 def generate_launch_description():
     description_pkg_share = launch_ros.substitutions.FindPackageShare(
@@ -104,7 +114,7 @@ def generate_launch_description():
         )
     }
 
-    controllers_file = "robotiq_controllers.yaml"
+    controllers_file = controllers_file_for_distro(os.environ.get("ROS_DISTRO"))
     initial_joint_controllers = PathJoinSubstitution(
         [description_pkg_share, "config", controllers_file]
     )
@@ -133,27 +143,29 @@ def generate_launch_description():
         condition=IfCondition(LaunchConfiguration("launch_rviz")),
     )
 
-    joint_state_broadcaster_spawner = launch_ros.actions.Node(
-        package="controller_manager",
-        executable="spawner",
-        arguments=[
-            "joint_state_broadcaster",
-            "--controller-manager",
-            "/controller_manager",
-        ],
-    )
+    # Each spawner is handed the controller config explicitly with --param-file.
+    # Passing it to ros2_control_node alone is not enough: up to Jazzy the
+    # controller_manager forwarded its own parameter file to each controller node,
+    # but from Lyrical (ros2_control 6.x) it does not, and the gripper controller
+    # then dies with "parameter 'joint' is not initialized". --param-file has been
+    # a spawner option since Humble, and each node reads only its own section of
+    # the file, so this is correct on every supported distro.
+    def spawner(controller_name):
+        return launch_ros.actions.Node(
+            package="controller_manager",
+            executable="spawner",
+            arguments=[
+                controller_name,
+                "--controller-manager",
+                "/controller_manager",
+                "--param-file",
+                initial_joint_controllers,
+            ],
+        )
 
-    robotiq_gripper_controller_spawner = launch_ros.actions.Node(
-        package="controller_manager",
-        executable="spawner",
-        arguments=["robotiq_gripper_controller", "-c", "/controller_manager"],
-    )
-
-    robotiq_activation_controller_spawner = launch_ros.actions.Node(
-        package="controller_manager",
-        executable="spawner",
-        arguments=["robotiq_activation_controller", "-c", "/controller_manager"],
-    )
+    joint_state_broadcaster_spawner = spawner("joint_state_broadcaster")
+    robotiq_gripper_controller_spawner = spawner("robotiq_gripper_controller")
+    robotiq_activation_controller_spawner = spawner("robotiq_activation_controller")
 
     nodes = [
         control_node,

--- a/grippers/robotiq_description/package.xml
+++ b/grippers/robotiq_description/package.xml
@@ -36,6 +36,8 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>python3-yaml</test_depend>
+  <!-- test_ros2_control_urdf expands the gripper xacro. -->
+  <test_depend>xacro</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/grippers/robotiq_description/package.xml
+++ b/grippers/robotiq_description/package.xml
@@ -24,11 +24,17 @@
   <exec_depend>ros2_controllers</exec_depend>
 
   <exec_depend>joint_state_broadcaster</exec_depend>
-  <exec_depend>parallel_gripper_controller</exec_depend>
+
+  <!-- Gripper action controller: parallel_gripper_controller is Jazzy and newer;
+       Humble only has gripper_controllers. config/robotiq_controllers*.yaml pick
+       the matching plugin. -->
+  <exec_depend condition="$ROS_DISTRO != humble">parallel_gripper_controller</exec_depend>
+  <exec_depend condition="$ROS_DISTRO == humble">gripper_controllers</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>python3-pytest</test_depend>
   <test_depend>python3-yaml</test_depend>
 
   <export>

--- a/grippers/robotiq_description/test/test_controller_config.py
+++ b/grippers/robotiq_description/test/test_controller_config.py
@@ -31,12 +31,21 @@
 # RobotiqGripperHardwareInterface::export_command_interfaces in
 # robotiq_driver). A mismatch is silent until runtime, where
 # robotiq_gripper_controller fails to activate.
+#
+# There are two configs — Humble has no parallel_gripper_controller package — and
+# robotiq_control.launch.py picks one per $ROS_DISTRO. Both are checked here
+# regardless of the distro the tests run on, so neither can rot unnoticed.
 
+import importlib.util
 from pathlib import Path
 
+import pytest
 import yaml
 
-CONFIG = Path(__file__).parents[1] / "config" / "robotiq_controllers.yaml"
+CONFIG_DIR = Path(__file__).parents[1] / "config"
+JAZZY_CONFIG = CONFIG_DIR / "robotiq_controllers.yaml"
+HUMBLE_CONFIG = CONFIG_DIR / "robotiq_controllers.humble.yaml"
+ALL_CONFIGS = (JAZZY_CONFIG, HUMBLE_CONFIG)
 
 # Names exported by robotiq_driver's hardware interface. Kept in sync by
 # robotiq_driver's test_robotiq_gripper_hardware_interface, which asserts the
@@ -48,23 +57,99 @@ EXPORTED_COMMAND_INTERFACES = {
     f"{JOINT}/set_gripper_max_effort",
 }
 
+# Plugin the launch expects per distro. Humble's stock controller takes a
+# control_msgs/GripperCommand goal, matching PickNik's humble branch; Jazzy and
+# newer take ParallelGripperCommand.
+EXPECTED_CONTROLLER_TYPES = {
+    JAZZY_CONFIG: "parallel_gripper_action_controller/GripperActionController",
+    HUMBLE_CONFIG: "position_controllers/GripperActionController",
+}
 
-def gripper_controller_params():
-    with open(CONFIG) as f:
-        config = yaml.safe_load(f)
-    return config["robotiq_gripper_controller"]["ros__parameters"]
+
+def load_launch_module():
+    """Import robotiq_control.launch.py for its distro -> config-file mapping."""
+    path = Path(__file__).parents[1] / "launch" / "robotiq_control.launch.py"
+    spec = importlib.util.spec_from_file_location("robotiq_control_launch", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def load(config):
+    with open(config) as f:
+        return yaml.safe_load(f)
+
+
+def gripper_controller_params(config):
+    return load(config)["robotiq_gripper_controller"]["ros__parameters"]
 
 
 def test_max_effort_interface_is_exported():
-    params = gripper_controller_params()
+    params = gripper_controller_params(JAZZY_CONFIG)
     assert params["max_effort_interface"] in EXPORTED_COMMAND_INTERFACES
 
 
 def test_max_velocity_interface_is_exported():
-    params = gripper_controller_params()
+    params = gripper_controller_params(JAZZY_CONFIG)
     assert params["max_velocity_interface"] in EXPORTED_COMMAND_INTERFACES
 
 
-def test_joint_matches_exported_interfaces():
-    params = gripper_controller_params()
-    assert params["joint"] == JOINT
+def test_humble_config_claims_no_unsupported_interfaces():
+    # Humble's gripper_controllers declares neither parameter; leaving them in
+    # would read as working speed/force control that Humble silently ignores.
+    params = gripper_controller_params(HUMBLE_CONFIG)
+    assert "max_effort_interface" not in params
+    assert "max_velocity_interface" not in params
+
+
+@pytest.mark.parametrize("config", ALL_CONFIGS)
+def test_joint_matches_exported_interfaces(config):
+    assert gripper_controller_params(config)["joint"] == JOINT
+
+
+@pytest.mark.parametrize("config", ALL_CONFIGS)
+def test_controller_type_matches_distro(config):
+    controllers = load(config)["controller_manager"]["ros__parameters"]
+    assert (
+        controllers["robotiq_gripper_controller"]["type"]
+        == EXPECTED_CONTROLLER_TYPES[config]
+    )
+
+
+@pytest.mark.parametrize(
+    "distro,expected",
+    [
+        ("humble", HUMBLE_CONFIG),
+        ("jazzy", JAZZY_CONFIG),
+        ("lyrical", JAZZY_CONFIG),
+        (None, JAZZY_CONFIG),  # ROS_DISTRO unset: newest layout is the default
+    ],
+)
+def test_launch_selects_the_config_for_the_distro(distro, expected):
+    launch_module = load_launch_module()
+    selected = launch_module.controllers_file_for_distro(distro)
+    assert selected == expected.name
+    assert (CONFIG_DIR / selected).is_file()
+
+
+@pytest.mark.parametrize("config", ALL_CONFIGS)
+def test_controller_names_and_update_rate_are_identical_across_distros(config):
+    # The controller names are the action/service namespaces users depend on
+    # (/robotiq_gripper_controller/gripper_cmd), so they must not drift between
+    # the two configs.
+    controllers = load(config)["controller_manager"]["ros__parameters"]
+    assert set(controllers) == {
+        "update_rate",
+        "joint_state_broadcaster",
+        "robotiq_gripper_controller",
+        "robotiq_activation_controller",
+    }
+    assert controllers["update_rate"] == 500
+    assert (
+        controllers["robotiq_activation_controller"]["type"]
+        == "robotiq_controllers/RobotiqActivationController"
+    )
+    assert (
+        controllers["joint_state_broadcaster"]["type"]
+        == "joint_state_broadcaster/JointStateBroadcaster"
+    )

--- a/grippers/robotiq_description/test/test_ros2_control_urdf.py
+++ b/grippers/robotiq_description/test/test_ros2_control_urdf.py
@@ -1,0 +1,154 @@
+# Copyright (c) 2026 Robotiq
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the copyright holder nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Expand the gripper xacro and check the ros2_control interfaces it declares.
+
+The two hardware plugins need different interface sets, and getting it wrong is
+silent until a controller fails to activate at runtime:
+
+* The real driver exports set_gripper_max_effort / set_gripper_max_velocity from
+  export_command_interfaces() rather than from the URDF, and its on_init rejects a
+  joint that declares more than one command interface.
+* Mock hardware exposes only what the URDF declares, so those two interfaces have
+  to be declared there or parallel_gripper_action_controller cannot claim them and
+  never activates under use_fake_hardware:=true.
+"""
+
+import shutil
+import subprocess
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+import yaml
+
+PKG_DIR = Path(__file__).parents[1]
+URDF_DIR = PKG_DIR / "urdf"
+CONFIG = PKG_DIR / "config" / "robotiq_controllers.yaml"
+
+# Top-level xacro -> the joint carrying the gripper's position command.
+MODELS = {
+    "robotiq_2f_85_gripper.urdf.xacro": "robotiq_85_left_knuckle_joint",
+    "robotiq_2f_140_gripper.urdf.xacro": "finger_joint",
+}
+
+MOCK_PLUGIN = "mock_components/GenericSystem"
+REAL_PLUGIN = "robotiq_driver/RobotiqGripperHardwareInterface"
+
+# Exported by the driver at runtime; needed from the URDF under mock hardware.
+EXTRA_MOCK_COMMAND_INTERFACES = {"set_gripper_max_velocity", "set_gripper_max_effort"}
+
+requires_xacro = pytest.mark.skipif(
+    shutil.which("xacro") is None, reason="xacro not on PATH"
+)
+
+
+def expand(model, use_fake_hardware):
+    """Run xacro on `model` and return the parsed <ros2_control> element."""
+    result = subprocess.run(
+        [
+            "xacro",
+            str(URDF_DIR / model),
+            f"use_fake_hardware:={str(use_fake_hardware).lower()}",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    ros2_control = ET.fromstring(result.stdout).find("ros2_control")
+    assert ros2_control is not None, f"{model} declares no <ros2_control> block"
+    return ros2_control
+
+
+def plugin_of(ros2_control):
+    return ros2_control.find("hardware/plugin").text.strip()
+
+
+def command_interfaces_of(ros2_control, joint_name):
+    joint = ros2_control.find(f"joint[@name='{joint_name}']")
+    assert joint is not None, f"joint {joint_name} missing from <ros2_control>"
+    return {ci.get("name") for ci in joint.findall("command_interface")}
+
+
+def joints_of(ros2_control):
+    return {j.get("name") for j in ros2_control.findall("joint")}
+
+
+@requires_xacro
+@pytest.mark.parametrize("model,joint", MODELS.items())
+def test_mock_declares_the_interfaces_the_gripper_controller_claims(model, joint):
+    ros2_control = expand(model, use_fake_hardware=True)
+    assert plugin_of(ros2_control) == MOCK_PLUGIN
+    assert (
+        command_interfaces_of(ros2_control, joint)
+        == {"position"} | EXTRA_MOCK_COMMAND_INTERFACES
+    )
+
+
+@requires_xacro
+@pytest.mark.parametrize("model,joint", MODELS.items())
+def test_real_hardware_declares_exactly_one_command_interface(model, joint):
+    # RobotiqGripperHardwareInterface::on_init fails the component outright if the
+    # joint declares anything other than a single position command interface.
+    ros2_control = expand(model, use_fake_hardware=False)
+    assert plugin_of(ros2_control) == REAL_PLUGIN
+    assert command_interfaces_of(ros2_control, joint) == {"position"}
+
+
+@requires_xacro
+@pytest.mark.parametrize("model,joint", MODELS.items())
+def test_mock_publishes_the_same_joints_as_hardware(model, joint):
+    # The mimic joints must NOT be declared under mock: mock_components would then
+    # own them and publish them in /joint_states, which Humble reports as 0.0 while
+    # Jazzy and Lyrical apply the URDF multipliers. Leaving them out makes
+    # robot_state_publisher derive them from the <mimic> tags on every distro,
+    # exactly as it already does for real hardware.
+    mock = joints_of(expand(model, use_fake_hardware=True))
+    real = joints_of(expand(model, use_fake_hardware=False))
+    assert mock == real == {joint}
+
+
+@requires_xacro
+def test_gripper_controller_config_interfaces_exist_under_mock():
+    # Ties config/robotiq_controllers.yaml to the mock URDF: these two parameters
+    # name "<joint>/<interface>" pairs the controller claims, and an unmatched name
+    # is why the controller used to fail to activate with use_fake_hardware:=true.
+    params = yaml.safe_load(CONFIG.read_text())["robotiq_gripper_controller"][
+        "ros__parameters"
+    ]
+    claimed = {params["max_effort_interface"], params["max_velocity_interface"]}
+
+    ros2_control = expand("robotiq_2f_85_gripper.urdf.xacro", use_fake_hardware=True)
+    joint = MODELS["robotiq_2f_85_gripper.urdf.xacro"]
+    available = {
+        f"{joint}/{name}" for name in command_interfaces_of(ros2_control, joint)
+    }
+
+    assert (
+        claimed <= available
+    ), f"controller claims {claimed - available}, which the mock URDF does not declare"

--- a/grippers/robotiq_description/urdf/2f_140.ros2_control.xacro
+++ b/grippers/robotiq_description/urdf/2f_140.ros2_control.xacro
@@ -48,13 +48,18 @@
             <!-- With Gazebo or Hardware, they handle mimic joints, so we only need this command interface activated -->
             <joint name="${prefix}finger_joint">
                 <command_interface name="position" />
+                <!-- Mock-only; see the same block in 2f_85.ros2_control.xacro. -->
+                <xacro:if value="${use_fake_hardware}">
+                    <command_interface name="set_gripper_max_velocity"/>
+                    <command_interface name="set_gripper_max_effort"/>
+                </xacro:if>
                 <state_interface name="position">
                     <param name="initial_value">${gripper_closed_position}</param>
                 </state_interface>
                 <state_interface name="velocity"/>
             </joint>
             <!-- When simulating we need to include the rest of the gripper joints -->
-            <xacro:if value="${use_fake_hardware or sim_isaac or sim_gazebo}">
+            <xacro:if value="${sim_isaac or sim_gazebo}">
                 <joint name="${prefix}left_inner_knuckle_joint">
                     <xacro:unless value="${sim_gazebo}">
                         <state_interface name="position"/>

--- a/grippers/robotiq_description/urdf/2f_85.ros2_control.xacro
+++ b/grippers/robotiq_description/urdf/2f_85.ros2_control.xacro
@@ -53,13 +53,25 @@
             <!-- With Gazebo or Hardware, they handle mimic joints, so we only need this command interface activated -->
             <joint name="${prefix}robotiq_85_left_knuckle_joint">
                 <command_interface name="position" />
+                <!-- The real hardware exports these two from
+                     export_command_interfaces() instead of the URDF, and its on_init
+                     rejects a joint declaring more than one command interface. Mock
+                     hardware exposes only what the URDF declares, so declare them for
+                     the mock alone: without them parallel_gripper_action_controller
+                     (Jazzy and newer) cannot claim max_effort_interface /
+                     max_velocity_interface and never activates under
+                     use_fake_hardware:=true. -->
+                <xacro:if value="${use_fake_hardware}">
+                    <command_interface name="set_gripper_max_velocity"/>
+                    <command_interface name="set_gripper_max_effort"/>
+                </xacro:if>
                 <state_interface name="position">
                     <param name="initial_value">${gripper_closed_position}</param>
                 </state_interface>
                 <state_interface name="velocity"/>
             </joint>
             <!-- When simulating we need to include the rest of the gripper joints -->
-            <xacro:if value="${use_fake_hardware or sim_isaac or sim_gazebo}">
+            <xacro:if value="${sim_isaac or sim_gazebo}">
                 <joint name="${prefix}robotiq_85_right_knuckle_joint">
                     <xacro:unless value="${sim_gazebo}">
                         <state_interface name="position"/>

--- a/grippers/robotiq_driver/CMakeLists.txt
+++ b/grippers/robotiq_driver/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library(
   include/robotiq_driver/hardware_interface.hpp
   include/robotiq_driver/hardware_parameters.hpp
   include/robotiq_driver/rclcpp_logger.hpp
+  include/robotiq_driver/ros2_control_compat.hpp
   include/robotiq_driver/visibility_control.hpp
   # Signposts for the headers this package used to install, so downstream
   # code that includes one stops with an explanation instead of a

--- a/grippers/robotiq_driver/CMakeLists.txt
+++ b/grippers/robotiq_driver/CMakeLists.txt
@@ -1,7 +1,9 @@
 # See https://docs.ros.org/en/humble/How-To-Guides/Ament-CMake-Documentation.html
 
 cmake_minimum_required(VERSION 3.10)
-project(robotiq_driver LANGUAGES CXX)
+# C as well as CXX: the gripper SDK added below is a C/C++ project, and CMake 4
+# wants the language enabled here before the subproject asks for it.
+project(robotiq_driver LANGUAGES C CXX)
 
 # This module provides installation directories as per the GNU coding standards.
 include(GNUInstallDirs)
@@ -46,9 +48,6 @@ set(_robotiq_saved_build_shared_libs "${BUILD_SHARED_LIBS}")
 set(BUILD_SHARED_LIBS OFF)
 add_subdirectory(${GRIPPERS_SDK_DIR} ${CMAKE_CURRENT_BINARY_DIR}/grippers_sdk EXCLUDE_FROM_ALL)
 set(BUILD_SHARED_LIBS "${_robotiq_saved_build_shared_libs}")
-# A static archive going into a shared plugin has to be position-independent.
-# CMake cannot set properties through the Robotiq::grippers alias.
-set_target_properties(grippers_sdk PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 ###############################################################################
 # Robotiq driver library.
@@ -99,18 +98,17 @@ target_link_libraries(
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
   PRIVATE
-  # $<BUILD_INTERFACE:...> keeps the statically-linked SDK out of the installed
-  # export set, where there would be no target for it to resolve to.
-  # WHOLE_ARCHIVE (CMake 3.24+, satisfied from Jazzy's 24.04 on) because the
-  # SDK's headers ship with this package: a consumer may call any SDK entry
-  # point, so every SDK object has to land in the library — not just the
-  # ones the wrapper itself references.
+  # The SDK's object library, not its archive: the SDK's headers ship with this
+  # package, so a consumer may call any SDK entry point and every object has to
+  # land in the library, not just the ones the wrapper references.
+  # $<BUILD_INTERFACE:...> keeps it out of the installed export set, where there
+  # would be no target for it to resolve to.
   #
   # The consequence to know about: the whole SDK symbol set is exported from a
   # dlopen'd plugin. A second package in the same process linking the SDK the
   # same way gets its own copy with independent static state, and Robotiq::Gripper
   # owns a serial link and a thread. One SDK consumer per process.
-  $<BUILD_INTERFACE:$<LINK_LIBRARY:WHOLE_ARCHIVE,Robotiq::grippers>>
+  $<BUILD_INTERFACE:Robotiq::grippers_objects>
 )
 
 ###############################################################################

--- a/grippers/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
+++ b/grippers/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
@@ -45,6 +45,8 @@
 #include <robotiq_driver/hardware_parameters.hpp>
 #include <robotiq_driver/visibility_control.hpp>
 
+#include <robotiq_driver/ros2_control_compat.hpp>
+
 #include <Robotiq/gripper.hpp>
 
 #include <hardware_interface/handle.hpp>
@@ -76,12 +78,14 @@ public:
    /**
     * Read and validate the hardware parameters and the joint's interfaces.
     * Performs no I/O — the link is opened in on_configure.
-    * @param params Structure with parameters for initializing this hardware component.
+    * @param params Structure with parameters for initializing this hardware component
+    * (a HardwareComponentInterfaceParams from Jazzy on, a HardwareInfo on Humble —
+    * see ros2_control_compat.hpp).
     * @returns CallbackReturn::SUCCESS if required data are provided and can be
     * parsed or CallbackReturn::ERROR if any error happens or data are missing.
     */
    ROBOTIQ_DRIVER_PUBLIC
-   CallbackReturn on_init(const hardware_interface::HardwareComponentInterfaceParams& params) override;
+   CallbackReturn on_init(const OnInitParams& params) override;
 
    /**
     * Open the serial link and start the SDK exchange cycle. Constructing the

--- a/grippers/robotiq_driver/include/robotiq_driver/ros2_control_compat.hpp
+++ b/grippers/robotiq_driver/include/robotiq_driver/ros2_control_compat.hpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Robotiq
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+// ros2_control API differences across the ROS 2 distros this package supports
+// (Humble, Jazzy, Lyrical).
+//
+// SystemInterface::on_init() takes a HardwareInfo on Humble (ros2_control 2.x)
+// and a HardwareComponentInterfaceParams from Jazzy's 4.x line on, where the
+// HardwareInfo overload is deprecated. Detection is by header presence rather
+// than a HARDWARE_INTERFACE_VERSION_GTE threshold: the struct arrived with its
+// own header, and Jazzy's 4.x line keeps moving, so there is no stable version
+// number to compare against.
+
+#if __has_include(<hardware_interface/types/hardware_component_interface_params.hpp>)
+#include <hardware_interface/types/hardware_component_interface_params.hpp>
+#else
+#include <hardware_interface/hardware_info.hpp>
+#endif
+
+namespace robotiq_driver {
+#if __has_include(<hardware_interface/types/hardware_component_interface_params.hpp>)
+/// Argument type of SystemInterface::on_init() on this distro.
+using OnInitParams = hardware_interface::HardwareComponentInterfaceParams;
+#else
+using OnInitParams = hardware_interface::HardwareInfo;
+#endif
+} // namespace robotiq_driver

--- a/grippers/robotiq_driver/include/robotiq_driver/ros2_control_compat.hpp
+++ b/grippers/robotiq_driver/include/robotiq_driver/ros2_control_compat.hpp
@@ -51,4 +51,5 @@ using OnInitParams = hardware_interface::HardwareComponentInterfaceParams;
 #else
 using OnInitParams = hardware_interface::HardwareInfo;
 #endif
+
 } // namespace robotiq_driver

--- a/grippers/robotiq_driver/src/hardware_interface.cpp
+++ b/grippers/robotiq_driver/src/hardware_interface.cpp
@@ -97,8 +97,7 @@ std::unique_ptr<Robotiq::Gripper> RobotiqGripperHardwareInterface::createGripper
    return std::make_unique<Robotiq::Gripper>(parameters_.connection, logger_);
 }
 
-hardware_interface::CallbackReturn RobotiqGripperHardwareInterface::on_init(
-   const hardware_interface::HardwareComponentInterfaceParams& params)
+hardware_interface::CallbackReturn RobotiqGripperHardwareInterface::on_init(const OnInitParams& params)
 {
    RCLCPP_DEBUG(kLogger, "on_init");
 

--- a/grippers/robotiq_driver/src/hardware_interface.cpp
+++ b/grippers/robotiq_driver/src/hardware_interface.cpp
@@ -40,6 +40,7 @@
 #include <robotiq_driver/rclcpp_logger.hpp>
 
 #include <Robotiq/gripper/fake/gripper_factory.hpp>
+#include <Robotiq/gripper/wait.hpp>
 
 #include <hardware_interface/actuator_interface.hpp>
 #include <hardware_interface/types/hardware_interface_type_values.hpp>
@@ -55,6 +56,20 @@ constexpr auto kDiagnosticThrottleMs = 5000;
 // exchange cycle sends it within a cycle or two; this only has to outlast a
 // retry or a lost frame.
 constexpr auto kDeactivationTimeout = std::chrono::seconds{2};
+
+// Where on_activate leaves the fingers. Fully open matches what the gripper does
+// on its own and what the driver did before the SDK; a parameter could choose it
+// instead, which would save the travel when the caller wants them elsewhere.
+constexpr uint8_t kPostActivationPosition = robotiq_driver::kGripperMinPos;
+
+// Waiting out that move, following the SDK's move_gripper example: how long the
+// gripper has to echo the request, how long to watch for the motion to start
+// (advisory — a short move can finish first), and the cap on the move itself.
+// The sequence below is the example's; it belongs in the SDK as a shared moveTo
+// so both callers get it from one place.
+constexpr auto kCommandEchoTimeout = std::chrono::seconds{1};
+constexpr auto kMotionStartTimeout = std::chrono::milliseconds{200};
+constexpr auto kMotionTimeout = std::chrono::seconds{5};
 
 namespace robotiq_driver {
 namespace {
@@ -308,6 +323,49 @@ hardware_interface::CallbackReturn RobotiqGripperHardwareInterface::on_activate(
                    static_cast<int>(parameters_.activation_timeout.count()));
       return CallbackReturn::ERROR;
    }
+
+   // Activation completes with the fingers closed, and the gripper re-opens them
+   // afterwards on its own. Command that move instead of waiting it out: the
+   // courtesy move runs with rGTO clear, and gOBJ only describes motion while
+   // rGTO is set, so it reads "moving" throughout and never settles. Commanding
+   // sets rGTO and makes gOBJ mean what the SDK's move_gripper example relies on.
+   //
+   // Something has to wait for it either way. Publishing a position mid-move
+   // hands a controller that seeds its hold target from the position state —
+   // both gripper_controllers and parallel_gripper_controller do — a half-closed
+   // pose to latch, which stops the fingers there.
+   command_.positionRequest = kPostActivationPosition;
+   command_.action.set(Robotiq::ActionRequestBit::GoTo);
+   gripper_->setCommand(command_);
+
+   if(!Robotiq::waitFor([&] { return gripper_->getStatus().positionRequestEcho == kPostActivationPosition; },
+                        kCommandEchoTimeout))
+   {
+      RCLCPP_WARN(kLogger, "The gripper never echoed the post-activation position request.");
+   }
+   else if(!Robotiq::waitFor(
+              [&] { return gripper_->getStatus().gripperStatus.objectDetection() == Robotiq::ObjectDetection::Moving; },
+              kMotionStartTimeout))
+   {
+      RCLCPP_DEBUG(kLogger, "No motion seen after the post-activation command; the fingers may already be there.");
+   }
+
+   if(!Robotiq::waitFor(
+         [&] { return gripper_->getStatus().gripperStatus.objectDetection() != Robotiq::ObjectDetection::Moving; },
+         kMotionTimeout))
+   {
+      RCLCPP_WARN(kLogger,
+                  "The gripper had not settled %d ms after the post-activation command; publishing its position "
+                  "anyway.",
+                  static_cast<int>(std::chrono::milliseconds{kMotionTimeout}.count()));
+   }
+   const Robotiq::GripperStatus status = gripper_->getStatus();
+
+   // Seed both sides from that settled reading so the first exported state, and
+   // any hold target derived from it, describe where the fingers actually are.
+   gripper_position_ = jointPositionFromRegister(status.position, parameters_.closed_position);
+   gripper_velocity_ = 0.0;
+   gripper_position_command_ = gripper_position_;
 
    RCLCPP_INFO(kLogger, "Robotiq Gripper successfully activated!");
    return CallbackReturn::SUCCESS;

--- a/grippers/robotiq_driver/src/hardware_parameters.cpp
+++ b/grippers/robotiq_driver/src/hardware_parameters.cpp
@@ -29,7 +29,12 @@
 
 #include <robotiq_driver/hardware_parameters.hpp>
 
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <cmath>
 #include <cstdint>
+#include <stdexcept>
 #include <string>
 
 #include <rclcpp/logging.hpp>

--- a/grippers/robotiq_driver/tests/ros2_control_compat.hpp
+++ b/grippers/robotiq_driver/tests/ros2_control_compat.hpp
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Robotiq
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <optional>
+#include <type_traits>
+#include <utility>
+
+#include <hardware_interface/types/hardware_interface_return_values.hpp>
+
+// Only the tests drive ros2_control's handles and ResourceManager directly, so
+// these shims live here rather than in the package's installed headers.
+//
+// Humble (ros2_control 2.x) has `void set_value(double)`, `double get_value()`
+// and HardwareReadWriteStatus::ok; from Jazzy's 4.x line on, writes report
+// success, reads can fail, and the status carries a return_type `result`. Each
+// shim keys off the shape of the operation it wraps, not a version threshold,
+// because Jazzy's 4.x line keeps moving.
+//
+// robotiq_controllers ships the same two handle shims in its own header. It does
+// not depend on this package — and should not, since that would put the gripper
+// SDK's build in front of the controllers — so the copies stay separate.
+
+namespace robotiq_driver::test::compat {
+namespace detail {
+template <typename HandleT, typename = void>
+struct HasGetOptional : std::false_type
+{
+};
+
+template <typename HandleT>
+struct HasGetOptional<HandleT, std::void_t<decltype(std::declval<const HandleT&>().get_optional())>> : std::true_type
+{
+};
+
+template <typename HandleT>
+struct SetValueReturnsBool : std::is_same<decltype(std::declval<HandleT&>().set_value(0.0)), bool>
+{
+};
+
+template <typename StatusT, typename = void>
+struct HasResult : std::false_type
+{
+};
+
+template <typename StatusT>
+struct HasResult<StatusT, std::void_t<decltype(std::declval<const StatusT&>().result)>> : std::true_type
+{
+};
+} // namespace detail
+
+/// Write `value` to `handle`; always true where the API cannot report failure.
+template <typename HandleT>
+bool setValue(HandleT& handle, double value)
+{
+   if constexpr(detail::SetValueReturnsBool<HandleT>::value)
+   {
+      return handle.set_value(value);
+   }
+   else
+   {
+      handle.set_value(value);
+      return true;
+   }
+}
+
+/// Read `handle`; std::nullopt only where the API can report a failed read.
+template <typename HandleT>
+std::optional<double> getValue(const HandleT& handle)
+{
+   if constexpr(detail::HasGetOptional<HandleT>::value)
+   {
+      return handle.get_optional();
+   }
+   else
+   {
+      return handle.get_value();
+   }
+}
+
+/// Whether a ResourceManager read()/write() cycle succeeded.
+template <typename StatusT>
+bool readWriteOk(const StatusT& status)
+{
+   if constexpr(detail::HasResult<StatusT>::value)
+   {
+      return status.result == hardware_interface::return_type::OK;
+   }
+   else
+   {
+      return status.ok;
+   }
+}
+} // namespace robotiq_driver::test::compat

--- a/grippers/robotiq_driver/tests/test_robotiq_gripper_hardware_interface.cpp
+++ b/grippers/robotiq_driver/tests/test_robotiq_gripper_hardware_interface.cpp
@@ -181,6 +181,15 @@ TEST(TestRobotiqGripperHardwareInterface, UseDummyActivatesAndFollowsCommands)
    auto position = rm.claim_state_interface("robotiq_85_left_knuckle_joint/position");
    auto command = rm.claim_command_interface("robotiq_85_left_knuckle_joint/position");
 
+   // Activation seeds both sides from where the fingers actually are, so a
+   // controller that adopts the position state as its hold target on activation
+   // holds the gripper still instead of dragging it somewhere else.
+   ASSERT_TRUE(compat::readWriteOk(rm.read(time, period)));
+   const auto seeded_position = compat::getValue(position);
+   ASSERT_TRUE(seeded_position.has_value());
+   EXPECT_DOUBLE_EQ(compat::getValue(command).value_or(-1.0), seeded_position.value())
+      << "the position command must start at the measured position, not at a fixed default";
+
    // Half closed, in joint radians against the 0.7929 closed position.
    constexpr double kTarget = 0.4;
    ASSERT_TRUE(compat::setValue(command, kTarget));

--- a/grippers/robotiq_driver/tests/test_robotiq_gripper_hardware_interface.cpp
+++ b/grippers/robotiq_driver/tests/test_robotiq_gripper_hardware_interface.cpp
@@ -53,6 +53,8 @@
 
 #include <robotiq_driver/hardware_interface.hpp>
 
+#include "ros2_control_compat.hpp"
+
 namespace robotiq_driver::test {
 
 namespace {
@@ -181,9 +183,8 @@ TEST(TestRobotiqGripperHardwareInterface, UseDummyActivatesAndFollowsCommands)
 
    // Half closed, in joint radians against the 0.7929 closed position.
    constexpr double kTarget = 0.4;
-   const bool success = command.set_value(kTarget);
-   ASSERT_TRUE(success);
-   ASSERT_EQ(hardware_interface::return_type::OK, rm.write(time, period).result);
+   ASSERT_TRUE(compat::setValue(command, kTarget));
+   ASSERT_TRUE(compat::readWriteOk(rm.write(time, period)));
 
    // The simulated gripper teleports, but the SDK's exchange cycle still has
    // to carry the command and bring the status back.
@@ -191,12 +192,12 @@ TEST(TestRobotiqGripperHardwareInterface, UseDummyActivatesAndFollowsCommands)
    bool reached = false;
    while(!reached && std::chrono::steady_clock::now() < deadline)
    {
-      ASSERT_EQ(hardware_interface::return_type::OK, rm.read(time, period).result);
-      reached = std::abs(position.get_optional().value_or(0.0) - kTarget) < 0.01;
+      ASSERT_TRUE(compat::readWriteOk(rm.read(time, period)));
+      reached = std::abs(compat::getValue(position).value_or(0.0) - kTarget) < 0.01;
       std::this_thread::sleep_for(std::chrono::milliseconds{5});
    }
    EXPECT_TRUE(reached) << "joint position never followed the command; last read "
-                        << position.get_optional().value_or(0.0);
+                        << compat::getValue(position).value_or(0.0);
 }
 
 namespace {

--- a/grippers/robotiq_hardware_tests/CMakeLists.txt
+++ b/grippers/robotiq_hardware_tests/CMakeLists.txt
@@ -38,4 +38,11 @@ add_executable(full_test
 # reach Robotiq::Gripper — there is no second package to find.
 target_link_libraries(full_test robotiq_driver::robotiq_driver)
 
+# Without this the executable only ever exists under build/, so
+# `ros2 run robotiq_hardware_tests full_test` cannot find it.
+install(
+  TARGETS full_test
+  DESTINATION lib/${PROJECT_NAME}
+)
+
 ament_package()

--- a/robotiq_tsf/CMakeLists.txt
+++ b/robotiq_tsf/CMakeLists.txt
@@ -97,17 +97,19 @@ target_include_directories(poll_data_sdk_lib
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     ${TSF_SDK_DIR}
 )
+# Imported targets rather than ament_target_dependencies(): the latter is gone
+# from ament_cmake in Lyrical. rclcpp::rclcpp, ament_index_cpp::ament_index_cpp
+# and the ${<pkg>_TARGETS} variables exist on every distro we support.
 target_link_libraries(poll_data_sdk_lib
-  ${PROJECT_NAME}_algorithms
-  ${cpp_typesupport_target}
-  robotiq_tactile_sdk
-  Threads::Threads
-)
-ament_target_dependencies(poll_data_sdk_lib
-  rclcpp
-  std_msgs
-  sensor_msgs
-  ament_index_cpp
+  PUBLIC
+    ${PROJECT_NAME}_algorithms
+    ${cpp_typesupport_target}
+    robotiq_tactile_sdk
+    Threads::Threads
+    rclcpp::rclcpp
+    ament_index_cpp::ament_index_cpp
+    ${std_msgs_TARGETS}
+    ${sensor_msgs_TARGETS}
 )
 
 add_executable(poll_data_sdk_node src/poll_data_sdk_main.cpp)
@@ -119,15 +121,13 @@ target_include_directories(tactile_total_sum_node
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 target_link_libraries(tactile_total_sum_node
-  ${PROJECT_NAME}_algorithms
-  ${cpp_typesupport_target}
-  Threads::Threads
-)
-
-ament_target_dependencies(tactile_total_sum_node
-  rclcpp
-  std_msgs
-  ament_index_cpp
+  PRIVATE
+    ${PROJECT_NAME}_algorithms
+    ${cpp_typesupport_target}
+    Threads::Threads
+    rclcpp::rclcpp
+    ament_index_cpp::ament_index_cpp
+    ${std_msgs_TARGETS}
 )
 
 install(TARGETS ${PROJECT_NAME}_algorithms

--- a/robotiq_tsf/package.xml
+++ b/robotiq_tsf/package.xml
@@ -2,7 +2,7 @@
 <package format="3">
   <name>robotiq_tsf</name>
   <version>1.0.0</version>
-  <description>ROS 2 Jazzy tactile sensing package for the Robotiq TSF-85.</description>
+  <description>ROS 2 tactile sensing package for the Robotiq TSF-85 (Humble, Jazzy, Lyrical).</description>
 
   <maintainer email="jean-philippe.roberge@etsmtl.ca">Jean-Philippe Roberge</maintainer>
   <maintainer email="jenkwia@example.com">Jen Kwia</maintainer>

--- a/robotiq_tsf/scripts/tactile_viz_node
+++ b/robotiq_tsf/scripts/tactile_viz_node
@@ -139,7 +139,7 @@ class TactileVizNode(Node):
         self._vmax = float(p("vmax").value)
         if self._vmax <= self._vmin:
             self._vmax = self._vmin + 1.0
-            self.get_logger().warn(
+            self.get_logger().warning(
                 f'vmax ({p("vmax").value}) <= vmin ({self._vmin}); '
                 f"using vmax = {self._vmax}"
             )
@@ -238,7 +238,7 @@ class TactileVizNode(Node):
         for fi in (0, 1):
             values = msg.taxels[fi].values
             if len(values) != _TAXELS:
-                self.get_logger().warn(
+                self.get_logger().warning(
                     f"finger_{fi}: expected {_TAXELS} taxels, got {len(values)}",
                     throttle_duration_sec=2.0,
                 )

--- a/robotiq_tsf/test/test_poll_data_sdk_node.cpp
+++ b/robotiq_tsf/test/test_poll_data_sdk_node.cpp
@@ -56,10 +56,14 @@ std::map<std::string, std::vector<std::string>> waitForNames(const rclcpp::Node:
 {
    using namespace std::chrono; // NOLINT(build/namespaces)
    const auto deadline = steady_clock::now() + seconds(10);
+   // Executor rather than the free rclcpp::spin_some(node), which is deprecated
+   // from Lyrical on.
+   rclcpp::executors::SingleThreadedExecutor executor;
+   executor.add_node(node);
    std::map<std::string, std::vector<std::string>> names;
    while(steady_clock::now() < deadline)
    {
-      rclcpp::spin_some(node);
+      executor.spin_some();
       names = query();
       bool all = true;
       for(const auto& e : expected)


### PR DESCRIPTION
## Summary

Supports ROS 2 Humble, Jazzy and Lyrical — the three live LTS distros — from this one branch, plus Rolling built non-blocking as early warning. `main` previously built on Jazzy only.

On Humble this is a drop-in replacement for PickNik's `humble` branch: same controller, same `control_msgs/GripperCommand` action, same launch files, and a repos file with identical contents, so existing action clients keep working untouched.

> **Depends on [Robotiq/grippers#13](https://github.com/Robotiq/grippers/pull/13).** `extern/grippers` is pinned to a commit on that PR's branch so CI could exercise the pair. **The pin must be moved to the merged SHA on the SDK's `main` before this merges** — a squash-merge there changes the SHA. **To prevent an accidental merge, this PR is left as a draft until the pin has been moved.**

## Problem

The two new distros broke in disjoint places — Lyrical in CMake, Humble in the `ros2_control` API — and the vendored gripper SDK assumed Jazzy throughout:

| Package | Humble | Jazzy | Lyrical |
|---|---|---|---|
| `robotiq_tsf` | builds | builds | **fails configure** |
| `robotiq_driver` / `robotiq_controllers` | **fail compile** | build | build |
| `robotiq_description` | `rosdep` unresolvable | builds | builds |

Lyrical's `ament_cmake` removed `ament_target_dependencies()`, and its CMake 4 wants `C` enabled before the SDK subproject asks. Humble's `ros2_control` 2.x passes `HardwareInfo` to `on_init()`, its command handles have no `get_optional()` or bool-returning `set_value()`, its GCC 11 doesn't supply `<cmath>` and friends transitively, and its CMake 3.22 has no `$<LINK_LIBRARY:WHOLE_ARCHIVE>`. And `parallel_gripper_controller` does not exist on Humble — ROS only gained it in Jazzy.

## Changes

- `robotiq_tsf`: imported targets instead of `ament_target_dependencies()`; fix `rclpy`'s removed `warn()` and the deprecated `spin_some(node)`.
- `robotiq_driver` / `robotiq_controllers`: a compat header per package, detecting each API by shape (`__has_include`, `std::void_t` on the handle) rather than a version threshold, since Jazzy's 4.x line keeps moving. The Humble path is byte-for-byte PickNik's. Adds `robotiq_controllers`' first tests, covering both handle shapes.
- `robotiq_driver` links the SDK's new object library, `Robotiq::grippers_objects`, so every object lands in the plugin with no whole-archive flags and no CMake version floor.
- `robotiq_description`: a Humble controller config using stock `position_controllers/GripperActionController`, selected on `$ROS_DISTRO`, and `condition=` deps so `rosdep` resolves on every distro with no `--skip-keys`.
- `use_fake_hardware` now behaves like hardware everywhere: the mock gets the gripper's effort/velocity command interfaces, and no longer owns the mimicked finger joints, so `robot_state_publisher` derives them as it does on hardware.
- CI matrix over the LTS distros inside `ros:<distro>-ros-base` containers; `docker/run.sh` takes `ROS_DISTRO`.

## Testing

CI is green on all four distros. Locally, all six packages build with no warnings from our code and `rosdep` resolves clean.

Hardware, real 2F-85 and TSF-85: 7 sensor topics including fused orientation; `full_test` from the installed path; 3 controllers active with `joint_states` at 500 Hz; `gripper_cmd` goals driving the gripper to target within 0.001 rad; and `~/reactivate_gripper` returning success — the only path that exercises the handle compat shim against real hardware. Re-run after the SDK bump, including holding and motion phases with no position hunting.

## Notes

- **The `gripper_cmd` action type differs by distro**: `GripperCommand` on Humble, `ParallelGripperCommand` on Jazzy and Lyrical. That break is upstream ROS's, not ours, and it is what lets Humble users migrate with no client changes. README carries the table.
- Three pre-existing bugs fixed along the way: `full_test` was built but never installed, so `ros2 run` could never find it; a dead `robotiq_update_rate.yaml` reference warned on every bringup; and controller parameters stopped reaching controllers on Lyrical because `controller_manager` no longer forwards its parameter file — now passed with the spawner's `--param-file`.
- **Deprecation debt**: the driver overrides `export_state_interfaces()` / `export_command_interfaces()`, which `ros2_control` 6.x marks deprecated in favour of `on_export_state_interfaces()`. Nothing warns about it today, so the non-blocking Rolling job is how we will see the break coming.
- 
FYI @JonathanBeaudoinRq @jlongvalRobotiq @bcastets-robotiq @jkski-robotiq 

🤖 Generated with [Claude Code](https://claude.com/claude-code)