### PR TITLE
refactor(robotiq_description): share the top-level and ros2_control xacros between the 2F models

### DIFF
--- a/grippers/robotiq_description/urdf/2f_140.ros2_control.xacro
+++ b/grippers/robotiq_description/urdf/2f_140.ros2_control.xacro
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
+    <xacro:include filename="$(find robotiq_description)/urdf/2f_common.ros2_control.xacro" />
+
     <xacro:macro name="robotiq_gripper_ros2_control" params="
         name
         prefix
@@ -20,31 +22,20 @@
 
         <ros2_control name="${name}" type="system">
             <!-- Plugins -->
-            <hardware>
-                <xacro:if value="${sim_isaac}">
-                    <plugin>topic_based_ros2_control/TopicBasedSystem</plugin>
-                    <param name="joint_commands_topic">${isaac_joint_commands}</param>
-                    <param name="joint_states_topic">${isaac_joint_states}</param>
-                </xacro:if>
-                <xacro:if value="${sim_gazebo}">
-                    <plugin>gz_ros2_control/GazeboSimSystem</plugin>
-                </xacro:if>
-                <xacro:if value="${use_fake_hardware}">
-                    <plugin>mock_components/GenericSystem</plugin>
-                    <param name="mock_sensor_commands">${mock_sensor_commands}</param>
-                    <param name="state_following_offset">0.0</param>
-                </xacro:if>
-                <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_isaac}">
-                    <plugin>robotiq_driver/RobotiqGripperHardwareInterface</plugin>
-                    <param name="gripper_closed_position">${gripper_closed_position}</param>
-                    <param name="COM_port">${com_port}</param>
-                    <param name="baudrate">${baudrate}</param>
-                    <param name="gripper_speed_multiplier">${gripper_speed_multiplier}</param>
-                    <param name="gripper_force_multiplier">${gripper_force_multiplier}</param>
-                    <param name="gripper_max_speed">${gripper_max_speed}</param>
-                    <param name="gripper_max_force">${gripper_max_force}</param>
-                </xacro:unless>
-            </hardware>
+            <xacro:robotiq_2f_hardware
+                sim_gazebo="${sim_gazebo}"
+                sim_isaac="${sim_isaac}"
+                isaac_joint_commands="${isaac_joint_commands}"
+                isaac_joint_states="${isaac_joint_states}"
+                use_fake_hardware="${use_fake_hardware}"
+                mock_sensor_commands="${mock_sensor_commands}"
+                com_port="${com_port}"
+                baudrate="${baudrate}"
+                gripper_speed_multiplier="${gripper_speed_multiplier}"
+                gripper_force_multiplier="${gripper_force_multiplier}"
+                gripper_max_speed="${gripper_max_speed}"
+                gripper_max_force="${gripper_max_force}"
+                gripper_closed_position="${gripper_closed_position}"/>
 
             <!-- Joint interfaces -->
             <!-- With Gazebo or Hardware, they handle mimic joints, so we only need this command interface activated -->
@@ -66,36 +57,11 @@
             </joint>
             <!-- When simulating we need to include the rest of the gripper joints -->
             <xacro:if value="${sim_isaac or sim_gazebo}">
-                <joint name="${prefix}left_inner_knuckle_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}left_inner_finger_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}right_outer_knuckle_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}right_inner_knuckle_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}right_inner_finger_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}left_inner_knuckle_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}left_inner_finger_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}right_outer_knuckle_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}right_inner_knuckle_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}right_inner_finger_joint" sim_gazebo="${sim_gazebo}"/>
             </xacro:if>
 
             <!-- Only add this with fake hardware mode -->

--- a/grippers/robotiq_description/urdf/2f_85.ros2_control.xacro
+++ b/grippers/robotiq_description/urdf/2f_85.ros2_control.xacro
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
+    <xacro:include filename="$(find robotiq_description)/urdf/2f_common.ros2_control.xacro" />
+
     <xacro:macro name="robotiq_gripper_ros2_control" params="
         name
         prefix
@@ -20,36 +22,20 @@
 
         <ros2_control name="${name}" type="system">
             <!-- Plugins -->
