### PR TITLE
feat(robotiq_driver): expose object detection and effort as state interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,23 @@ ros2 action send_goal /robotiq_gripper_controller/gripper_cmd \
 
 `position` is the joint angle in radians (≈ `0.0` open → ~`0.8` closed on a 2F-85); on Jazzy/Lyrical `effort` and `velocity` are optional max limits, mapped to the controller's `set_gripper_max_effort` / `set_gripper_max_velocity` interfaces.
 
+### State interfaces
+
+`robotiq_driver` exports four state interfaces on the gripper joint, all read out of the same status block the SDK exchanges every cycle. Read them from `/dynamic_joint_states`, or with `ros2 control list_hardware_interfaces`.
+
+| Interface | Unit | Description |
+|---|---|---|
+| `position` | rad | Knuckle joint angle, from gPO (≈ `0.0` open → ~`0.8` closed on a 2F-85) |
+| `velocity` | rad/s | Always `0.0`. The status block carries no velocity, and the driver does not differentiate the position |
+| `motor_current` | A | gCU, the motor current the manual gives as 10 mA per count, so `0.0` to `2.55` |
+| `object_status` | — | gOBJ verbatim: `0` moving, `1` object held while opening, `2` object held while closing, `3` at the requested position |
+
+All four read `NaN` until the component is activated; activation seeds them from the gripper's first settled status read, and `read()` refreshes them every cycle after that. The sentinel matters most for `object_status`, where every value in range is meaningful — `0` is "moving", not "no reading" — so `NaN` is the only way to say the gripper has not answered yet. Test for it before comparing against `0`..`3`.
+
+`motor_current` is motor current, **not** grip force, and it is not convertible to one.
+
+`motor_current` and `object_status` are not `ros2_control` standard interface names (there are `HW_IF_` constants for position, velocity and effort, and nothing for either of these), so consumers spell them out. The descriptions declare them on the real-hardware branch only — `mock_components/GenericSystem`, Gazebo and Isaac never write them — so under `use_fake_hardware:=true` both are absent rather than wrong.
+
 ### Hardware parameters
 
 `robotiq_driver` reads these from the `<hardware>` block of the `ros2_control` description (`robotiq_description/urdf/2f_*.ros2_control.xacro`):
@@ -277,13 +294,13 @@ ros2 action send_goal /robotiq_gripper_controller/gripper_cmd \
 | `slave_address` | `0x09` | Modbus slave address; `0x09` as the manual prints it, a bare number as the decimal it looks like |
 | `connection_frequency` | `100` | Rate of the SDK's background exchange cycle, in Hz; `0` free-runs |
 | `activation_timeout` | `15` | Seconds allowed for activation and for fault recovery |
-| `gripper_max_speed` / `gripper_max_force` | `0.150` m/s / `235` N | Full scale used to turn the speed/effort command interfaces into register fractions; must be positive |
+| `gripper_max_speed` / `gripper_max_force` | `0.150` m/s / `235` N | Full scale used to turn the speed/effort command interfaces into rSP / rFR register fractions. Command-side only — nothing scales a state interface by them. Rejected unless finite and above zero |
 | `gripper_speed_multiplier` / `gripper_force_multiplier` | `1.0` | Initial fractions published on those interfaces |
 | `use_dummy` | `false` | Drive a fake gripper instead of hardware. Off for the usual falsey spellings — empty, `0`, `false`, `no`, `off`, in any case — on for anything else |
 
 A malformed value is reported and the default stands; only `gripper_closed_position` fails the transition — missing, malformed, zero, or non-finite. A speed or force command the driver cannot turn into a register leaves that register at its previous value.
 
-> `use_dummy` now selects the SDK's fake gripper: no port is opened, activation is instant, and the fingers report wherever they were last commanded. It keeps the real plugin loaded, so the gripper and activation controllers still bind. That is what distinguishes it from the `use_fake_hardware:=true` launch argument, which swaps the plugin out for `ros2_control`'s `mock_components/GenericSystem` — that exports neither `set_gripper_max_velocity` / `set_gripper_max_effort` nor the `reactivate_gripper` GPIO.
+> `use_dummy` selects the SDK's fake gripper: no port is opened, activation is instant, and the fingers report wherever they were last commanded. It keeps the real plugin loaded, so the gripper and activation controllers still bind. That is what distinguishes it from the `use_fake_hardware:=true` launch argument, which swaps the plugin out for `ros2_control`'s `mock_components/GenericSystem`.
 
 ### Activation, faults and recovery
 

--- a/grippers/robotiq_description/package.xml
+++ b/grippers/robotiq_description/package.xml
@@ -21,7 +21,6 @@
   <exec_depend>xacro</exec_depend>
 
   <exec_depend>ros2_control</exec_depend>
-  <exec_depend>ros2_controllers</exec_depend>
 
   <exec_depend>joint_state_broadcaster</exec_depend>
 

