### PR TITLE
Issue 35/baudrate launch arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ ros2 action send_goal /robotiq_gripper_controller/gripper_cmd \
 
 #### What you gain
 
-- `use_fake_hardware` launch arg on `robotiq_control.launch.py` (hardware-free bringup, previously hardcoded off)
+- `use_fake_hardware` and `baudrate` launch args on `robotiq_control.launch.py` (hardware-free bringup, previously hardcoded off; a custom baudrate, previously an edit to the xacro)
 - Actionable error messages when the gripper does not respond (24 V power, RS-485 wiring, `slave_address` / `baudrate` hints)
 - A unified Docker image with device mapping ([Docker](#docker))
 - Active maintenance — PickNik's in-tree README and CI were removed; docs live in this README, and issues go to [robotiq/ros/issues](https://github.com/robotiq/ros/issues)
@@ -252,6 +252,7 @@ Bring up a gripper:
 ros2 launch robotiq_description robotiq_control.launch.py                    # real hw, com_port:=/dev/ttyUSB0
 ros2 launch robotiq_description robotiq_control.launch.py use_fake_hardware:=true   # ros2_control mock
 ros2 launch robotiq_description robotiq_control.launch.py launch_rviz:=true         # + RViz visualization
+ros2 launch robotiq_description robotiq_control.launch.py baudrate:=<rate>
 ```
 
 This activates `joint_state_broadcaster`, `robotiq_gripper_controller`, and `robotiq_activation_controller`.
@@ -304,7 +305,7 @@ All four read `NaN` until the component is activated; activation seeds them from
 |---|---|---|
 | `gripper_closed_position` | *required* | Joint angle in radians at a fully closed gripper — the scale of the whole position mapping |
 | `COM_port` | `/dev/ttyUSB0` | Serial port |
-| `baudrate` | `115200` | Must match the gripper's persisted setting |
+| `baudrate` | `115200` | Must match the gripper's persisted setting, which is why it is also a launch argument, `baudrate:=<rate>`. Rejected outside 1..1000000. Most units stay at 115200; the gripper's own rate is changed in the Robotiq User Interface (*Modbus RTU Parameters*), not from here, and the gripper must be rebooted afterwards |
 | `timeout` | `0.5` | Per-transaction serial timeout, in seconds |
 | `slave_address` | `0x09` | Modbus slave address; `0x09` as the manual prints it, a bare number as the decimal it looks like |
 | `connection_frequency` | `100` | Rate of the SDK's background exchange cycle, in Hz; `0` free-runs |

--- a/grippers/robotiq_description/launch/robotiq_control.launch.py
+++ b/grippers/robotiq_description/launch/robotiq_control.launch.py
@@ -88,6 +88,13 @@ def generate_launch_description():
     )
     args.append(
         launch.actions.DeclareLaunchArgument(
+            name="baudrate",
+            default_value="115200",
+            description="Modbus RTU baudrate the gripper is configured for",
+        )
+    )
+    args.append(
+        launch.actions.DeclareLaunchArgument(
             name="use_fake_hardware",
             default_value="false",
             description="Use ros2_control mock (fake) hardware instead of a real gripper",
@@ -105,6 +112,9 @@ def generate_launch_description():
             " ",
             "com_port:=",
             LaunchConfiguration("com_port"),
+            " ",
+            "baudrate:=",
+            LaunchConfiguration("baudrate"),
         ]
     )
 

--- a/grippers/robotiq_description/test/test_ros2_control_urdf.py
+++ b/grippers/robotiq_description/test/test_ros2_control_urdf.py
@@ -72,13 +72,14 @@ requires_xacro = pytest.mark.skipif(
 )
 
 
-def expand(model, use_fake_hardware):
+def expand(model, use_fake_hardware, *extra_args):
     """Run xacro on `model` and return the parsed <ros2_control> element."""
     result = subprocess.run(
         [
             "xacro",
             str(URDF_DIR / model),
             f"use_fake_hardware:={str(use_fake_hardware).lower()}",
+            *extra_args,
         ],
         capture_output=True,
         text=True,
@@ -91,6 +92,11 @@ def expand(model, use_fake_hardware):
 
 def plugin_of(ros2_control):
     return ros2_control.find("hardware/plugin").text.strip()
+
+
+def hardware_param(ros2_control, name):
+    param = ros2_control.find(f"hardware/param[@name='{name}']")
+    return None if param is None else param.text.strip()
 
 
 def command_interfaces_of(ros2_control, joint_name):
@@ -173,3 +179,16 @@ def test_only_real_hardware_declares_the_status_block_interfaces(model, joint):
     assert HARDWARE_ONLY_STATE_INTERFACES <= real
     assert HARDWARE_ONLY_STATE_INTERFACES.isdisjoint(mock)
     assert real - HARDWARE_ONLY_STATE_INTERFACES == mock == {"position", "velocity"}
+
+
+@requires_xacro
+@pytest.mark.parametrize("model", MODELS)
+def test_baudrate_reaches_the_driver(model):
+    # The launch argument crosses three xacro files to get here, and a half
+    # updated chain fails at runtime with `Invalid parameter "baudrate"` rather
+    # than at expansion.
+    ros2_control = expand(model, False, "baudrate:=57600")
+    assert hardware_param(ros2_control, "baudrate") == "57600"
+
+    assert hardware_param(expand(model, False), "baudrate") == "115200"
+    assert hardware_param(expand(model, True), "baudrate") is None

--- a/grippers/robotiq_description/urdf/2f_140.ros2_control.xacro
+++ b/grippers/robotiq_description/urdf/2f_140.ros2_control.xacro
@@ -11,6 +11,7 @@
         use_fake_hardware:=false
         mock_sensor_commands:=false
         com_port:=/dev/ttyUSB0
+        baudrate:=115200
         gripper_speed_multiplier:=1.0
         gripper_force_multiplier:=0.5
         gripper_max_speed:=0.250
@@ -37,6 +38,7 @@
                     <plugin>robotiq_driver/RobotiqGripperHardwareInterface</plugin>
                     <param name="gripper_closed_position">${gripper_closed_position}</param>
                     <param name="COM_port">${com_port}</param>
+                    <param name="baudrate">${baudrate}</param>
                     <param name="gripper_speed_multiplier">${gripper_speed_multiplier}</param>
                     <param name="gripper_force_multiplier">${gripper_force_multiplier}</param>
                     <param name="gripper_max_speed">${gripper_max_speed}</param>

--- a/grippers/robotiq_description/urdf/2f_85.ros2_control.xacro
+++ b/grippers/robotiq_description/urdf/2f_85.ros2_control.xacro
@@ -11,6 +11,7 @@
         use_fake_hardware:=false
         mock_sensor_commands:=false
         com_port:=/dev/ttyUSB0
+        baudrate:=115200
         gripper_speed_multiplier:=1.0
         gripper_force_multiplier:=0.5
         gripper_max_speed:=0.150
@@ -42,6 +43,7 @@
                     <plugin>robotiq_driver/RobotiqGripperHardwareInterface</plugin>
                     <param name="gripper_closed_position">${gripper_closed_position}</param>
                     <param name="COM_port">${com_port}</param>
+                    <param name="baudrate">${baudrate}</param>
                     <param name="gripper_speed_multiplier">${gripper_speed_multiplier}</param>
                     <param name="gripper_force_multiplier">${gripper_force_multiplier}</param>
                     <param name="gripper_max_speed">${gripper_max_speed}</param>

--- a/grippers/robotiq_description/urdf/robotiq_2f_140_gripper.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_140_gripper.urdf.xacro
@@ -3,12 +3,13 @@
     <!-- parameters -->
     <xacro:arg name="use_fake_hardware" default="true" />
     <xacro:arg name="com_port" default="/dev/ttyUSB0" />
+    <xacro:arg name="baudrate" default="115200" />
 
     <!-- Import macros -->
     <xacro:include filename="$(find robotiq_description)/urdf/robotiq_2f_140_macro.urdf.xacro" />
 
     <link name="world" />
-    <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg com_port)">
+    <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg com_port)" baudrate="$(arg baudrate)">
         <origin xyz="0 0 0" rpy="0 0 0" />
     </xacro:robotiq_gripper>
 </robot>

--- a/grippers/robotiq_description/urdf/robotiq_2f_140_macro.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_140_macro.urdf.xacro
@@ -13,6 +13,7 @@
         mock_sensor_commands:=false
         include_ros2_control:=true
         com_port:=/dev/ttyUSB0
+        baudrate:=115200
         gripper_speed_multiplier:=1.0
         gripper_force_multiplier:=0.5
         gripper_max_speed:=0.250
@@ -32,6 +33,7 @@
                 use_fake_hardware="${use_fake_hardware}"
                 mock_sensor_commands="${mock_sensor_commands}"
                 com_port="${com_port}"
+                baudrate="${baudrate}"
                 gripper_speed_multiplier="${gripper_speed_multiplier}"
                 gripper_force_multiplier="${gripper_force_multiplier}"
                 gripper_max_speed="${gripper_max_speed}"

--- a/grippers/robotiq_description/urdf/robotiq_2f_85_gripper.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_85_gripper.urdf.xacro
@@ -3,12 +3,13 @@
     <!-- parameters -->
     <xacro:arg name="use_fake_hardware" default="true" />
     <xacro:arg name="com_port" default="/dev/ttyUSB0" />
+    <xacro:arg name="baudrate" default="115200" />
 
     <!-- Import macros -->
     <xacro:include filename="$(find robotiq_description)/urdf/robotiq_2f_85_macro.urdf.xacro" />
 
     <link name="world" />
-    <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg com_port)">
+    <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg com_port)" baudrate="$(arg baudrate)">
         <origin xyz="0 0 0" rpy="0 0 0" />
     </xacro:robotiq_gripper>
 </robot>

--- a/grippers/robotiq_description/urdf/robotiq_2f_85_macro.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_85_macro.urdf.xacro
@@ -13,6 +13,7 @@
         mock_sensor_commands:=false
         include_ros2_control:=true
         com_port:=/dev/ttyUSB0
+        baudrate:=115200
         gripper_speed_multiplier:=1.0
         gripper_force_multiplier:=0.5
         gripper_max_speed:=0.150
@@ -33,6 +34,7 @@
                 use_fake_hardware="${use_fake_hardware}"
                 mock_sensor_commands="${mock_sensor_commands}"
                 com_port="${com_port}"
+                baudrate="${baudrate}"
                 gripper_speed_multiplier="${gripper_speed_multiplier}"
                 gripper_force_multiplier="${gripper_force_multiplier}"
                 gripper_max_speed="${gripper_max_speed}"

--- a/grippers/robotiq_driver/src/hardware_interface.cpp
+++ b/grippers/robotiq_driver/src/hardware_interface.cpp
@@ -30,9 +30,12 @@
 #include <chrono>
 #include <cmath>
 #include <future>
+#include <iomanip>
 #include <limits>
 #include <memory>
 #include <optional>
+#include <sstream>
+#include <string>
 #include <vector>
 
 #include <robotiq_driver/gripper_scaling.hpp>
@@ -111,6 +114,18 @@ bool declaresOnlySupportedStateInterfaces(const hardware_interface::ComponentInf
       }
    }
    return true;
+}
+
+// Shared by the two messages that report whether the link came up. A failed
+// connect is almost always one of these three being wrong, and the SDK logs
+// only the port and baud rate, at debug level.
+std::string describeLink(const Robotiq::ConnectionConfig& connection)
+{
+   std::ostringstream text;
+   text << connection.serial.port << " at " << connection.serial.baudrate << " bps (slave address 0x" << std::hex
+        << std::uppercase << std::setw(2) << std::setfill('0') << static_cast<unsigned>(connection.modbusSlaveAddress)
+        << ")";
+   return text.str();
 }
 
 // A recovery future stays valid from launch until read() consumes its result,
@@ -211,15 +226,16 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Roboti
    }
    catch(const std::exception& e)
    {
-      RCLCPP_ERROR(kLogger, "Cannot connect to the Robotiq gripper: %s", e.what());
+      RCLCPP_ERROR(kLogger,
+                   "Cannot connect to the Robotiq gripper on %s: %s",
+                   describeLink(parameters_.connection).c_str(),
+                   e.what());
       return CallbackReturn::ERROR;
    }
 
    RCLCPP_INFO(kLogger,
-               "Connected to the Robotiq gripper on %s at %u bps (slave address 0x%02X), exchanging at %.1f Hz.",
-               parameters_.connection.serial.port.c_str(),
-               parameters_.connection.serial.baudrate,
-               parameters_.connection.modbusSlaveAddress,
+               "Connected to the Robotiq gripper on %s, exchanging at %.1f Hz.",
+               describeLink(parameters_.connection).c_str(),
                parameters_.connection.connectionFrequency);
    return CallbackReturn::SUCCESS;
 }

--- a/grippers/robotiq_driver/src/hardware_parameters.cpp
+++ b/grippers/robotiq_driver/src/hardware_parameters.cpp
@@ -90,6 +90,32 @@ T parameterOr(const hardware_interface::HardwareInfo& info,
    }
 }
 
+//! Parse \p text in \p base, rejecting the trailing characters std::stoull
+//! silently ignores: "115200bps" would otherwise read as 115200 and "1.152e5"
+//! as 1.
+uint64_t asWholeNumber(const std::string& text, int base = 10)
+{
+   std::size_t consumed = 0;
+   const uint64_t value = std::stoull(text, &consumed, base);
+   if(consumed != text.size())
+   {
+      throw std::invalid_argument("expected a whole number");
+   }
+   return value;
+}
+
+//! The range libserialport accepts. Out of it the port still opens and every
+//! exchange then times out, which reads as a dead gripper rather than a typo.
+uint32_t asBaudrate(const std::string& text)
+{
+   const uint64_t value = asWholeNumber(text);
+   if(value == 0 || value > 1000000)
+   {
+      throw std::out_of_range("baudrate must be between 1 and 1000000");
+   }
+   return static_cast<uint32_t>(value);
+}
+
 double asDouble(const std::string& text)
 {
    return std::stod(text);
@@ -116,9 +142,7 @@ GripperParameters parseParameters(const hardware_interface::HardwareInfo& info, 
          return text;
       });
    parameters.connection.serial.baudrate =
-      parameterOr<uint32_t>(info, logger, kBaudrateParam, kBaudrateDefault, [](const std::string& text) {
-         return static_cast<uint32_t>(std::stoul(text));
-      });
+      parameterOr<uint32_t>(info, logger, kBaudrateParam, kBaudrateDefault, asBaudrate);
    // The URDF spells the timeout in seconds; SerialConfig wants milliseconds.
    parameters.connection.serial.timeout =
       parameterOr<std::chrono::milliseconds>(info, logger, kTimeoutParam, kTimeoutDefault, [](const std::string& text) {
@@ -129,7 +153,7 @@ GripperParameters parseParameters(const hardware_interface::HardwareInfo& info, 
    // quietly addressing a different device.
    parameters.connection.modbusSlaveAddress =
       parameterOr<uint8_t>(info, logger, kSlaveAddressParam, kSlaveAddressDefault, [](const std::string& text) {
-         const auto address = std::stoul(text, nullptr, 0);
+         const auto address = asWholeNumber(text, 0);
          if(address > 0xFF)
          {
             throw std::out_of_range("slave_address does not fit in a byte");

--- a/grippers/robotiq_driver/tests/test_hardware_parameters.cpp
+++ b/grippers/robotiq_driver/tests/test_hardware_parameters.cpp
@@ -85,6 +85,26 @@ TEST(HardwareParameters, ReadsTheConnectionParameters)
    EXPECT_DOUBLE_EQ(50.0, parameters.connection.connectionFrequency);
 }
 
+TEST(HardwareParameters, ABaudrateTheSerialPortCannotUseKeepsTheDefault)
+{
+   // Now that a launch argument feeds this, the ways someone writes the rate
+   // wrong matter: std::stoul alone reads "115200bps" as 115200 and "1.152e5"
+   // as 1, and libserialport takes 0 or a wrapped negative without complaint,
+   // leaving a port that opens and then answers nothing.
+   for(const char* unusable : {"115200bps", "1.152e5", "115 200", "0", "-1", "2000000", ""})
+   {
+      EXPECT_EQ(kBaudrateDefault,
+                parseParameters(info_with({{"baudrate", unusable}}), logger()).connection.serial.baudrate)
+         << "baudrate '" << unusable << "'";
+   }
+}
+
+TEST(HardwareParameters, ASlaveAddressWithTrailingCharactersKeepsTheDefault)
+{
+   EXPECT_EQ(kSlaveAddressDefault,
+             parseParameters(info_with({{"slave_address", "0x9 (default)"}}), logger()).connection.modbusSlaveAddress);
+}
+
 TEST(HardwareParameters, AClosedPositionItCannotDivideByIsFatal)
 {
    // on_init turns this into CallbackReturn::ERROR. PickNik accepted it and

--- a/robotiq_tsf/launch/gripper_tactile_viz.launch.py
+++ b/robotiq_tsf/launch/gripper_tactile_viz.launch.py
@@ -73,12 +73,18 @@ def generate_launch_description():
     default_rviz = os.path.join(pkg_tsf, "rviz", "gripper_tactile.rviz")
 
     com_port = LaunchConfiguration("com_port")
+    baudrate = LaunchConfiguration("baudrate")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
     rviz_config = LaunchConfiguration("rviz_config")
 
     args = [
         DeclareLaunchArgument(
             "com_port", default_value="/dev/ttyUSB0", description="Gripper serial port."
+        ),
+        DeclareLaunchArgument(
+            "baudrate",
+            default_value="115200",
+            description="Modbus RTU baudrate the gripper is configured for.",
         ),
         DeclareLaunchArgument(
             "poller",
@@ -141,6 +147,7 @@ def generate_launch_description():
         ),
         launch_arguments={
             "com_port": com_port,
+            "baudrate": baudrate,
             "use_fake_hardware": use_fake_hardware,
             "launch_rviz": "false",
         }.items(),


### PR DESCRIPTION
Closes #35.

The baudrate was reachable only by editing the xacro. It is now a launch argument
on `robotiq_control.launch.py`, threaded through the top-level descriptions, the
gripper macros and the `ros2_control` blocks for both the 2F-85 and the 2F-140.
`gripper_tactile_viz.launch.py` forwards it too, so the tactile path is not stuck
at 115200.

Because the value is now user-facing, the driver validates it. `std::stoul` alone
ignores trailing characters, so `115200bps` parsed as 115200 and `1.152e5` as 1,
and `0` or a wrapped `-1` reached `sp_set_baudrate` unchallenged — each leaving a
port that opens and then answers nothing. Parsing now rejects trailing characters
and bounds the rate, falling back to the default with a log line as the other
malformed parameters do. `slave_address` had the same latent bug and shares the fix.

## Testing

Verified on a 2F-85, reconfiguring the gripper itself between rates:

| gripper | `baudrate:=115200` | `baudrate:=57600` |
|---|---|---|
| 115200 | connects, activates | fails in `on_configure` |
| 57600  | fails in `on_configure` | connects, activates |

A mismatch fails before activation, so a wrong rate cannot move the gripper. New
unit tests cover the rejected spellings; a new xacro test asserts the argument
reaches `<param name="baudrate">`, which is the half-updated-macro regression.