-            <hardware>
-
-                <!-- Set use_dummy to true to connect to a dummy driver for testing purposes. -->
-                <param name="use_dummy">false</param>
-
-                <xacro:if value="${sim_isaac}">
-                    <plugin>topic_based_ros2_control/TopicBasedSystem</plugin>
-                    <param name="joint_commands_topic">${isaac_joint_commands}</param>
-                    <param name="joint_states_topic">${isaac_joint_states}</param>
-                    <param name="trigger_joint_command_threshold">0.02</param>
-                </xacro:if>
-                <xacro:if value="${sim_gazebo}">
-                    <plugin>gz_ros2_control/GazeboSimSystem</plugin>
-                </xacro:if>
-                <xacro:if value="${use_fake_hardware}">
-                    <plugin>mock_components/GenericSystem</plugin>
-                    <param name="mock_sensor_commands">${mock_sensor_commands}</param>
-                    <param name="state_following_offset">0.0</param>
-                </xacro:if>
-                <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_isaac}">
-                    <plugin>robotiq_driver/RobotiqGripperHardwareInterface</plugin>
-                    <param name="gripper_closed_position">${gripper_closed_position}</param>
-                    <param name="COM_port">${com_port}</param>
-                    <param name="baudrate">${baudrate}</param>
-                    <param name="gripper_speed_multiplier">${gripper_speed_multiplier}</param>
-                    <param name="gripper_force_multiplier">${gripper_force_multiplier}</param>
-                    <param name="gripper_max_speed">${gripper_max_speed}</param>
-                    <param name="gripper_max_force">${gripper_max_force}</param>
-                </xacro:unless>
-            </hardware>
+            <xacro:robotiq_2f_hardware
+                sim_gazebo="${sim_gazebo}"
+                sim_isaac="${sim_isaac}"
+                isaac_joint_commands="${isaac_joint_commands}"
+                isaac_joint_states="${isaac_joint_states}"
+                use_fake_hardware="${use_fake_hardware}"
+                mock_sensor_commands="${mock_sensor_commands}"
+                com_port="${com_port}"
+                baudrate="${baudrate}"
+                gripper_speed_multiplier="${gripper_speed_multiplier}"
+                gripper_force_multiplier="${gripper_force_multiplier}"
+                gripper_max_speed="${gripper_max_speed}"
+                gripper_max_force="${gripper_max_force}"
+                gripper_closed_position="${gripper_closed_position}"/>
 
             <!-- Joint interfaces -->
             <!-- With Gazebo or Hardware, they handle mimic joints, so we only need this command interface activated -->
@@ -78,36 +64,11 @@
             </joint>
             <!-- When simulating we need to include the rest of the gripper joints -->
             <xacro:if value="${sim_isaac or sim_gazebo}">
-                <joint name="${prefix}robotiq_85_right_knuckle_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}robotiq_85_left_inner_knuckle_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}robotiq_85_right_inner_knuckle_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}robotiq_85_left_finger_tip_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}robotiq_85_right_finger_tip_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}robotiq_85_right_knuckle_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}robotiq_85_left_inner_knuckle_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}robotiq_85_right_inner_knuckle_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}robotiq_85_left_finger_tip_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}robotiq_85_right_finger_tip_joint" sim_gazebo="${sim_gazebo}"/>
             </xacro:if>
 
             <!-- Only add this with fake hardware mode -->

--- a/grippers/robotiq_description/urdf/2f_common.ros2_control.xacro
+++ b/grippers/robotiq_description/urdf/2f_common.ros2_control.xacro
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+    <!-- The <hardware> block is the same for every 2F model: only the joint
+         names and the per-model defaults differ, and those stay in
+         2f_85.ros2_control.xacro / 2f_140.ros2_control.xacro. -->
+    <xacro:macro name="robotiq_2f_hardware" params="
+        sim_gazebo
+        sim_isaac
+        isaac_joint_commands
+        isaac_joint_states
+        use_fake_hardware
+        mock_sensor_commands
+        com_port
+        baudrate
+        gripper_speed_multiplier
+        gripper_force_multiplier
+        gripper_max_speed
+        gripper_max_force
+        gripper_closed_position">
+
+        <hardware>
+
+            <!-- Set use_dummy to true to connect to a dummy driver for testing purposes. -->
+            <param name="use_dummy">false</param>
+
+            <xacro:if value="${sim_isaac}">
+                <plugin>topic_based_ros2_control/TopicBasedSystem</plugin>
+                <param name="joint_commands_topic">${isaac_joint_commands}</param>
+                <param name="joint_states_topic">${isaac_joint_states}</param>
+                <param name="trigger_joint_command_threshold">0.02</param>
+            </xacro:if>
+            <xacro:if value="${sim_gazebo}">
+                <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+            </xacro:if>
+            <xacro:if value="${use_fake_hardware}">
+                <plugin>mock_components/GenericSystem</plugin>
+                <param name="mock_sensor_commands">${mock_sensor_commands}</param>
+                <param name="state_following_offset">0.0</param>
+            </xacro:if>
+            <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_isaac}">
+                <plugin>robotiq_driver/RobotiqGripperHardwareInterface</plugin>
+                <param name="gripper_closed_position">${gripper_closed_position}</param>
+                <param name="COM_port">${com_port}</param>
+                <param name="baudrate">${baudrate}</param>
+                <param name="gripper_speed_multiplier">${gripper_speed_multiplier}</param>
+                <param name="gripper_force_multiplier">${gripper_force_multiplier}</param>
+                <param name="gripper_max_speed">${gripper_max_speed}</param>
+                <param name="gripper_max_force">${gripper_max_force}</param>
+            </xacro:unless>
+        </hardware>
+    </xacro:macro>
+
+    <!-- A mimic joint the simulator owns: declared so /joint_states carries it,
+         but never commanded. Gazebo derives mimic joints itself, so it gets no
+         state interfaces either. -->
+    <xacro:macro name="robotiq_2f_sim_mimic_joint" params="name sim_gazebo">
+        <joint name="${name}">
+            <xacro:unless value="${sim_gazebo}">
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </xacro:unless>
+        </joint>
+    </xacro:macro>
+
+</robot>

