### PR TITLE
feat(robotiq_description): let the sim_isaac / sim_gazebo plugins activate from the launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,11 @@ In the combined launch the pad frames are TF-mounted on the gripper fingertip li
 ROS 2 `ros2_control` driver for Robotiq 2F adaptive grippers, under [`grippers/`](grippers/).
 
 Descriptions ship for the **2F-85** and the **2F-140**; `robotiq_control.launch.py` defaults to the
-2F-85, so pass `description_file` for a 2F-140. Hardware validation to date is on a 2F-85 — the
-2F-140 description ships untested against hardware.
+2F-85, so pass `model:=$(ros2 pkg prefix robotiq_description)/share/robotiq_description/urdf/robotiq_2f_140_gripper.urdf.xacro`
+for a 2F-140. The controller configs take the driven joint from the `gripper_joint` launch argument,
+which defaults to the 2F-85's `robotiq_85_left_knuckle_joint`, or to `finger_joint` when the model
+path names a 2F-140; set it explicitly for a custom description. Hardware validation to date is on a
+2F-85 — the 2F-140 description ships untested against hardware.
 
 The driver itself is model-agnostic: it needs a serial link and the `gripper_closed_position` of
 whatever is attached. A **Hand-E** therefore works once you supply a URDF for it, but no Hand-E

--- a/README.md
+++ b/README.md
@@ -256,9 +256,24 @@ ros2 launch robotiq_description robotiq_control.launch.py                    # r
 ros2 launch robotiq_description robotiq_control.launch.py use_fake_hardware:=true   # ros2_control mock
 ros2 launch robotiq_description robotiq_control.launch.py launch_rviz:=true         # + RViz visualization
 ros2 launch robotiq_description robotiq_control.launch.py baudrate:=<rate>