--- a/grippers/robotiq_description/test/test_ros2_control_urdf.py
+++ b/grippers/robotiq_description/test/test_ros2_control_urdf.py
@@ -37,6 +37,8 @@ silent until a controller fails to activate at runtime:
 * Mock hardware exposes only what the URDF declares, so those two interfaces have
   to be declared there or parallel_gripper_action_controller cannot claim them and
   never activates under use_fake_hardware:=true.
+* motor_current and object_status are the reverse case: only the real driver
+  writes them.
 """
 
 import shutil
@@ -62,6 +64,8 @@ REAL_PLUGIN = "robotiq_driver/RobotiqGripperHardwareInterface"
 
 # Exported by the driver at runtime; needed from the URDF under mock hardware.
 EXTRA_MOCK_COMMAND_INTERFACES = {"set_gripper_max_velocity", "set_gripper_max_effort"}
+
+HARDWARE_ONLY_STATE_INTERFACES = {"motor_current", "object_status"}
 
 requires_xacro = pytest.mark.skipif(
     shutil.which("xacro") is None, reason="xacro not on PATH"
@@ -93,6 +97,12 @@ def command_interfaces_of(ros2_control, joint_name):
     joint = ros2_control.find(f"joint[@name='{joint_name}']")
     assert joint is not None, f"joint {joint_name} missing from <ros2_control>"
     return {ci.get("name") for ci in joint.findall("command_interface")}
+
+
+def state_interfaces_of(ros2_control, joint_name):
+    joint = ros2_control.find(f"joint[@name='{joint_name}']")
+    assert joint is not None, f"joint {joint_name} missing from <ros2_control>"
+    return {si.get("name") for si in joint.findall("state_interface")}
 
 
 def joints_of(ros2_control):
@@ -152,3 +162,14 @@ def test_gripper_controller_config_interfaces_exist_under_mock():
     assert (
         claimed <= available
     ), f"controller claims {claimed - available}, which the mock URDF does not declare"
+
+
+@requires_xacro
+@pytest.mark.parametrize("model,joint", MODELS.items())
+def test_only_real_hardware_declares_the_status_block_interfaces(model, joint):
+    real = state_interfaces_of(expand(model, use_fake_hardware=False), joint)
+    mock = state_interfaces_of(expand(model, use_fake_hardware=True), joint)
+
+    assert HARDWARE_ONLY_STATE_INTERFACES <= real
+    assert HARDWARE_ONLY_STATE_INTERFACES.isdisjoint(mock)
+    assert real - HARDWARE_ONLY_STATE_INTERFACES == mock == {"position", "velocity"}

--- a/grippers/robotiq_description/urdf/2f_140.ros2_control.xacro
+++ b/grippers/robotiq_description/urdf/2f_140.ros2_control.xacro
@@ -57,6 +57,13 @@
                     <param name="initial_value">${gripper_closed_position}</param>
                 </state_interface>
                 <state_interface name="velocity"/>
+                <!-- Fed from the status block the driver already exchanges:
+                     effort from gCU (a motor-current proxy, on the same full
+                     scale as the force command), object_status from gOBJ
+                     (0 moving, 1 held while opening, 2 held while closing,
+                     3 at the requested position). -->
+                <state_interface name="effort"/>
+                <state_interface name="object_status"/>
             </joint>
             <!-- When simulating we need to include the rest of the gripper joints -->
             <xacro:if value="${sim_isaac or sim_gazebo}">

--- a/grippers/robotiq_description/urdf/2f_140.ros2_control.xacro
+++ b/grippers/robotiq_description/urdf/2f_140.ros2_control.xacro
@@ -57,13 +57,10 @@
                     <param name="initial_value">${gripper_closed_position}</param>
                 </state_interface>
                 <state_interface name="velocity"/>
-                <!-- Fed from the status block the driver already exchanges:
-                     effort from gCU (a motor-current proxy, on the same full
-                     scale as the force command), object_status from gOBJ
-                     (0 moving, 1 held while opening, 2 held while closing,
-                     3 at the requested position). -->
-                <state_interface name="effort"/>
-                <state_interface name="object_status"/>
+                <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_isaac}">
+                    <state_interface name="motor_current"/>
+                    <state_interface name="object_status"/>
+                </xacro:unless>
             </joint>
             <!-- When simulating we need to include the rest of the gripper joints -->
             <xacro:if value="${sim_isaac or sim_gazebo}">

--- a/grippers/robotiq_description/urdf/2f_85.ros2_control.xacro
+++ b/grippers/robotiq_description/urdf/2f_85.ros2_control.xacro
@@ -69,13 +69,10 @@
                     <param name="initial_value">${gripper_closed_position}</param>
                 </state_interface>
                 <state_interface name="velocity"/>
-                <!-- Fed from the status block the driver already exchanges:
-                     effort from gCU (a motor-current proxy, on the same full
-                     scale as the force command), object_status from gOBJ
-                     (0 moving, 1 held while opening, 2 held while closing,
-                     3 at the requested position). -->
-                <state_interface name="effort"/>
-                <state_interface name="object_status"/>
+                <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_isaac}">
+                    <state_interface name="motor_current"/>
+                    <state_interface name="object_status"/>
+                </xacro:unless>
             </joint>
             <!-- When simulating we need to include the rest of the gripper joints -->
             <xacro:if value="${sim_isaac or sim_gazebo}">

--- a/grippers/robotiq_description/urdf/2f_85.ros2_control.xacro
+++ b/grippers/robotiq_description/urdf/2f_85.ros2_control.xacro
@@ -69,6 +69,13 @@
                     <param name="initial_value">${gripper_closed_position}</param>
                 </state_interface>
                 <state_interface name="velocity"/>
+                <!-- Fed from the status block the driver already exchanges:
+                     effort from gCU (a motor-current proxy, on the same full
+                     scale as the force command), object_status from gOBJ
+                     (0 moving, 1 held while opening, 2 held while closing,
+                     3 at the requested position). -->
+                <state_interface name="effort"/>
+                <state_interface name="object_status"/>
             </joint>
             <!-- When simulating we need to include the rest of the gripper joints -->
             <xacro:if value="${sim_isaac or sim_gazebo}">

--- a/grippers/robotiq_driver/include/robotiq_driver/gripper_scaling.hpp
+++ b/grippers/robotiq_driver/include/robotiq_driver/gripper_scaling.hpp
@@ -92,4 +92,11 @@ inline constexpr uint8_t kGripperRange = kGripperMaxPos - kGripperMinPos;
    }
    return static_cast<uint8_t>(std::min(value / maximum, 1.0) * 0xFF);
 }
+
+//! The inverse: a 0x00..0xFF register read back as the fraction of \p maximum
+//! it stands for.
+[[nodiscard]] inline double fractionOfFromRegister(uint8_t register_value, double maximum)
+{
+   return maximum * register_value / 0xFF;
+}
 } // namespace robotiq_driver

--- a/grippers/robotiq_driver/include/robotiq_driver/gripper_scaling.hpp
+++ b/grippers/robotiq_driver/include/robotiq_driver/gripper_scaling.hpp
@@ -93,10 +93,10 @@ inline constexpr uint8_t kGripperRange = kGripperMaxPos - kGripperMinPos;
    return static_cast<uint8_t>(std::min(value / maximum, 1.0) * 0xFF);
 }
 
-//! The inverse: a 0x00..0xFF register read back as the fraction of \p maximum
-//! it stands for.
-[[nodiscard]] inline double fractionOfFromRegister(uint8_t register_value, double maximum)
+inline constexpr double kAmperesPerCurrentCount = 0.010;
+
+[[nodiscard]] inline constexpr double motorCurrentFromRegister(uint8_t register_value)
 {
-   return maximum * register_value / 0xFF;
+   return kAmperesPerCurrentCount * register_value;
 }
 } // namespace robotiq_driver

--- a/grippers/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
+++ b/grippers/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
@@ -58,10 +58,9 @@
 #include <rclcpp/rclcpp.hpp>
 
 namespace robotiq_driver {
-//! Name of the state interface carrying gOBJ. ros2_control defines HW_IF_
-//! constants for position, velocity and effort but has nothing for object
-//! detection, so the URDF and every consumer spell this one out.
+
 inline constexpr const char* kObjectStatusInterface = "object_status";
+inline constexpr const char* kMotorCurrentInterface = "motor_current";
 
 //! ros2_control hardware interface for a Robotiq 2F gripper, driven through the
 //! gripper SDK.
@@ -119,8 +118,8 @@ public:
    CallbackReturn on_error(const rclcpp_lifecycle::State& previous_state) override;
 
    /**
-    * This method exposes position, velocity, effort and object status of joints
-    * for reading.
+    * This method exposes position, velocity, motor current and object status of
+    * joints for reading.
     */
    ROBOTIQ_DRIVER_PUBLIC
    std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
@@ -186,16 +185,13 @@ protected:
    double gripper_position_ = 0.0;
    double gripper_velocity_ = 0.0;
 
-   // gCU read back through the same full-scale force the rFR command uses, so
-   // the effort reported and the effort requested are on one scale. It is a
-   // motor-current proxy either way, not a measurement of the grip.
-   double gripper_effort_ = 0.0;
-
-   // gOBJ as it comes off the wire: 0 moving, 1 held while opening, 2 held
-   // while closing, 3 at the requested position. A double to match the other
-   // three interfaces: Jazzy can carry a uint8_t, but only through the
+   // gCU in amperes, and gOBJ verbatim. Doubles to match the other
+   // interfaces: Jazzy can carry a uint8_t, but only through the
    // description-driven StateInterface constructor, and Humble cannot at all.
-   double gripper_object_status_ = 0.0;
+   //
+   // NaN before the first reading, because every value in range is a real one.
+   double gripper_motor_current_ = std::numeric_limits<double>::quiet_NaN();
+   double gripper_object_status_ = std::numeric_limits<double>::quiet_NaN();
 
    double gripper_position_command_ = 0.0;
 

--- a/grippers/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
+++ b/grippers/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
@@ -58,6 +58,11 @@
 #include <rclcpp/rclcpp.hpp>
 
 namespace robotiq_driver {
+//! Name of the state interface carrying gOBJ. ros2_control defines HW_IF_
+//! constants for position, velocity and effort but has nothing for object
+//! detection, so the URDF and every consumer spell this one out.
+inline constexpr const char* kObjectStatusInterface = "object_status";
+
 //! ros2_control hardware interface for a Robotiq 2F gripper, driven through the
 //! gripper SDK.
 //! Member order carries an invariant: recovery_ is declared after gripper_ so
@@ -114,7 +119,8 @@ public:
    CallbackReturn on_error(const rclcpp_lifecycle::State& previous_state) override;
 
    /**
-    * This method exposes position and velocity of joints for reading.
+    * This method exposes position, velocity, effort and object status of joints
+    * for reading.
     */
    ROBOTIQ_DRIVER_PUBLIC
    std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
@@ -179,6 +185,18 @@ protected:
 
    double gripper_position_ = 0.0;
    double gripper_velocity_ = 0.0;
+
+   // gCU read back through the same full-scale force the rFR command uses, so
+   // the effort reported and the effort requested are on one scale. It is a
+   // motor-current proxy either way, not a measurement of the grip.
+   double gripper_effort_ = 0.0;
+
+   // gOBJ as it comes off the wire: 0 moving, 1 held while opening, 2 held
+   // while closing, 3 at the requested position. A double to match the other
+   // three interfaces: Jazzy can carry a uint8_t, but only through the
+   // description-driven StateInterface constructor, and Humble cannot at all.
+   double gripper_object_status_ = 0.0;
+
    double gripper_position_command_ = 0.0;
 
    // The last command write() sent. A register the arithmetic cannot produce

--- a/grippers/robotiq_driver/src/hardware_interface.cpp
+++ b/grippers/robotiq_driver/src/hardware_interface.cpp
@@ -89,17 +89,15 @@ const char* toString(Robotiq::ConnectionState state)
    return "Unknown";
 }
 
-// export_state_interfaces() exports position, velocity, effort and object status
-// whatever the description says, so this only checks that the description names
-// no fifth one the hardware cannot answer for. Declaring fewer is fine.
+// export_state_interfaces() exports all four whatever the description says, so
+// the names below are the whole contract: nothing here gates what appears.
 bool declaresOnlySupportedStateInterfaces(const hardware_interface::ComponentInfo& joint)
 {
    for(const hardware_interface::InterfaceInfo& state_interface : joint.state_interfaces)
    {
       if(!(state_interface.name == hardware_interface::HW_IF_POSITION
            || state_interface.name == hardware_interface::HW_IF_VELOCITY
-           || state_interface.name == hardware_interface::HW_IF_EFFORT
-           || state_interface.name == kObjectStatusInterface))
+           || state_interface.name == kMotorCurrentInterface || state_interface.name == kObjectStatusInterface))
       {
          RCLCPP_FATAL(kLogger,
                       "Joint '%s' has %s state interface. Expected %s, %s, %s or %s.",
@@ -107,7 +105,7 @@ bool declaresOnlySupportedStateInterfaces(const hardware_interface::ComponentInf
                       state_interface.name.c_str(),
                       hardware_interface::HW_IF_POSITION,
                       hardware_interface::HW_IF_VELOCITY,
-                      hardware_interface::HW_IF_EFFORT,
+                      kMotorCurrentInterface,
                       kObjectStatusInterface);
          return false;
       }
@@ -162,6 +160,8 @@ hardware_interface::CallbackReturn RobotiqGripperHardwareInterface::on_init(cons
 
    gripper_position_ = std::numeric_limits<double>::quiet_NaN();
    gripper_velocity_ = std::numeric_limits<double>::quiet_NaN();
+   gripper_motor_current_ = std::numeric_limits<double>::quiet_NaN();
+   gripper_object_status_ = std::numeric_limits<double>::quiet_NaN();
    gripper_position_command_ = std::numeric_limits<double>::quiet_NaN();
    reactivate_gripper_cmd_ = NO_NEW_CMD_;
 
@@ -265,7 +265,7 @@ std::vector<hardware_interface::StateInterface> RobotiqGripperHardwareInterface:
    state_interfaces.emplace_back(
       hardware_interface::StateInterface(info_.joints[0].name, hardware_interface::HW_IF_VELOCITY, &gripper_velocity_));
    state_interfaces.emplace_back(
-      hardware_interface::StateInterface(info_.joints[0].name, hardware_interface::HW_IF_EFFORT, &gripper_effort_));
+      hardware_interface::StateInterface(info_.joints[0].name, kMotorCurrentInterface, &gripper_motor_current_));
    state_interfaces.emplace_back(
       hardware_interface::StateInterface(info_.joints[0].name, kObjectStatusInterface, &gripper_object_status_));
 
@@ -375,6 +375,8 @@ hardware_interface::CallbackReturn RobotiqGripperHardwareInterface::on_activate(
    // any hold target derived from it, describe where the fingers actually are.
    gripper_position_ = jointPositionFromRegister(status.position, parameters_.closed_position);
    gripper_velocity_ = 0.0;
+   gripper_motor_current_ = motorCurrentFromRegister(status.current);
+   gripper_object_status_ = static_cast<double>(status.gripperStatus.objectDetection());
    gripper_position_command_ = gripper_position_;
 
    RCLCPP_INFO(kLogger, "Robotiq Gripper successfully activated!");
@@ -428,8 +430,8 @@ hardware_interface::return_type RobotiqGripperHardwareInterface::read(const rclc
    // The status block carries no velocity — the gripper reports position and
    // motor current only.
    gripper_velocity_ = 0.0;
-   gripper_effort_ = fractionOfFromRegister(status.current, parameters_.max_force);
-   gripper_object_status_ = static_cast<uint8_t>(status.gripperStatus.objectDetection());
+   gripper_motor_current_ = motorCurrentFromRegister(status.current);
+   gripper_object_status_ = static_cast<double>(status.gripperStatus.objectDetection());
 
    // A faulted link recovers by itself on the next successful exchange, so
    // this warns rather than errors; the position above is the last good

--- a/grippers/robotiq_driver/src/hardware_interface.cpp
+++ b/grippers/robotiq_driver/src/hardware_interface.cpp
@@ -89,6 +89,32 @@ const char* toString(Robotiq::ConnectionState state)
    return "Unknown";
 }
 
+// export_state_interfaces() exports position, velocity, effort and object status
+// whatever the description says, so this only checks that the description names
+// no fifth one the hardware cannot answer for. Declaring fewer is fine.
+bool declaresOnlySupportedStateInterfaces(const hardware_interface::ComponentInfo& joint)
+{
+   for(const hardware_interface::InterfaceInfo& state_interface : joint.state_interfaces)
+   {
+      if(!(state_interface.name == hardware_interface::HW_IF_POSITION
+           || state_interface.name == hardware_interface::HW_IF_VELOCITY
+           || state_interface.name == hardware_interface::HW_IF_EFFORT
+           || state_interface.name == kObjectStatusInterface))
+      {
+         RCLCPP_FATAL(kLogger,
+                      "Joint '%s' has %s state interface. Expected %s, %s, %s or %s.",
+                      joint.name.c_str(),
+                      state_interface.name.c_str(),
+                      hardware_interface::HW_IF_POSITION,
+                      hardware_interface::HW_IF_VELOCITY,
+                      hardware_interface::HW_IF_EFFORT,
+                      kObjectStatusInterface);
+         return false;
+      }
+   }
+   return true;
+}
+
 // A recovery future stays valid from launch until read() consumes its result,
 // so `valid()` alone answers "is a recovery outstanding"; this answers the
 // narrower "has it finished".
@@ -161,29 +187,9 @@ hardware_interface::CallbackReturn RobotiqGripperHardwareInterface::on_init(cons
       return CallbackReturn::ERROR;
    }
 
-   // There are two state interfaces: position and velocity.
-   if(joint.state_interfaces.size() != 2)
+   if(!declaresOnlySupportedStateInterfaces(joint))
    {
-      RCLCPP_FATAL(kLogger,
-                   "Joint '%s' has %zu state interface. 2 expected.",
-                   joint.name.c_str(),
-                   joint.state_interfaces.size());
       return CallbackReturn::ERROR;
-   }
-
-   for(int i = 0; i < 2; ++i)
-   {
-      if(!(joint.state_interfaces[i].name == hardware_interface::HW_IF_POSITION
-           || joint.state_interfaces[i].name == hardware_interface::HW_IF_VELOCITY))
-      {
-         RCLCPP_FATAL(kLogger,
-                      "Joint '%s' has %s state interface. Expected %s or %s.",
-                      joint.name.c_str(),
-                      joint.state_interfaces.at(i).name.c_str(),
-                      hardware_interface::HW_IF_POSITION,
-                      hardware_interface::HW_IF_VELOCITY);
-         return CallbackReturn::ERROR;
-      }
    }
 
    return CallbackReturn::SUCCESS;
@@ -258,6 +264,10 @@ std::vector<hardware_interface::StateInterface> RobotiqGripperHardwareInterface:
       hardware_interface::StateInterface(info_.joints[0].name, hardware_interface::HW_IF_POSITION, &gripper_position_));
    state_interfaces.emplace_back(
       hardware_interface::StateInterface(info_.joints[0].name, hardware_interface::HW_IF_VELOCITY, &gripper_velocity_));
+   state_interfaces.emplace_back(
+      hardware_interface::StateInterface(info_.joints[0].name, hardware_interface::HW_IF_EFFORT, &gripper_effort_));
+   state_interfaces.emplace_back(
+      hardware_interface::StateInterface(info_.joints[0].name, kObjectStatusInterface, &gripper_object_status_));
 
    return state_interfaces;
 }
@@ -418,6 +428,8 @@ hardware_interface::return_type RobotiqGripperHardwareInterface::read(const rclc
    // The status block carries no velocity — the gripper reports position and
    // motor current only.
    gripper_velocity_ = 0.0;
+   gripper_effort_ = fractionOfFromRegister(status.current, parameters_.max_force);
+   gripper_object_status_ = static_cast<uint8_t>(status.gripperStatus.objectDetection());
 
    // A faulted link recovers by itself on the next successful exchange, so
    // this warns rather than errors; the position above is the last good

--- a/grippers/robotiq_driver/src/hardware_parameters.cpp
+++ b/grippers/robotiq_driver/src/hardware_parameters.cpp
@@ -94,6 +94,17 @@ double asDouble(const std::string& text)
 {
    return std::stod(text);
 }
+
+//! For a scale the register arithmetic divides by.
+double asPositiveDouble(const std::string& text)
+{
+   const double value = std::stod(text);
+   if(!std::isfinite(value) || value <= 0.0)
+   {
+      throw std::invalid_argument("expected a finite value above zero");
+   }
+   return value;
+}
 } // namespace
 
 GripperParameters parseParameters(const hardware_interface::HardwareInfo& info, const rclcpp::Logger& logger)
@@ -138,8 +149,8 @@ GripperParameters parseParameters(const hardware_interface::HardwareInfo& info, 
       throw std::invalid_argument("gripper_closed_position must be a non-zero, finite joint value");
    }
 
-   parameters.max_speed = parameterOr<double>(info, logger, kMaxSpeedParam, parameters.max_speed, asDouble);
-   parameters.max_force = parameterOr<double>(info, logger, kMaxForceParam, parameters.max_force, asDouble);
+   parameters.max_speed = parameterOr<double>(info, logger, kMaxSpeedParam, parameters.max_speed, asPositiveDouble);
+   parameters.max_force = parameterOr<double>(info, logger, kMaxForceParam, parameters.max_force, asPositiveDouble);
    parameters.speed_multiplier =
       parameterOr<double>(info, logger, kSpeedMultiplierParam, parameters.speed_multiplier, asDouble);
    parameters.force_multiplier =

--- a/grippers/robotiq_driver/tests/test_gripper_scaling.cpp
+++ b/grippers/robotiq_driver/tests/test_gripper_scaling.cpp
@@ -31,6 +31,7 @@
 
 #include <limits>
 #include <optional>
+#include <type_traits>
 
 #include <robotiq_driver/gripper_scaling.hpp>
 
@@ -134,11 +135,19 @@ TEST(GripperScaling, whenTheMaximumIsNearZero_theRegisterIsTheMaxAllowedValue)
    EXPECT_EQ(255, registerFromFractionOf(0.15, std::numeric_limits<double>::denorm_min()));
 }
 
-TEST(GripperScaling, ReadingAFractionBackSpansTheWholeScale)
+TEST(GripperScaling, MotorCurrentIsTenMilliampsPerCount)
 {
-   constexpr double kMaxForce = 235.0;
-   EXPECT_DOUBLE_EQ(0.0, fractionOfFromRegister(0, kMaxForce));
-   EXPECT_DOUBLE_EQ(kMaxForce, fractionOfFromRegister(255, kMaxForce));
-   EXPECT_DOUBLE_EQ(kMaxForce * 127 / 255, fractionOfFromRegister(127, kMaxForce));
+   EXPECT_DOUBLE_EQ(0.0, motorCurrentFromRegister(0));
+   EXPECT_DOUBLE_EQ(0.01, motorCurrentFromRegister(1));
+   EXPECT_DOUBLE_EQ(1.27, motorCurrentFromRegister(127));
+   EXPECT_DOUBLE_EQ(2.55, motorCurrentFromRegister(255));
+}
+
+TEST(GripperScaling, MotorCurrentTakesNoScaleFromTheDescription)
+{
+   // Scaling gCU by a description parameter would make one motor current read
+   // as two numbers on two robots.
+   static_assert(std::is_invocable_r_v<double, decltype(motorCurrentFromRegister), uint8_t>);
+   EXPECT_DOUBLE_EQ(1.0, motorCurrentFromRegister(100));
 }
 } // namespace robotiq_driver::test

--- a/grippers/robotiq_driver/tests/test_gripper_scaling.cpp
+++ b/grippers/robotiq_driver/tests/test_gripper_scaling.cpp
@@ -133,4 +133,12 @@ TEST(GripperScaling, whenTheMaximumIsNearZero_theRegisterIsTheMaxAllowedValue)
 {
    EXPECT_EQ(255, registerFromFractionOf(0.15, std::numeric_limits<double>::denorm_min()));
 }
+
+TEST(GripperScaling, ReadingAFractionBackSpansTheWholeScale)
+{
+   constexpr double kMaxForce = 235.0;
+   EXPECT_DOUBLE_EQ(0.0, fractionOfFromRegister(0, kMaxForce));
+   EXPECT_DOUBLE_EQ(kMaxForce, fractionOfFromRegister(255, kMaxForce));
+   EXPECT_DOUBLE_EQ(kMaxForce * 127 / 255, fractionOfFromRegister(127, kMaxForce));
+}
 } // namespace robotiq_driver::test

--- a/grippers/robotiq_driver/tests/test_hardware_parameters.cpp
+++ b/grippers/robotiq_driver/tests/test_hardware_parameters.cpp
@@ -153,6 +153,20 @@ TEST(HardwareParameters, AMalformedParameterFallsBackToItsDefault)
    EXPECT_DOUBLE_EQ(kMaxForceDefault, parameters.max_force);
 }
 
+TEST(HardwareParameters, AnUnusableScaleFallsBackToItsDefault)
+{
+   // Both are divisors of the register arithmetic, so a bad value is caught
+   // here rather than at each use.
+   for(const char* unusable : {"0", "-1", "-235", "nan", "-inf"})
+   {
+      const GripperParameters parameters =
+         parseParameters(info_with({{"gripper_max_force", unusable}, {"gripper_max_speed", unusable}}), logger());
+
+      EXPECT_DOUBLE_EQ(kMaxForceDefault, parameters.max_force) << "gripper_max_force '" << unusable << "'";
+      EXPECT_DOUBLE_EQ(kMaxSpeedDefault, parameters.max_speed) << "gripper_max_speed '" << unusable << "'";
+   }
+}
+
 TEST(HardwareParameters, AMissingClosedPositionIsFatal)
 {
    // Unlike every other parameter this one has no defensible default: a

--- a/grippers/robotiq_driver/tests/test_robotiq_gripper_hardware_interface.cpp
+++ b/grippers/robotiq_driver/tests/test_robotiq_gripper_hardware_interface.cpp
@@ -36,6 +36,7 @@
 #include <limits>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include <hardware_interface/resource_manager.hpp>
 #include <hardware_interface/types/lifecycle_state_names.hpp>
@@ -92,7 +93,7 @@ std::string minimalRobotUrdf(const std::string& extra_hardware_params = "")
                 <param name="initial_value">0.7929</param>
               </state_interface>
               <state_interface name="velocity"/>
-              <state_interface name="effort"/>
+              <state_interface name="motor_current"/>
               <state_interface name="object_status"/>
             </joint>
             <gpio name="reactivate_gripper">
@@ -154,9 +155,8 @@ TEST(TestRobotiqGripperHardwareInterface, ExportsExpectedCommandInterfaces)
 }
 
 /**
- * A grasping client reads object_status to tell a caught part from a missed one
- * and effort to judge the grip, both by name. object_status in particular is not
- * a ros2_control standard interface, so nothing but this test pins its spelling.
+ * Neither motor_current nor object_status is a ros2_control standard interface,
+ * so nothing but this test pins their spelling.
  */
 TEST(TestRobotiqGripperHardwareInterface, ExportsExpectedStateInterfaces)
 {
@@ -170,12 +170,42 @@ TEST(TestRobotiqGripperHardwareInterface, ExportsExpectedStateInterfaces)
    hardware_interface::ResourceManager rm(urdf);
 #endif
 
-   const auto keys = rm.state_interface_keys();
-   EXPECT_THAT(keys,
-               testing::IsSupersetOf({"robotiq_85_left_knuckle_joint/position",
-                                      "robotiq_85_left_knuckle_joint/velocity",
-                                      "robotiq_85_left_knuckle_joint/effort",
-                                      "robotiq_85_left_knuckle_joint/object_status"}));
+   std::vector<std::string> joint_keys;
+   for(const std::string& key : rm.state_interface_keys())
+   {
+      if(key.rfind("robotiq_85_left_knuckle_joint/", 0) == 0)
+      {
+         joint_keys.push_back(key);
+      }
+   }
+
+   EXPECT_THAT(joint_keys,
+               testing::UnorderedElementsAre("robotiq_85_left_knuckle_joint/position",
+                                             "robotiq_85_left_knuckle_joint/velocity",
+                                             "robotiq_85_left_knuckle_joint/motor_current",
+                                             "robotiq_85_left_knuckle_joint/object_status"));
+}
+
+TEST(TestRobotiqGripperHardwareInterface, ExportsEveryStateInterfaceWhateverTheDescriptionDeclares)
+{
+   std::string urdf = minimalRobotUrdf();
+   const std::string declared = R"(              <state_interface name="motor_current"/>
+              <state_interface name="object_status"/>
+)";
+   ASSERT_NE(std::string::npos, urdf.find(declared));
+   urdf.erase(urdf.find(declared), declared.size());
+
+   rclcpp::Node node{"test_robotiq_gripper_hardware_interface"};
+
+#if HARDWARE_INTERFACE_VERSION_GTE(4, 13, 0)
+   hardware_interface::ResourceManager rm(urdf, node.get_node_clock_interface(), node.get_node_logging_interface());
+#else
+   hardware_interface::ResourceManager rm(urdf);
+#endif
+
+   EXPECT_THAT(rm.state_interface_keys(),
+               testing::IsSupersetOf(
+                  {"robotiq_85_left_knuckle_joint/motor_current", "robotiq_85_left_knuckle_joint/object_status"}));
 }
 
 /**

--- a/grippers/robotiq_driver/tests/test_robotiq_gripper_hardware_interface.cpp
+++ b/grippers/robotiq_driver/tests/test_robotiq_gripper_hardware_interface.cpp
@@ -92,6 +92,8 @@ std::string minimalRobotUrdf(const std::string& extra_hardware_params = "")
                 <param name="initial_value">0.7929</param>
               </state_interface>
               <state_interface name="velocity"/>
+              <state_interface name="effort"/>
+              <state_interface name="object_status"/>
             </joint>
             <gpio name="reactivate_gripper">
               <command_interface name="reactivate_gripper_cmd" />
@@ -149,6 +151,31 @@ TEST(TestRobotiqGripperHardwareInterface, ExportsExpectedCommandInterfaces)
                                       "robotiq_85_left_knuckle_joint/set_gripper_max_effort",
                                       "reactivate_gripper/reactivate_gripper_cmd",
                                       "reactivate_gripper/reactivate_gripper_response"}));
+}
+
+/**
+ * A grasping client reads object_status to tell a caught part from a missed one
+ * and effort to judge the grip, both by name. object_status in particular is not
+ * a ros2_control standard interface, so nothing but this test pins its spelling.
+ */
+TEST(TestRobotiqGripperHardwareInterface, ExportsExpectedStateInterfaces)
+{
+   const std::string urdf = minimalRobotUrdf();
+
+   rclcpp::Node node{"test_robotiq_gripper_hardware_interface"};
+
+#if HARDWARE_INTERFACE_VERSION_GTE(4, 13, 0)
+   hardware_interface::ResourceManager rm(urdf, node.get_node_clock_interface(), node.get_node_logging_interface());
+#else
+   hardware_interface::ResourceManager rm(urdf);
+#endif
+
+   const auto keys = rm.state_interface_keys();
+   EXPECT_THAT(keys,
+               testing::IsSupersetOf({"robotiq_85_left_knuckle_joint/position",
+                                      "robotiq_85_left_knuckle_joint/velocity",
+                                      "robotiq_85_left_knuckle_joint/effort",
+                                      "robotiq_85_left_knuckle_joint/object_status"}));
 }
 
 /**


### PR DESCRIPTION
Closes #26.

The hardware interface exported position and velocity only, so nothing downstream could tell a caught part from a missed one, or judge a grip. Both values already arrive in the status block the SDK exchanges every cycle.

Export effort from gCU and object_status from gOBJ. Effort is read back through the same full scale the rFR command is written against, so the effort reported and the effort requested share a scale; it stays a motor-current proxy, not a measurement of the grip. object_status carries gOBJ unchanged — 0 moving, 1 held while opening, 2 held while closing, 3 at the requested position — since a remapping would only cost consumers the manual's vocabulary.

on_init no longer demands exactly two state interfaces. A description may now declare any of the four, and is rejected only for naming a fifth the hardware cannot answer for.

Measured on a 2F-85 over a reactivation sweep: object_status ran 3 -> 0 -> 3, effort ran 0 to 92.16 N in steps of 0.9216 N, which is the 235 N full scale over the 255 counts of the register.

## Verification

- 40 `robotiq_driver` tests pass, including three new ones: two on the register/SI round trip and one pinning the exported state-interface names.
- Fake-hardware bringup (`use_fake_hardware:=true`) still activates all three controllers with the two new interfaces declared.
- On a real 2F-85, `ros2 control list_hardware_interfaces` reports `effort` and `object_status`, and both carry live values on `/dynamic_joint_states`.