--- a/grippers/robotiq_description/urdf/robotiq_2f_140_gripper.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_140_gripper.urdf.xacro
@@ -1,15 +1,5 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro" name="robotiq_gripper">
-    <!-- parameters -->
-    <xacro:arg name="use_fake_hardware" default="true" />
-    <xacro:arg name="com_port" default="/dev/ttyUSB0" />
-    <xacro:arg name="baudrate" default="115200" />
-
-    <!-- Import macros -->
-    <xacro:include filename="$(find robotiq_description)/urdf/robotiq_2f_140_macro.urdf.xacro" />
-
-    <link name="world" />
-    <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg com_port)" baudrate="$(arg baudrate)">
-        <origin xyz="0 0 0" rpy="0 0 0" />
-    </xacro:robotiq_gripper>
+    <xacro:arg name="model" default="2f_140" />
+    <xacro:include filename="$(find robotiq_description)/urdf/robotiq_2f_gripper.urdf.xacro" />
 </robot>

--- a/grippers/robotiq_description/urdf/robotiq_2f_85_gripper.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_85_gripper.urdf.xacro
@@ -1,15 +1,5 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro" name="robotiq_gripper">
-    <!-- parameters -->
-    <xacro:arg name="use_fake_hardware" default="true" />
-    <xacro:arg name="com_port" default="/dev/ttyUSB0" />
-    <xacro:arg name="baudrate" default="115200" />
-
-    <!-- Import macros -->
-    <xacro:include filename="$(find robotiq_description)/urdf/robotiq_2f_85_macro.urdf.xacro" />
-
-    <link name="world" />
-    <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg com_port)" baudrate="$(arg baudrate)">
-        <origin xyz="0 0 0" rpy="0 0 0" />
-    </xacro:robotiq_gripper>
+    <xacro:arg name="model" default="2f_85" />
+    <xacro:include filename="$(find robotiq_description)/urdf/robotiq_2f_gripper.urdf.xacro" />
 </robot>

--- a/grippers/robotiq_description/urdf/robotiq_2f_gripper.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_gripper.urdf.xacro
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://wiki.ros.org/xacro" name="robotiq_gripper">
+    <!-- parameters -->
+    <xacro:arg name="model" default="2f_85" />
+    <xacro:arg name="use_fake_hardware" default="true" />
+    <xacro:arg name="com_port" default="/dev/ttyUSB0" />
+    <xacro:arg name="baudrate" default="115200" />
+
+    <!-- Import macros -->
+    <xacro:include filename="$(find robotiq_description)/urdf/robotiq_$(arg model)_macro.urdf.xacro" />
+
+    <link name="world" />
+    <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg com_port)" baudrate="$(arg baudrate)">
+        <origin xyz="0 0 0" rpy="0 0 0" />
+    </xacro:robotiq_gripper>
+</robot>


### PR DESCRIPTION
## Summary
- The 2F-85 and 2F-140 top-level xacros were identical apart from the macro they include. The body now lives in `robotiq_2f_gripper.urdf.xacro`, keyed by a `model` arg (`2f_85` / `2f_140`); the two per-model files are 4-line wrappers, so existing `model:=` launch paths keep working.
- The `<hardware>` block of the two `ros2_control` xacros (plugin selection + driver params) was copied and had drifted: only the 2F-85 declared `use_dummy` and the Isaac `trigger_joint_command_threshold`. It now lives in one macro in `2f_common.ros2_control.xacro`, with a second macro for the state-only mimic joints the simulators need.
- Every launch argument added lately (`baudrate`, and the `sim_*` args in #47) had to be typed into four files; after this it is one top-level file plus one hardware macro. #47 will be rebased onto this.

## Behaviour
- 2F-85: expanded URDF byte-identical to `main` under mock, driver, sim_isaac and sim_gazebo (checked with `diff` on the `xacro` output).
- 2F-140: gains `use_dummy=false`, which is the driver's default when the param is absent, and the same Isaac threshold as the 2F-85. Nothing else changes.

## Test plan
- [x] `pytest test/test_ros2_control_urdf.py` passes (11 tests)
- [x] `xacro` output diffed against `main` for both models under all four hardware plugins
- [x] `ros2 launch robotiq_description robotiq_control.launch.py use_fake_hardware:=true` on Jazzy (in the `robotiq_ros2:jazzy` image with this branch's `urdf/`, `launch/`, `config/` mounted over the installed package): mock plugin loads, `joint_state_broadcaster`, `robotiq_gripper_controller` and `robotiq_activation_controller` all report `active`
- [x] same with `model:=.../robotiq_2f_140_gripper.urdf.xacro`: launches, but `robotiq_gripper_controller` fails to activate. Identical result on `main`, so pre-existing and unrelated to this PR: every `config/robotiq_controllers*.yaml` hardcodes `joint: robotiq_85_left_knuckle_joint`, and the 2F-140 drives `finger_joint`. Fixed in #49, which is stacked on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