+ros2 launch robotiq_description robotiq_control.launch.py sim_gazebo:=true        # gz_ros2_control
+ros2 launch robotiq_description robotiq_control.launch.py sim_isaac:=true \
+  isaac_joint_commands:=/isaac_joint_commands isaac_joint_states:=/isaac_joint_states  # topic_based_ros2_control
 ```
 
 This activates `joint_state_broadcaster`, `robotiq_gripper_controller`, and `robotiq_activation_controller`.
+
+`sim_gazebo` and `sim_isaac` swap the hardware plugin for `gz_ros2_control/GazeboSimSystem` or
+`topic_based_ros2_control/TopicBasedSystem` (any simulator that exchanges `sensor_msgs/JointState`
+on two topics — Isaac Sim is the usual one, hence the argument names). Both plugins export only the
+standard joint interfaces, so the launch loads `config/robotiq_controllers.sim.yaml` for them
+(per-goal `effort`/`velocity` are accepted and ignored; stall detection is tuned for a loop that
+runs over a topic) and skips `robotiq_activation_controller`, whose `reactivate_gripper` GPIO only
+the driver and the mock declare. `TopicBasedSystem` matches joints to the simulator's `JointState`
+**by name**, so the simulator must publish this description's joint names (`robotiq_85_left_knuckle_joint`
+and the five mimic joints, with your `prefix`), or nothing moves. Neither plugin is a dependency of
+this package — install `ros-$ROS_DISTRO-gz-ros2-control` or build
+[topic_based_ros2_control](https://github.com/PickNikRobotics/topic_based_ros2_control) yourself.
 
 ### Commanding the gripper
 

--- a/grippers/robotiq_description/config/robotiq_controllers.humble.yaml
+++ b/grippers/robotiq_description/config/robotiq_controllers.humble.yaml
@@ -27,7 +27,7 @@ controller_manager:
 
 robotiq_gripper_controller:
   ros__parameters:
-    joint: robotiq_85_left_knuckle_joint
+    joint: $(var gripper_joint)
 
     max_effort: 50.0   # TODO tune
 

--- a/grippers/robotiq_description/config/robotiq_controllers.sim.humble.yaml
+++ b/grippers/robotiq_description/config/robotiq_controllers.sim.humble.yaml
@@ -1,0 +1,25 @@
+# Humble controller configuration for the simulated hardware plugins
+# (`sim_isaac:=true` / `sim_gazebo:=true`). Same controller as
+# robotiq_controllers.humble.yaml — Humble's stock
+# position_controllers/GripperActionController, since parallel_gripper_controller
+# only arrived in Jazzy — with the two departures robotiq_controllers.sim.yaml
+# explains: no activation controller (no reactivate GPIO to claim) and stall
+# detection tuned for a plugin fed over a topic.
+controller_manager:
+  ros__parameters:
+    update_rate: 500  # Hz
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+    robotiq_gripper_controller:
+      type: position_controllers/GripperActionController
+
+robotiq_gripper_controller:
+  ros__parameters:
+    joint: $(var gripper_joint)
+
+    max_effort: 50.0
+
+    allow_stalling: true
+    stall_timeout: 0.5
+    stall_velocity_threshold: 0.05
+    goal_tolerance: 0.02

--- a/grippers/robotiq_description/config/robotiq_controllers.sim.yaml
+++ b/grippers/robotiq_description/config/robotiq_controllers.sim.yaml
@@ -1,0 +1,37 @@
+# Controller configuration for the simulated hardware plugins the description
+# can select: `sim_isaac:=true` (topic_based_ros2_control/TopicBasedSystem) and
+# `sim_gazebo:=true` (gz_ros2_control/GazeboSimSystem). Selected by
+# launch/robotiq_control.launch.py whenever either argument is set; see
+# config/robotiq_controllers.yaml for the hardware and mock config it replaces,
+# and robotiq_controllers.sim.humble.yaml for the Humble variant.
+#
+# It differs from robotiq_controllers.yaml only where the simulated plugins
+# export something different from the driver, so the controller can activate:
+#
+# - No `robotiq_activation_controller`. The `reactivate_gripper` GPIO it claims is
+#   declared for the driver and the mock only (2f_85.ros2_control.xacro); under a
+#   simulated plugin there is nothing to reactivate.
+# - No `max_effort_interface` / `max_velocity_interface`. Both plugins expose the
+#   standard position/velocity/effort interfaces only, never the driver's
+#   `set_gripper_max_*`, and a claimed interface that does not exist stops the
+#   controller from activating. Goal effort/velocity are accepted and ignored.
+# - Stall detection tuned for a plugin fed over a topic rather than a serial
+#   link: a goal needs longer than 0.05 s to show up as joint motion, and
+#   simulated joint velocities carry more noise than the driver's.
+controller_manager:
+  ros__parameters:
+    update_rate: 500  # Hz
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+    robotiq_gripper_controller:
+      type: parallel_gripper_action_controller/GripperActionController
+
+robotiq_gripper_controller:
+  ros__parameters:
+    joint: $(var gripper_joint)
+
+    state_interfaces: ["position", "velocity"]
+    allow_stalling: true
+    stall_timeout: 0.5
+    stall_velocity_threshold: 0.05
+    goal_tolerance: 0.02

--- a/grippers/robotiq_description/config/robotiq_controllers.yaml
+++ b/grippers/robotiq_description/config/robotiq_controllers.yaml
@@ -14,14 +14,14 @@ controller_manager:
 
 robotiq_gripper_controller:
   ros__parameters:
-    joint: robotiq_85_left_knuckle_joint
+    joint: $(var gripper_joint)
 
     # Enable effort control (replacement for use_effort_interface)
-    max_effort_interface: "robotiq_85_left_knuckle_joint/set_gripper_max_effort"
+    max_effort_interface: "$(var gripper_joint)/set_gripper_max_effort"
     max_effort: 50.0   # TODO tune
 
     # Enable velocity/speed control (replacement for use_speed_interface)
-    max_velocity_interface: "robotiq_85_left_knuckle_joint/set_gripper_max_velocity"
+    max_velocity_interface: "$(var gripper_joint)/set_gripper_max_velocity"
     max_velocity: 0.5    # TODO tune
 
     # Optional (recommended)

--- a/grippers/robotiq_description/launch/robotiq_control.launch.py
+++ b/grippers/robotiq_description/launch/robotiq_control.launch.py
@@ -35,20 +35,29 @@ from launch.substitutions import (
     PathJoinSubstitution,
     PythonExpression,
 )
-from launch.conditions import IfCondition
+from launch.conditions import IfCondition, UnlessCondition
 import launch_ros
 from launch_ros.parameter_descriptions import ParameterFile
 import os
 
 # Humble has no parallel_gripper_controller package, so it needs its own
-# controller config. See both config/robotiq_controllers*.yaml.
+# controller config, and the simulated plugins (sim_isaac / sim_gazebo) export a
+# different interface set from the driver and the mock, so they need theirs.
+# See config/robotiq_controllers*.yaml.
 JAZZY_CONTROLLERS_FILE = "robotiq_controllers.yaml"
 HUMBLE_CONTROLLERS_FILE = "robotiq_controllers.humble.yaml"
+JAZZY_SIM_CONTROLLERS_FILE = "robotiq_controllers.sim.yaml"
+HUMBLE_SIM_CONTROLLERS_FILE = "robotiq_controllers.sim.humble.yaml"
 
 
-def controllers_file_for_distro(distro):
-    """Return the controller config file name to load on ROS distro `distro`."""
-    return HUMBLE_CONTROLLERS_FILE if distro == "humble" else JAZZY_CONTROLLERS_FILE
+def controllers_file_for_distro(distro, simulated=False):
+    """Return the controller config file name for ROS distro `distro`.
+
+    `simulated` selects the config for the sim_isaac / sim_gazebo hardware plugins.
+    """
+    if distro == "humble":
+        return HUMBLE_SIM_CONTROLLERS_FILE if simulated else HUMBLE_CONTROLLERS_FILE
+    return JAZZY_SIM_CONTROLLERS_FILE if simulated else JAZZY_CONTROLLERS_FILE
 
 
 class ParameterFilePath(Substitution):
@@ -129,6 +138,45 @@ def generate_launch_description():
             description="Use ros2_control mock (fake) hardware instead of a real gripper",
         )
     )
+    args.append(
+        launch.actions.DeclareLaunchArgument(
+            name="sim_isaac",
+            default_value="false",
+            description="Drive a simulator over topic_based_ros2_control instead of a real gripper",
+        )
+    )
+    args.append(
+        launch.actions.DeclareLaunchArgument(
+            name="sim_gazebo",
+            default_value="false",
+            description="Drive Gazebo over gz_ros2_control instead of a real gripper",
+        )
+    )
+    args.append(
+        launch.actions.DeclareLaunchArgument(
+            name="isaac_joint_commands",
+            default_value="/isaac_joint_commands",
+            description="sim_isaac only: JointState topic the simulator takes commands on",
+        )
+    )
+    args.append(
+        launch.actions.DeclareLaunchArgument(
+            name="isaac_joint_states",
+            default_value="/isaac_joint_states",
+            description="sim_isaac only: JointState topic the simulator publishes",
+        )
+    )
+
+    # "True"/"False": a PythonExpression is a string, and IfCondition reads both.
+    simulated = PythonExpression(
+        [
+            "'",
+            LaunchConfiguration("sim_isaac"),
+            "'.lower() in ('true', '1') or '",
+            LaunchConfiguration("sim_gazebo"),
+            "'.lower() in ('true', '1')",
+        ]
+    )
 
     robot_description_content = Command(
         [
@@ -144,6 +192,18 @@ def generate_launch_description():
             " ",
             "baudrate:=",
             LaunchConfiguration("baudrate"),
+            " ",
+            "sim_isaac:=",
+            LaunchConfiguration("sim_isaac"),
+            " ",
+            "sim_gazebo:=",
+            LaunchConfiguration("sim_gazebo"),
+            " ",
+            "isaac_joint_commands:=",
+            LaunchConfiguration("isaac_joint_commands"),
+            " ",
+            "isaac_joint_states:=",
+            LaunchConfiguration("isaac_joint_states"),
         ]
     )
 
@@ -153,7 +213,18 @@ def generate_launch_description():
         )
     }
 
-    controllers_file = controllers_file_for_distro(os.environ.get("ROS_DISTRO"))
+    distro = os.environ.get("ROS_DISTRO")
+    controllers_file = PythonExpression(
+        [
+            "'",
+            controllers_file_for_distro(distro, simulated=True),
+            "' if ",
+            simulated,
+            " else '",
+            controllers_file_for_distro(distro),
+            "'",
+        ]
+    )
     initial_joint_controllers = ParameterFile(
         PathJoinSubstitution([description_pkg_share, "config", controllers_file]),
         allow_substs=True,
@@ -190,7 +261,7 @@ def generate_launch_description():
     # then dies with "parameter 'joint' is not initialized". --param-file has been
     # a spawner option since Humble, and each node reads only its own section of
     # the file, so this is correct on every supported distro.
-    def spawner(controller_name):
+    def spawner(controller_name, condition=None):
         return launch_ros.actions.Node(
             package="controller_manager",
             executable="spawner",
@@ -201,11 +272,16 @@ def generate_launch_description():
                 "--param-file",
                 ParameterFilePath(initial_joint_controllers),
             ],
+            condition=condition,
         )
 
     joint_state_broadcaster_spawner = spawner("joint_state_broadcaster")
     robotiq_gripper_controller_spawner = spawner("robotiq_gripper_controller")
-    robotiq_activation_controller_spawner = spawner("robotiq_activation_controller")
+    # The reactivate_gripper GPIO this controller claims is declared for the
+    # driver and the mock only; the simulated plugins have nothing to reactivate.
+    robotiq_activation_controller_spawner = spawner(
+        "robotiq_activation_controller", condition=UnlessCondition(simulated)
+    )
 
     nodes = [
         control_node,

--- a/grippers/robotiq_description/launch/robotiq_control.launch.py
+++ b/grippers/robotiq_description/launch/robotiq_control.launch.py
@@ -27,14 +27,17 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import launch
+from launch.substitution import Substitution
 from launch.substitutions import (
     Command,
     FindExecutable,
     LaunchConfiguration,
     PathJoinSubstitution,
+    PythonExpression,
 )
 from launch.conditions import IfCondition
 import launch_ros
+from launch_ros.parameter_descriptions import ParameterFile
 import os
 
 # Humble has no parallel_gripper_controller package, so it needs its own
@@ -46,6 +49,25 @@ HUMBLE_CONTROLLERS_FILE = "robotiq_controllers.humble.yaml"
 def controllers_file_for_distro(distro):
     """Return the controller config file name to load on ROS distro `distro`."""
     return HUMBLE_CONTROLLERS_FILE if distro == "humble" else JAZZY_CONTROLLERS_FILE
+
+
+class ParameterFilePath(Substitution):
+    def __init__(self, parameter_file):
+        super().__init__()
+        self.parameter_file = parameter_file
+
+    def perform(self, context):
+        return str(self.parameter_file.evaluate(context))
+
+
+def default_gripper_joint():
+    return PythonExpression(
+        [
+            "'finger_joint' if '2f_140' in '",
+            LaunchConfiguration("model"),
+            "' else 'robotiq_85_left_knuckle_joint'",
+        ]
+    )
 
 
 def generate_launch_description():
@@ -77,6 +99,13 @@ def generate_launch_description():
     args.append(
         launch.actions.DeclareLaunchArgument(
             name="launch_rviz", default_value="false", description="Launch RViz?"
+        )
+    )
+    args.append(
+        launch.actions.DeclareLaunchArgument(
+            name="gripper_joint",
+            default_value=default_gripper_joint(),
+            description="Joint the gripper controller drives; defaults from the model",
         )
     )
     args.append(
@@ -125,8 +154,9 @@ def generate_launch_description():
     }
 
     controllers_file = controllers_file_for_distro(os.environ.get("ROS_DISTRO"))
-    initial_joint_controllers = PathJoinSubstitution(
-        [description_pkg_share, "config", controllers_file]
+    initial_joint_controllers = ParameterFile(
+        PathJoinSubstitution([description_pkg_share, "config", controllers_file]),
+        allow_substs=True,
     )
 
     control_node = launch_ros.actions.Node(
@@ -169,7 +199,7 @@ def generate_launch_description():
                 "--controller-manager",
                 "/controller_manager",
                 "--param-file",
-                initial_joint_controllers,
+                ParameterFilePath(initial_joint_controllers),
             ],
         )
 

--- a/grippers/robotiq_description/test/test_controller_config.py
+++ b/grippers/robotiq_description/test/test_controller_config.py
@@ -41,11 +41,16 @@ from pathlib import Path
 
 import pytest
 import yaml
+from launch import LaunchContext
 
 CONFIG_DIR = Path(__file__).parents[1] / "config"
 JAZZY_CONFIG = CONFIG_DIR / "robotiq_controllers.yaml"
 HUMBLE_CONFIG = CONFIG_DIR / "robotiq_controllers.humble.yaml"
 ALL_CONFIGS = (JAZZY_CONFIG, HUMBLE_CONFIG)
+
+# The configs name the joint through this launch placeholder so one file serves
+# both models; robotiq_control.launch.py resolves it via ParameterFile.
+JOINT_PLACEHOLDER = "$(var gripper_joint)"
 
 # Names exported by robotiq_driver's hardware interface. Kept in sync by
 # robotiq_driver's test_robotiq_gripper_hardware_interface, which asserts the
@@ -80,8 +85,18 @@ def load(config):
         return yaml.safe_load(f)
 
 
-def gripper_controller_params(config):
-    return load(config)["robotiq_gripper_controller"]["ros__parameters"]
+def gripper_controller_params(config, joint=JOINT):
+    params = load(config)["robotiq_gripper_controller"]["ros__parameters"]
+    return {
+        k: v.replace(JOINT_PLACEHOLDER, joint) if isinstance(v, str) else v
+        for k, v in params.items()
+    }
+
+
+def perform(substitution, **launch_configurations):
+    context = LaunchContext()
+    context.launch_configurations.update(launch_configurations)
+    return substitution.perform(context)
 
 
 def test_max_effort_interface_is_exported():
@@ -105,6 +120,33 @@ def test_humble_config_claims_no_unsupported_interfaces():
 @pytest.mark.parametrize("config", ALL_CONFIGS)
 def test_joint_matches_exported_interfaces(config):
     assert gripper_controller_params(config)["joint"] == JOINT
+
+
+@pytest.mark.parametrize("config", ALL_CONFIGS)
+def test_joint_is_left_to_the_launch(config):
+    # Hardcoding the 2F-85 joint here is why a 2F-140 launch used to fail to
+    # activate robotiq_gripper_controller.
+    raw = load(config)["robotiq_gripper_controller"]["ros__parameters"]
+    assert raw["joint"] == JOINT_PLACEHOLDER
+    assert JOINT not in yaml.safe_dump(raw)
+
+
+def test_launch_description_builds():
+    # Import errors in the launch file only surface when `ros2 launch` runs it.
+    load_launch_module().generate_launch_description()
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("/opt/share/urdf/robotiq_2f_85_gripper.urdf.xacro", JOINT),
+        ("/opt/share/urdf/robotiq_2f_140_gripper.urdf.xacro", "finger_joint"),
+        ("/home/me/my_cell.urdf.xacro", JOINT),
+    ],
+)
+def test_launch_defaults_the_joint_from_the_model(model, expected):
+    launch_module = load_launch_module()
+    assert perform(launch_module.default_gripper_joint(), model=model) == expected
 
 
 @pytest.mark.parametrize("config", ALL_CONFIGS)

--- a/grippers/robotiq_description/test/test_controller_config.py
+++ b/grippers/robotiq_description/test/test_controller_config.py
@@ -206,7 +206,12 @@ def spawned_controllers(distro, monkeypatch, **launch_arguments):
         monkeypatch.setenv("ROS_DISTRO", distro)
     context = LaunchContext()
     context.launch_configurations.update(
-        {"sim_isaac": "false", "sim_gazebo": "false", **launch_arguments}
+        {
+            "sim_isaac": "false",
+            "sim_gazebo": "false",
+            "gripper_joint": JOINT,
+            **launch_arguments,
+        }
     )
 
     spawned = {}
@@ -216,8 +221,12 @@ def spawned_controllers(distro, monkeypatch, **launch_arguments):
         if action.condition is not None and not action.condition.evaluate(context):
             continue
         cmd = [perform_substitutions(context, part) for part in action.cmd]
-        spawned[cmd[1]] = Path(cmd[cmd.index("--param-file") + 1]).name
+        spawned[cmd[1]] = Path(cmd[cmd.index("--param-file") + 1]).read_text()
     return spawned
+
+
+def resolved(config, joint=JOINT):
+    return config.read_text().replace(JOINT_PLACEHOLDER, joint)
 
 
 @requires_launch
@@ -237,15 +246,15 @@ def test_launch_spawns_per_plugin(
     # and the activation controller only exists where its GPIO does.
     hardware = spawned_controllers(distro, monkeypatch)
     assert hardware == {
-        "joint_state_broadcaster": hardware_config.name,
-        "robotiq_gripper_controller": hardware_config.name,
-        "robotiq_activation_controller": hardware_config.name,
+        "joint_state_broadcaster": resolved(hardware_config),
+        "robotiq_gripper_controller": resolved(hardware_config),
+        "robotiq_activation_controller": resolved(hardware_config),
     }
 
     simulated = spawned_controllers(distro, monkeypatch, **{sim_argument: "true"})
     assert simulated == {
-        "joint_state_broadcaster": sim_config.name,
-        "robotiq_gripper_controller": sim_config.name,
+        "joint_state_broadcaster": resolved(sim_config),
+        "robotiq_gripper_controller": resolved(sim_config),
     }
 
 

--- a/grippers/robotiq_description/test/test_controller_config.py
+++ b/grippers/robotiq_description/test/test_controller_config.py
@@ -52,10 +52,19 @@ ALL_CONFIGS = (JAZZY_CONFIG, HUMBLE_CONFIG)
 # both models; robotiq_control.launch.py resolves it via ParameterFile.
 JOINT_PLACEHOLDER = "$(var gripper_joint)"
 
+# The simulated plugins (sim_isaac / sim_gazebo) export neither the
+# set_gripper_max_* command interfaces nor the reactivate_gripper GPIO, so they
+# get a config of their own per distro, selected by the same launch file.
+JAZZY_SIM_CONFIG = CONFIG_DIR / "robotiq_controllers.sim.yaml"
+HUMBLE_SIM_CONFIG = CONFIG_DIR / "robotiq_controllers.sim.humble.yaml"
+SIM_CONFIGS = (JAZZY_SIM_CONFIG, HUMBLE_SIM_CONFIG)
+SIM_OF = {JAZZY_CONFIG: JAZZY_SIM_CONFIG, HUMBLE_CONFIG: HUMBLE_SIM_CONFIG}
+
 # Names exported by robotiq_driver's hardware interface. Kept in sync by
 # robotiq_driver's test_robotiq_gripper_hardware_interface, which asserts the
 # hardware exports exactly these.
 JOINT = "robotiq_85_left_knuckle_joint"
+UPDATE_RATE_HZ = 500
 EXPORTED_COMMAND_INTERFACES = {
     f"{JOINT}/position",
     f"{JOINT}/set_gripper_max_velocity",
@@ -69,6 +78,9 @@ EXPECTED_CONTROLLER_TYPES = {
     JAZZY_CONFIG: "parallel_gripper_action_controller/GripperActionController",
     HUMBLE_CONFIG: "position_controllers/GripperActionController",
 }
+EXPECTED_CONTROLLER_TYPES.update(
+    {SIM_OF[config]: plugin for config, plugin in EXPECTED_CONTROLLER_TYPES.items()}
+)
 
 
 def load_launch_module():
@@ -117,12 +129,12 @@ def test_humble_config_claims_no_unsupported_interfaces():
     assert "max_velocity_interface" not in params
 
 
-@pytest.mark.parametrize("config", ALL_CONFIGS)
+@pytest.mark.parametrize("config", ALL_CONFIGS + SIM_CONFIGS)
 def test_joint_matches_exported_interfaces(config):
     assert gripper_controller_params(config)["joint"] == JOINT
 
 
-@pytest.mark.parametrize("config", ALL_CONFIGS)
+@pytest.mark.parametrize("config", ALL_CONFIGS + SIM_CONFIGS)
 def test_joint_is_left_to_the_launch(config):
     # Hardcoding the 2F-85 joint here is why a 2F-140 launch used to fail to
     # activate robotiq_gripper_controller.
@@ -149,7 +161,7 @@ def test_launch_defaults_the_joint_from_the_model(model, expected):
     assert perform(launch_module.default_gripper_joint(), model=model) == expected
 
 
-@pytest.mark.parametrize("config", ALL_CONFIGS)
+@pytest.mark.parametrize("config", ALL_CONFIGS + SIM_CONFIGS)
 def test_controller_type_matches_distro(config):
     controllers = load(config)["controller_manager"]["ros__parameters"]
     assert (
@@ -174,6 +186,48 @@ def test_launch_selects_the_config_for_the_distro(distro, expected):
     assert (CONFIG_DIR / selected).is_file()
 
 
+@pytest.mark.parametrize("config", SIM_CONFIGS)
+def test_sim_configs_claim_no_driver_only_command_interfaces(config):
+    # TopicBasedSystem and GazeboSimSystem export the standard joint interfaces
+    # only; claiming set_gripper_max_* here is why the sim paths never activated.
+    params = gripper_controller_params(config)
+    assert "max_effort_interface" not in params
+    assert "max_velocity_interface" not in params
+
+
+@pytest.mark.parametrize("config", SIM_CONFIGS)
+def test_sim_configs_spawn_no_activation_controller(config):
+    # No reactivate_gripper GPIO is declared under sim_isaac / sim_gazebo (see
+    # 2f_85.ros2_control.xacro), so the controller would have nothing to claim.
+    controllers = load(config)["controller_manager"]["ros__parameters"]
+    assert set(controllers) == {
+        "update_rate",
+        "joint_state_broadcaster",
+        "robotiq_gripper_controller",
+    }
+    assert controllers["update_rate"] == UPDATE_RATE_HZ
+    assert "robotiq_activation_controller" not in load(config)
+
+
+@pytest.mark.parametrize("config", ALL_CONFIGS)
+def test_sim_config_keeps_the_action_surface_of_its_distro(config):
+    # Same controller name, type, joint and goal tolerance as the hardware config
+    # for that distro: an action client must not notice which plugin is behind.
+    hardware = gripper_controller_params(config)
+    sim = gripper_controller_params(SIM_OF[config])
+    assert sim["joint"] == hardware["joint"]
+    assert sim["goal_tolerance"] == hardware["goal_tolerance"]
+    assert sim["allow_stalling"] == hardware["allow_stalling"]
+    assert (
+        load(SIM_OF[config])["controller_manager"]["ros__parameters"][
+            "robotiq_gripper_controller"
+        ]
+        == load(config)["controller_manager"]["ros__parameters"][
+            "robotiq_gripper_controller"
+        ]
+    )
+
+
 @pytest.mark.parametrize("config", ALL_CONFIGS)
 def test_controller_names_and_update_rate_are_identical_across_distros(config):
     # The controller names are the action/service namespaces users depend on
@@ -186,7 +240,7 @@ def test_controller_names_and_update_rate_are_identical_across_distros(config):
         "robotiq_gripper_controller",
         "robotiq_activation_controller",
     }
-    assert controllers["update_rate"] == 500
+    assert controllers["update_rate"] == UPDATE_RATE_HZ
     assert (
         controllers["robotiq_activation_controller"]["type"]
         == "robotiq_controllers/RobotiqActivationController"

--- a/grippers/robotiq_description/test/test_controller_config.py
+++ b/grippers/robotiq_description/test/test_controller_config.py
@@ -185,6 +185,69 @@ def test_launch_selects_the_config_for_the_distro(distro, expected):
     assert selected == expected.name
     assert (CONFIG_DIR / selected).is_file()
 
+    simulated = launch_module.controllers_file_for_distro(distro, simulated=True)
+    assert simulated == SIM_OF[expected].name
+    assert (CONFIG_DIR / simulated).is_file()
+
+
+requires_launch = pytest.mark.skipif(
+    importlib.util.find_spec("launch_ros") is None, reason="launch_ros not importable"
+)
+
+
+def spawned_controllers(distro, monkeypatch, **launch_arguments):
+    from launch import LaunchContext
+    from launch.utilities import perform_substitutions
+    from launch_ros.actions import Node
+
+    if distro is None:
+        monkeypatch.delenv("ROS_DISTRO", raising=False)
+    else:
+        monkeypatch.setenv("ROS_DISTRO", distro)
+    context = LaunchContext()
+    context.launch_configurations.update(
+        {"sim_isaac": "false", "sim_gazebo": "false", **launch_arguments}
+    )
+
+    spawned = {}
+    for action in load_launch_module().generate_launch_description().entities:
+        if not isinstance(action, Node) or action.node_executable != "spawner":
+            continue
+        if action.condition is not None and not action.condition.evaluate(context):
+            continue
+        cmd = [perform_substitutions(context, part) for part in action.cmd]
+        spawned[cmd[1]] = Path(cmd[cmd.index("--param-file") + 1]).name
+    return spawned
+
+
+@requires_launch
+@pytest.mark.parametrize(
+    "distro,hardware_config,sim_config",
+    [
+        ("humble", HUMBLE_CONFIG, HUMBLE_SIM_CONFIG),
+        ("jazzy", JAZZY_CONFIG, JAZZY_SIM_CONFIG),
+        (None, JAZZY_CONFIG, JAZZY_SIM_CONFIG),
+    ],
+)
+@pytest.mark.parametrize("sim_argument", ["sim_isaac", "sim_gazebo"])
+def test_launch_spawns_per_plugin(
+    distro, hardware_config, sim_config, sim_argument, monkeypatch
+):
+    # Every spawner must be handed the same config the controller_manager loaded,
+    # and the activation controller only exists where its GPIO does.
+    hardware = spawned_controllers(distro, monkeypatch)
+    assert hardware == {
+        "joint_state_broadcaster": hardware_config.name,
+        "robotiq_gripper_controller": hardware_config.name,
+        "robotiq_activation_controller": hardware_config.name,
+    }
+
+    simulated = spawned_controllers(distro, monkeypatch, **{sim_argument: "true"})
+    assert simulated == {
+        "joint_state_broadcaster": sim_config.name,
+        "robotiq_gripper_controller": sim_config.name,
+    }
+
 
 @pytest.mark.parametrize("config", SIM_CONFIGS)
 def test_sim_configs_claim_no_driver_only_command_interfaces(config):

--- a/grippers/robotiq_description/test/test_ros2_control_urdf.py
+++ b/grippers/robotiq_description/test/test_ros2_control_urdf.py
@@ -52,6 +52,7 @@ import yaml
 PKG_DIR = Path(__file__).parents[1]
 URDF_DIR = PKG_DIR / "urdf"
 CONFIG = PKG_DIR / "config" / "robotiq_controllers.yaml"
+SIM_CONFIG = PKG_DIR / "config" / "robotiq_controllers.sim.yaml"
 
 # Top-level xacro -> the joint carrying the gripper's position command.
 MODELS = {
@@ -257,3 +258,19 @@ def test_isaac_topics_reach_the_plugin(model):
     default = expand(model, False, "sim_isaac:=true")
     assert hardware_param(default, "joint_commands_topic") == "/isaac_joint_commands"
     assert hardware_param(default, "joint_states_topic") == "/isaac_joint_states"
+
+
+@requires_xacro
+@pytest.mark.parametrize("sim_arg", SIM_ARGS.values())
+def test_sim_controller_config_claims_only_what_the_sim_urdf_declares(sim_arg):
+    # The sim counterpart of test_gripper_controller_config_interfaces_exist_under_mock.
+    params = yaml.safe_load(SIM_CONFIG.read_text())["robotiq_gripper_controller"][
+        "ros__parameters"
+    ]
+    joint = MODELS["robotiq_2f_85_gripper.urdf.xacro"]
+    ros2_control = expand("robotiq_2f_85_gripper.urdf.xacro", False, sim_arg)
+
+    assert params["joint"] == "$(var gripper_joint)"
+    assert "max_effort_interface" not in params
+    assert "max_velocity_interface" not in params
+    assert set(params["state_interfaces"]) <= state_interfaces_of(ros2_control, joint)

--- a/grippers/robotiq_description/test/test_ros2_control_urdf.py
+++ b/grippers/robotiq_description/test/test_ros2_control_urdf.py
@@ -157,10 +157,12 @@ def test_gripper_controller_config_interfaces_exist_under_mock():
     params = yaml.safe_load(CONFIG.read_text())["robotiq_gripper_controller"][
         "ros__parameters"
     ]
-    claimed = {params["max_effort_interface"], params["max_velocity_interface"]}
-
     ros2_control = expand("robotiq_2f_85_gripper.urdf.xacro", use_fake_hardware=True)
     joint = MODELS["robotiq_2f_85_gripper.urdf.xacro"]
+    claimed = {
+        params[k].replace("$(var gripper_joint)", joint)
+        for k in ("max_effort_interface", "max_velocity_interface")
+    }
     available = {
         f"{joint}/{name}" for name in command_interfaces_of(ros2_control, joint)
     }

--- a/grippers/robotiq_description/test/test_ros2_control_urdf.py
+++ b/grippers/robotiq_description/test/test_ros2_control_urdf.py
@@ -61,6 +61,12 @@ MODELS = {
 
 MOCK_PLUGIN = "mock_components/GenericSystem"
 REAL_PLUGIN = "robotiq_driver/RobotiqGripperHardwareInterface"
+ISAAC_PLUGIN = "topic_based_ros2_control/TopicBasedSystem"
+GAZEBO_PLUGIN = "gz_ros2_control/GazeboSimSystem"
+SIM_ARGS = {ISAAC_PLUGIN: "sim_isaac:=true", GAZEBO_PLUGIN: "sim_gazebo:=true"}
+
+# Every 2F finger joint except the driven knuckle follows it through <mimic>.
+MIMIC_JOINT_COUNT = 5
 
 # Exported by the driver at runtime; needed from the URDF under mock hardware.
 EXTRA_MOCK_COMMAND_INTERFACES = {"set_gripper_max_velocity", "set_gripper_max_effort"}
@@ -194,3 +200,60 @@ def test_baudrate_reaches_the_driver(model):
 
     assert hardware_param(expand(model, False), "baudrate") == "115200"
     assert hardware_param(expand(model, True), "baudrate") is None
+
+
+@requires_xacro
+@pytest.mark.parametrize("model,joint", MODELS.items())
+@pytest.mark.parametrize("plugin,sim_arg", SIM_ARGS.items())
+def test_sim_plugins_declare_only_the_position_command(model, joint, plugin, sim_arg):
+    # Neither simulated plugin knows the driver's set_gripper_max_* interfaces;
+    # config/robotiq_controllers.sim.yaml therefore claims none, and the URDF must
+    # not declare them either or the plugin rejects the joint.
+    ros2_control = expand(model, False, sim_arg)
+    assert plugin_of(ros2_control) == plugin
+    assert command_interfaces_of(ros2_control, joint) == {"position"}
+
+
+@requires_xacro
+@pytest.mark.parametrize("model,joint", MODELS.items())
+@pytest.mark.parametrize("sim_arg", SIM_ARGS.values())
+def test_sim_plugins_declare_no_reactivate_gpio(model, joint, sim_arg):
+    # robotiq_control.launch.py skips robotiq_activation_controller under sim_*;
+    # this is the URDF side of that agreement.
+    assert expand(model, False, sim_arg).find("gpio") is None
+    assert expand(model, False).find("gpio[@name='reactivate_gripper']") is not None
+    assert expand(model, True).find("gpio[@name='reactivate_gripper']") is not None
+
+
+@requires_xacro
+@pytest.mark.parametrize("model,joint", MODELS.items())
+def test_sim_isaac_declares_the_mimic_joints_as_state_only(model, joint):
+    # TopicBasedSystem reports only the joints declared here, and the simulator
+    # owns the mimic joints, so they must be declared for /joint_states to carry
+    # them, but with no command interface: only the knuckle is driven.
+    ros2_control = expand(model, False, "sim_isaac:=true")
+    mimic = joints_of(ros2_control) - {joint}
+    assert len(mimic) == MIMIC_JOINT_COUNT
+    for name in mimic:
+        assert command_interfaces_of(ros2_control, name) == set()
+        assert state_interfaces_of(ros2_control, name) == {"position", "velocity"}
+
+
+@requires_xacro
+@pytest.mark.parametrize("model", MODELS)
+def test_isaac_topics_reach_the_plugin(model):
+    # Same three-file chain as baudrate: a half-forwarded argument only shows up
+    # as a simulator that never hears a command.
+    ros2_control = expand(
+        model,
+        False,
+        "sim_isaac:=true",
+        "isaac_joint_commands:=/sim/cmd",
+        "isaac_joint_states:=/sim/state",
+    )
+    assert hardware_param(ros2_control, "joint_commands_topic") == "/sim/cmd"
+    assert hardware_param(ros2_control, "joint_states_topic") == "/sim/state"
+
+    default = expand(model, False, "sim_isaac:=true")
+    assert hardware_param(default, "joint_commands_topic") == "/isaac_joint_commands"
+    assert hardware_param(default, "joint_states_topic") == "/isaac_joint_states"

--- a/grippers/robotiq_description/urdf/2f_140.ros2_control.xacro
+++ b/grippers/robotiq_description/urdf/2f_140.ros2_control.xacro
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
+    <xacro:include filename="$(find robotiq_description)/urdf/2f_common.ros2_control.xacro" />
+
     <xacro:macro name="robotiq_gripper_ros2_control" params="
         name
         prefix
@@ -20,31 +22,20 @@
 
         <ros2_control name="${name}" type="system">
             <!-- Plugins -->
-            <hardware>
-                <xacro:if value="${sim_isaac}">
-                    <plugin>topic_based_ros2_control/TopicBasedSystem</plugin>
-                    <param name="joint_commands_topic">${isaac_joint_commands}</param>
-                    <param name="joint_states_topic">${isaac_joint_states}</param>
-                </xacro:if>
-                <xacro:if value="${sim_gazebo}">
-                    <plugin>gz_ros2_control/GazeboSimSystem</plugin>
-                </xacro:if>
-                <xacro:if value="${use_fake_hardware}">
-                    <plugin>mock_components/GenericSystem</plugin>
-                    <param name="mock_sensor_commands">${mock_sensor_commands}</param>
-                    <param name="state_following_offset">0.0</param>
-                </xacro:if>
-                <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_isaac}">
-                    <plugin>robotiq_driver/RobotiqGripperHardwareInterface</plugin>
-                    <param name="gripper_closed_position">${gripper_closed_position}</param>
-                    <param name="COM_port">${com_port}</param>
-                    <param name="baudrate">${baudrate}</param>
-                    <param name="gripper_speed_multiplier">${gripper_speed_multiplier}</param>
-                    <param name="gripper_force_multiplier">${gripper_force_multiplier}</param>
-                    <param name="gripper_max_speed">${gripper_max_speed}</param>
-                    <param name="gripper_max_force">${gripper_max_force}</param>
-                </xacro:unless>
-            </hardware>
+            <xacro:robotiq_2f_hardware
+                sim_gazebo="${sim_gazebo}"
+                sim_isaac="${sim_isaac}"
+                isaac_joint_commands="${isaac_joint_commands}"
+                isaac_joint_states="${isaac_joint_states}"
+                use_fake_hardware="${use_fake_hardware}"
+                mock_sensor_commands="${mock_sensor_commands}"
+                com_port="${com_port}"
+                baudrate="${baudrate}"
+                gripper_speed_multiplier="${gripper_speed_multiplier}"
+                gripper_force_multiplier="${gripper_force_multiplier}"
+                gripper_max_speed="${gripper_max_speed}"
+                gripper_max_force="${gripper_max_force}"
+                gripper_closed_position="${gripper_closed_position}"/>
 
             <!-- Joint interfaces -->
             <!-- With Gazebo or Hardware, they handle mimic joints, so we only need this command interface activated -->
@@ -66,36 +57,11 @@
             </joint>
             <!-- When simulating we need to include the rest of the gripper joints -->
             <xacro:if value="${sim_isaac or sim_gazebo}">
-                <joint name="${prefix}left_inner_knuckle_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}left_inner_finger_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}right_outer_knuckle_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}right_inner_knuckle_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}right_inner_finger_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}left_inner_knuckle_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}left_inner_finger_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}right_outer_knuckle_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}right_inner_knuckle_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}right_inner_finger_joint" sim_gazebo="${sim_gazebo}"/>
             </xacro:if>
 
             <!-- Only add this with fake hardware mode -->

--- a/grippers/robotiq_description/urdf/2f_85.ros2_control.xacro
+++ b/grippers/robotiq_description/urdf/2f_85.ros2_control.xacro
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
+    <xacro:include filename="$(find robotiq_description)/urdf/2f_common.ros2_control.xacro" />
+
     <xacro:macro name="robotiq_gripper_ros2_control" params="
         name
         prefix
@@ -20,36 +22,20 @@
 
         <ros2_control name="${name}" type="system">
             <!-- Plugins -->
-            <hardware>
-
-                <!-- Set use_dummy to true to connect to a dummy driver for testing purposes. -->
-                <param name="use_dummy">false</param>
-
-                <xacro:if value="${sim_isaac}">
-                    <plugin>topic_based_ros2_control/TopicBasedSystem</plugin>
-                    <param name="joint_commands_topic">${isaac_joint_commands}</param>
-                    <param name="joint_states_topic">${isaac_joint_states}</param>
-                    <param name="trigger_joint_command_threshold">0.02</param>
-                </xacro:if>
-                <xacro:if value="${sim_gazebo}">
-                    <plugin>gz_ros2_control/GazeboSimSystem</plugin>
-                </xacro:if>
-                <xacro:if value="${use_fake_hardware}">
-                    <plugin>mock_components/GenericSystem</plugin>
-                    <param name="mock_sensor_commands">${mock_sensor_commands}</param>
-                    <param name="state_following_offset">0.0</param>
-                </xacro:if>
-                <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_isaac}">
-                    <plugin>robotiq_driver/RobotiqGripperHardwareInterface</plugin>
-                    <param name="gripper_closed_position">${gripper_closed_position}</param>
-                    <param name="COM_port">${com_port}</param>
-                    <param name="baudrate">${baudrate}</param>
-                    <param name="gripper_speed_multiplier">${gripper_speed_multiplier}</param>
-                    <param name="gripper_force_multiplier">${gripper_force_multiplier}</param>
-                    <param name="gripper_max_speed">${gripper_max_speed}</param>
-                    <param name="gripper_max_force">${gripper_max_force}</param>
-                </xacro:unless>
-            </hardware>
+            <xacro:robotiq_2f_hardware
+                sim_gazebo="${sim_gazebo}"
+                sim_isaac="${sim_isaac}"
+                isaac_joint_commands="${isaac_joint_commands}"
+                isaac_joint_states="${isaac_joint_states}"
+                use_fake_hardware="${use_fake_hardware}"
+                mock_sensor_commands="${mock_sensor_commands}"
+                com_port="${com_port}"
+                baudrate="${baudrate}"
+                gripper_speed_multiplier="${gripper_speed_multiplier}"
+                gripper_force_multiplier="${gripper_force_multiplier}"
+                gripper_max_speed="${gripper_max_speed}"
+                gripper_max_force="${gripper_max_force}"
+                gripper_closed_position="${gripper_closed_position}"/>
 
             <!-- Joint interfaces -->
             <!-- With Gazebo or Hardware, they handle mimic joints, so we only need this command interface activated -->
@@ -78,36 +64,11 @@
             </joint>
             <!-- When simulating we need to include the rest of the gripper joints -->
             <xacro:if value="${sim_isaac or sim_gazebo}">
-                <joint name="${prefix}robotiq_85_right_knuckle_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}robotiq_85_left_inner_knuckle_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}robotiq_85_right_inner_knuckle_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}robotiq_85_left_finger_tip_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}robotiq_85_right_finger_tip_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}robotiq_85_right_knuckle_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}robotiq_85_left_inner_knuckle_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}robotiq_85_right_inner_knuckle_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}robotiq_85_left_finger_tip_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}robotiq_85_right_finger_tip_joint" sim_gazebo="${sim_gazebo}"/>
             </xacro:if>
 
             <!-- Only add this with fake hardware mode -->

--- a/grippers/robotiq_description/urdf/2f_common.ros2_control.xacro
+++ b/grippers/robotiq_description/urdf/2f_common.ros2_control.xacro
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+    <!-- The <hardware> block is the same for every 2F model: only the joint
+         names and the per-model defaults differ, and those stay in
+         2f_85.ros2_control.xacro / 2f_140.ros2_control.xacro. -->
+    <xacro:macro name="robotiq_2f_hardware" params="
+        sim_gazebo
+        sim_isaac
+        isaac_joint_commands
+        isaac_joint_states
+        use_fake_hardware
+        mock_sensor_commands
+        com_port
+        baudrate
+        gripper_speed_multiplier
+        gripper_force_multiplier
+        gripper_max_speed
+        gripper_max_force
+        gripper_closed_position">
+
+        <hardware>
+
+            <!-- Set use_dummy to true to connect to a dummy driver for testing purposes. -->
+            <param name="use_dummy">false</param>
+
+            <xacro:if value="${sim_isaac}">
+                <plugin>topic_based_ros2_control/TopicBasedSystem</plugin>
+                <param name="joint_commands_topic">${isaac_joint_commands}</param>
+                <param name="joint_states_topic">${isaac_joint_states}</param>
+                <param name="trigger_joint_command_threshold">0.02</param>
+            </xacro:if>
+            <xacro:if value="${sim_gazebo}">
+                <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+            </xacro:if>
+            <xacro:if value="${use_fake_hardware}">
+                <plugin>mock_components/GenericSystem</plugin>
+                <param name="mock_sensor_commands">${mock_sensor_commands}</param>
+                <param name="state_following_offset">0.0</param>
+            </xacro:if>
+            <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_isaac}">
+                <plugin>robotiq_driver/RobotiqGripperHardwareInterface</plugin>
+                <param name="gripper_closed_position">${gripper_closed_position}</param>
+                <param name="COM_port">${com_port}</param>
+                <param name="baudrate">${baudrate}</param>
+                <param name="gripper_speed_multiplier">${gripper_speed_multiplier}</param>
+                <param name="gripper_force_multiplier">${gripper_force_multiplier}</param>
+                <param name="gripper_max_speed">${gripper_max_speed}</param>
+                <param name="gripper_max_force">${gripper_max_force}</param>
+            </xacro:unless>
+        </hardware>
+    </xacro:macro>
+
+    <!-- A mimic joint the simulator owns: declared so /joint_states carries it,
+         but never commanded. Gazebo derives mimic joints itself, so it gets no
+         state interfaces either. -->
+    <xacro:macro name="robotiq_2f_sim_mimic_joint" params="name sim_gazebo">
+        <joint name="${name}">
+            <xacro:unless value="${sim_gazebo}">
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </xacro:unless>
+        </joint>
+    </xacro:macro>
+
+</robot>

--- a/grippers/robotiq_description/urdf/robotiq_2f_140_gripper.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_140_gripper.urdf.xacro
@@ -1,15 +1,5 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro" name="robotiq_gripper">
-    <!-- parameters -->
-    <xacro:arg name="use_fake_hardware" default="true" />
-    <xacro:arg name="com_port" default="/dev/ttyUSB0" />
-    <xacro:arg name="baudrate" default="115200" />
-
-    <!-- Import macros -->
-    <xacro:include filename="$(find robotiq_description)/urdf/robotiq_2f_140_macro.urdf.xacro" />
-
-    <link name="world" />
-    <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg com_port)" baudrate="$(arg baudrate)">
-        <origin xyz="0 0 0" rpy="0 0 0" />
-    </xacro:robotiq_gripper>
+    <xacro:arg name="model" default="2f_140" />
+    <xacro:include filename="$(find robotiq_description)/urdf/robotiq_2f_gripper.urdf.xacro" />
 </robot>

--- a/grippers/robotiq_description/urdf/robotiq_2f_85_gripper.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_85_gripper.urdf.xacro
@@ -1,15 +1,5 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro" name="robotiq_gripper">
-    <!-- parameters -->
-    <xacro:arg name="use_fake_hardware" default="true" />
-    <xacro:arg name="com_port" default="/dev/ttyUSB0" />
-    <xacro:arg name="baudrate" default="115200" />
-
-    <!-- Import macros -->
-    <xacro:include filename="$(find robotiq_description)/urdf/robotiq_2f_85_macro.urdf.xacro" />
-
-    <link name="world" />
-    <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg com_port)" baudrate="$(arg baudrate)">
-        <origin xyz="0 0 0" rpy="0 0 0" />
-    </xacro:robotiq_gripper>
+    <xacro:arg name="model" default="2f_85" />
+    <xacro:include filename="$(find robotiq_description)/urdf/robotiq_2f_gripper.urdf.xacro" />
 </robot>

--- a/grippers/robotiq_description/urdf/robotiq_2f_gripper.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_gripper.urdf.xacro
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://wiki.ros.org/xacro" name="robotiq_gripper">
+    <!-- parameters -->
+    <xacro:arg name="model" default="2f_85" />
+    <xacro:arg name="use_fake_hardware" default="true" />
+    <xacro:arg name="com_port" default="/dev/ttyUSB0" />
+    <xacro:arg name="baudrate" default="115200" />
+
+    <!-- Import macros -->
+    <xacro:include filename="$(find robotiq_description)/urdf/robotiq_$(arg model)_macro.urdf.xacro" />
+
+    <link name="world" />
+    <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg com_port)" baudrate="$(arg baudrate)">
+        <origin xyz="0 0 0" rpy="0 0 0" />
+    </xacro:robotiq_gripper>
+</robot>

--- a/grippers/robotiq_description/urdf/robotiq_2f_gripper.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_gripper.urdf.xacro
@@ -5,12 +5,18 @@
     <xacro:arg name="use_fake_hardware" default="true" />
     <xacro:arg name="com_port" default="/dev/ttyUSB0" />
     <xacro:arg name="baudrate" default="115200" />
+    <xacro:arg name="sim_isaac" default="false" />
+    <xacro:arg name="sim_gazebo" default="false" />
+    <xacro:arg name="isaac_joint_commands" default="/isaac_joint_commands" />
+    <xacro:arg name="isaac_joint_states" default="/isaac_joint_states" />
 
     <!-- Import macros -->
     <xacro:include filename="$(find robotiq_description)/urdf/robotiq_$(arg model)_macro.urdf.xacro" />
 
     <link name="world" />
-    <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg com_port)" baudrate="$(arg baudrate)">
+    <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg com_port)" baudrate="$(arg baudrate)"
+        sim_isaac="$(arg sim_isaac)" sim_gazebo="$(arg sim_gazebo)"
+        isaac_joint_commands="$(arg isaac_joint_commands)" isaac_joint_states="$(arg isaac_joint_states)">
         <origin xyz="0 0 0" rpy="0 0 0" />
     </xacro:robotiq_gripper>
 </robot>


### PR DESCRIPTION
## Problem

The gripper xacros have let you pick `sim_isaac` (topic_based_ros2_control) or `sim_gazebo` (gz_ros2_control) as the hardware plugin for years, but the controller config and the launch file were written for the real driver only. Pick a sim plugin and `robotiq_gripper_controller` never activates: the config claims `set_gripper_max_effort` / `set_gripper_max_velocity`, which only the driver exports, and the launch spawns `robotiq_activation_controller`, whose GPIO the sim URDF does not declare. The launch also never exposed the sim flags at all.

## Change

One commit per layer, oldest first:

1. **xacro** — the top-level 2F-85 / 2F-140 xacros accept and forward `sim_isaac`, `sim_gazebo`, `isaac_joint_commands`, `isaac_joint_states` (the macro already had them).
2. **config** — `robotiq_controllers.sim.yaml` (+ Humble variant): same controllers as the hardware config minus the activation controller and the two driver-only command interfaces.
3. **launch** — new arguments, defaulting to today's behaviour; either sim flag selects the sim config and skips the activation spawner.
4. **README** — the two sim launch lines and a note that `TopicBasedSystem` matches joints by name.

Hardware and mock bringup are unchanged: same files, same controllers, same action surface. Neither sim plugin becomes a dependency.

## Verification

- 24 → 54 tests in `robotiq_description`; green at every commit. New tests pin what each sim plugin exports, that the sim config claims only that, and the launch's own spawner wiring per distro.
- Jazzy: `use_fake_hardware:=true` still activates all three controllers; `sim_isaac:=true` exercised live against an Isaac Sim 5.1 twin of a 2F-85 (open, close, stall-on-object through `gripper_cmd`).
- black, flake8, codespell clean.

## Note
only the last 4 commits constitute this PR. The commits before that come from PRs that havent yet been merged #48 and #49 )

🤖 Generated with [Claude Code](https://claude.com/claude-code)

