### PR TITLE
fix(robotiq_description): take the gripper joint from the launch so the 2F-140 activates

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,11 @@ In the combined launch the pad frames are TF-mounted on the gripper fingertip li
 ROS 2 `ros2_control` driver for Robotiq 2F adaptive grippers, under [`grippers/`](grippers/).
 
 Descriptions ship for the **2F-85** and the **2F-140**; `robotiq_control.launch.py` defaults to the
-2F-85, so pass `description_file` for a 2F-140. Hardware validation to date is on a 2F-85 — the
-2F-140 description ships untested against hardware.
+2F-85, so pass `model:=$(ros2 pkg prefix robotiq_description)/share/robotiq_description/urdf/robotiq_2f_140_gripper.urdf.xacro`
+for a 2F-140. The controller configs take the driven joint from the `gripper_joint` launch argument,
+which defaults to the 2F-85's `robotiq_85_left_knuckle_joint`, or to `finger_joint` when the model
+path names a 2F-140; set it explicitly for a custom description. Hardware validation to date is on a
+2F-85 — the 2F-140 description ships untested against hardware.
 
 The driver itself is model-agnostic: it needs a serial link and the `gripper_closed_position` of
 whatever is attached. A **Hand-E** therefore works once you supply a URDF for it, but no Hand-E

--- a/grippers/robotiq_description/config/robotiq_controllers.humble.yaml
+++ b/grippers/robotiq_description/config/robotiq_controllers.humble.yaml
@@ -27,7 +27,7 @@ controller_manager:
 
 robotiq_gripper_controller:
   ros__parameters:
-    joint: robotiq_85_left_knuckle_joint
+    joint: $(var gripper_joint)
 
     max_effort: 50.0   # TODO tune
 

--- a/grippers/robotiq_description/config/robotiq_controllers.yaml
+++ b/grippers/robotiq_description/config/robotiq_controllers.yaml
@@ -14,14 +14,14 @@ controller_manager:
 
 robotiq_gripper_controller:
   ros__parameters:
-    joint: robotiq_85_left_knuckle_joint
+    joint: $(var gripper_joint)
 
     # Enable effort control (replacement for use_effort_interface)
-    max_effort_interface: "robotiq_85_left_knuckle_joint/set_gripper_max_effort"
+    max_effort_interface: "$(var gripper_joint)/set_gripper_max_effort"
     max_effort: 50.0   # TODO tune
 
     # Enable velocity/speed control (replacement for use_speed_interface)
-    max_velocity_interface: "robotiq_85_left_knuckle_joint/set_gripper_max_velocity"
+    max_velocity_interface: "$(var gripper_joint)/set_gripper_max_velocity"
     max_velocity: 0.5    # TODO tune
 
     # Optional (recommended)

--- a/grippers/robotiq_description/launch/robotiq_control.launch.py
+++ b/grippers/robotiq_description/launch/robotiq_control.launch.py
@@ -27,14 +27,17 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import launch
+from launch.substitution import Substitution
 from launch.substitutions import (
     Command,
     FindExecutable,
     LaunchConfiguration,
     PathJoinSubstitution,
+    PythonExpression,
 )
 from launch.conditions import IfCondition
 import launch_ros
+from launch_ros.parameter_descriptions import ParameterFile
 import os
 
 # Humble has no parallel_gripper_controller package, so it needs its own
@@ -46,6 +49,25 @@ HUMBLE_CONTROLLERS_FILE = "robotiq_controllers.humble.yaml"
 def controllers_file_for_distro(distro):
     """Return the controller config file name to load on ROS distro `distro`."""
     return HUMBLE_CONTROLLERS_FILE if distro == "humble" else JAZZY_CONTROLLERS_FILE
+
+
+class ParameterFilePath(Substitution):
+    def __init__(self, parameter_file):
+        super().__init__()
+        self.parameter_file = parameter_file
+
+    def perform(self, context):
+        return str(self.parameter_file.evaluate(context))
+
+
+def default_gripper_joint():
+    return PythonExpression(
+        [
+            "'finger_joint' if '2f_140' in '",
+            LaunchConfiguration("model"),
+            "' else 'robotiq_85_left_knuckle_joint'",
+        ]
+    )
 
 
 def generate_launch_description():
@@ -77,6 +99,13 @@ def generate_launch_description():
     args.append(
         launch.actions.DeclareLaunchArgument(
             name="launch_rviz", default_value="false", description="Launch RViz?"
+        )
+    )
+    args.append(
+        launch.actions.DeclareLaunchArgument(
+            name="gripper_joint",
+            default_value=default_gripper_joint(),
+            description="Joint the gripper controller drives; defaults from the model",
         )
     )
     args.append(
@@ -125,8 +154,9 @@ def generate_launch_description():
     }
 
     controllers_file = controllers_file_for_distro(os.environ.get("ROS_DISTRO"))
-    initial_joint_controllers = PathJoinSubstitution(
-        [description_pkg_share, "config", controllers_file]
+    initial_joint_controllers = ParameterFile(
+        PathJoinSubstitution([description_pkg_share, "config", controllers_file]),
+        allow_substs=True,
     )
 
     control_node = launch_ros.actions.Node(
@@ -169,7 +199,7 @@ def generate_launch_description():
                 "--controller-manager",
                 "/controller_manager",
                 "--param-file",
-                initial_joint_controllers,
+                ParameterFilePath(initial_joint_controllers),
             ],
         )
 

--- a/grippers/robotiq_description/test/test_controller_config.py
+++ b/grippers/robotiq_description/test/test_controller_config.py
@@ -41,11 +41,16 @@ from pathlib import Path
 
 import pytest
 import yaml
+from launch import LaunchContext
 
 CONFIG_DIR = Path(__file__).parents[1] / "config"
 JAZZY_CONFIG = CONFIG_DIR / "robotiq_controllers.yaml"
 HUMBLE_CONFIG = CONFIG_DIR / "robotiq_controllers.humble.yaml"
 ALL_CONFIGS = (JAZZY_CONFIG, HUMBLE_CONFIG)
+
+# The configs name the joint through this launch placeholder so one file serves
+# both models; robotiq_control.launch.py resolves it via ParameterFile.
+JOINT_PLACEHOLDER = "$(var gripper_joint)"
 
 # Names exported by robotiq_driver's hardware interface. Kept in sync by
 # robotiq_driver's test_robotiq_gripper_hardware_interface, which asserts the
@@ -80,8 +85,18 @@ def load(config):
         return yaml.safe_load(f)
 
 
-def gripper_controller_params(config):
-    return load(config)["robotiq_gripper_controller"]["ros__parameters"]
+def gripper_controller_params(config, joint=JOINT):
+    params = load(config)["robotiq_gripper_controller"]["ros__parameters"]
+    return {
+        k: v.replace(JOINT_PLACEHOLDER, joint) if isinstance(v, str) else v
+        for k, v in params.items()
+    }
+
+
+def perform(substitution, **launch_configurations):
+    context = LaunchContext()
+    context.launch_configurations.update(launch_configurations)
+    return substitution.perform(context)
 
 
 def test_max_effort_interface_is_exported():
@@ -105,6 +120,33 @@ def test_humble_config_claims_no_unsupported_interfaces():
 @pytest.mark.parametrize("config", ALL_CONFIGS)
 def test_joint_matches_exported_interfaces(config):
     assert gripper_controller_params(config)["joint"] == JOINT
+
+
+@pytest.mark.parametrize("config", ALL_CONFIGS)
+def test_joint_is_left_to_the_launch(config):
+    # Hardcoding the 2F-85 joint here is why a 2F-140 launch used to fail to
+    # activate robotiq_gripper_controller.
+    raw = load(config)["robotiq_gripper_controller"]["ros__parameters"]
+    assert raw["joint"] == JOINT_PLACEHOLDER
+    assert JOINT not in yaml.safe_dump(raw)
+
+
+def test_launch_description_builds():
+    # Import errors in the launch file only surface when `ros2 launch` runs it.
+    load_launch_module().generate_launch_description()
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("/opt/share/urdf/robotiq_2f_85_gripper.urdf.xacro", JOINT),
+        ("/opt/share/urdf/robotiq_2f_140_gripper.urdf.xacro", "finger_joint"),
+        ("/home/me/my_cell.urdf.xacro", JOINT),
+    ],
+)
+def test_launch_defaults_the_joint_from_the_model(model, expected):
+    launch_module = load_launch_module()
+    assert perform(launch_module.default_gripper_joint(), model=model) == expected
 
 
 @pytest.mark.parametrize("config", ALL_CONFIGS)

--- a/grippers/robotiq_description/test/test_ros2_control_urdf.py
+++ b/grippers/robotiq_description/test/test_ros2_control_urdf.py
@@ -157,10 +157,12 @@ def test_gripper_controller_config_interfaces_exist_under_mock():
     params = yaml.safe_load(CONFIG.read_text())["robotiq_gripper_controller"][
         "ros__parameters"
     ]
-    claimed = {params["max_effort_interface"], params["max_velocity_interface"]}
-
     ros2_control = expand("robotiq_2f_85_gripper.urdf.xacro", use_fake_hardware=True)
     joint = MODELS["robotiq_2f_85_gripper.urdf.xacro"]
+    claimed = {
+        params[k].replace("$(var gripper_joint)", joint)
+        for k in ("max_effort_interface", "max_velocity_interface")
+    }
     available = {
         f"{joint}/{name}" for name in command_interfaces_of(ros2_control, joint)
     }

--- a/grippers/robotiq_description/urdf/2f_140.ros2_control.xacro
+++ b/grippers/robotiq_description/urdf/2f_140.ros2_control.xacro
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
+    <xacro:include filename="$(find robotiq_description)/urdf/2f_common.ros2_control.xacro" />
+
     <xacro:macro name="robotiq_gripper_ros2_control" params="
         name
         prefix
@@ -20,31 +22,20 @@
 
         <ros2_control name="${name}" type="system">
             <!-- Plugins -->
-            <hardware>
-                <xacro:if value="${sim_isaac}">
-                    <plugin>topic_based_ros2_control/TopicBasedSystem</plugin>
-                    <param name="joint_commands_topic">${isaac_joint_commands}</param>
-                    <param name="joint_states_topic">${isaac_joint_states}</param>
-                </xacro:if>
-                <xacro:if value="${sim_gazebo}">
-                    <plugin>gz_ros2_control/GazeboSimSystem</plugin>
-                </xacro:if>
-                <xacro:if value="${use_fake_hardware}">
-                    <plugin>mock_components/GenericSystem</plugin>
-                    <param name="mock_sensor_commands">${mock_sensor_commands}</param>
-                    <param name="state_following_offset">0.0</param>
-                </xacro:if>
-                <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_isaac}">
-                    <plugin>robotiq_driver/RobotiqGripperHardwareInterface</plugin>
-                    <param name="gripper_closed_position">${gripper_closed_position}</param>
-                    <param name="COM_port">${com_port}</param>
-                    <param name="baudrate">${baudrate}</param>
-                    <param name="gripper_speed_multiplier">${gripper_speed_multiplier}</param>
-                    <param name="gripper_force_multiplier">${gripper_force_multiplier}</param>
-                    <param name="gripper_max_speed">${gripper_max_speed}</param>
-                    <param name="gripper_max_force">${gripper_max_force}</param>
-                </xacro:unless>
-            </hardware>
+            <xacro:robotiq_2f_hardware
+                sim_gazebo="${sim_gazebo}"
+                sim_isaac="${sim_isaac}"
+                isaac_joint_commands="${isaac_joint_commands}"
+                isaac_joint_states="${isaac_joint_states}"
+                use_fake_hardware="${use_fake_hardware}"
+                mock_sensor_commands="${mock_sensor_commands}"
+                com_port="${com_port}"
+                baudrate="${baudrate}"
+                gripper_speed_multiplier="${gripper_speed_multiplier}"
+                gripper_force_multiplier="${gripper_force_multiplier}"
+                gripper_max_speed="${gripper_max_speed}"
+                gripper_max_force="${gripper_max_force}"
+                gripper_closed_position="${gripper_closed_position}"/>
 
             <!-- Joint interfaces -->
             <!-- With Gazebo or Hardware, they handle mimic joints, so we only need this command interface activated -->
@@ -66,36 +57,11 @@
             </joint>
             <!-- When simulating we need to include the rest of the gripper joints -->
             <xacro:if value="${sim_isaac or sim_gazebo}">
-                <joint name="${prefix}left_inner_knuckle_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}left_inner_finger_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}right_outer_knuckle_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}right_inner_knuckle_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}right_inner_finger_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}left_inner_knuckle_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}left_inner_finger_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}right_outer_knuckle_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}right_inner_knuckle_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}right_inner_finger_joint" sim_gazebo="${sim_gazebo}"/>
             </xacro:if>
 
             <!-- Only add this with fake hardware mode -->

--- a/grippers/robotiq_description/urdf/2f_85.ros2_control.xacro
+++ b/grippers/robotiq_description/urdf/2f_85.ros2_control.xacro
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
+    <xacro:include filename="$(find robotiq_description)/urdf/2f_common.ros2_control.xacro" />
+
     <xacro:macro name="robotiq_gripper_ros2_control" params="
         name
         prefix
@@ -20,36 +22,20 @@
 
         <ros2_control name="${name}" type="system">
             <!-- Plugins -->
-            <hardware>
-
-                <!-- Set use_dummy to true to connect to a dummy driver for testing purposes. -->
-                <param name="use_dummy">false</param>
-
-                <xacro:if value="${sim_isaac}">
-                    <plugin>topic_based_ros2_control/TopicBasedSystem</plugin>
-                    <param name="joint_commands_topic">${isaac_joint_commands}</param>
-                    <param name="joint_states_topic">${isaac_joint_states}</param>
-                    <param name="trigger_joint_command_threshold">0.02</param>
-                </xacro:if>
-                <xacro:if value="${sim_gazebo}">
-                    <plugin>gz_ros2_control/GazeboSimSystem</plugin>
-                </xacro:if>
-                <xacro:if value="${use_fake_hardware}">
-                    <plugin>mock_components/GenericSystem</plugin>
-                    <param name="mock_sensor_commands">${mock_sensor_commands}</param>
-                    <param name="state_following_offset">0.0</param>
-                </xacro:if>
-                <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_isaac}">
-                    <plugin>robotiq_driver/RobotiqGripperHardwareInterface</plugin>
-                    <param name="gripper_closed_position">${gripper_closed_position}</param>
-                    <param name="COM_port">${com_port}</param>
-                    <param name="baudrate">${baudrate}</param>
-                    <param name="gripper_speed_multiplier">${gripper_speed_multiplier}</param>
-                    <param name="gripper_force_multiplier">${gripper_force_multiplier}</param>
-                    <param name="gripper_max_speed">${gripper_max_speed}</param>
-                    <param name="gripper_max_force">${gripper_max_force}</param>
-                </xacro:unless>
-            </hardware>
+            <xacro:robotiq_2f_hardware
+                sim_gazebo="${sim_gazebo}"
+                sim_isaac="${sim_isaac}"
+                isaac_joint_commands="${isaac_joint_commands}"
+                isaac_joint_states="${isaac_joint_states}"
+                use_fake_hardware="${use_fake_hardware}"
+                mock_sensor_commands="${mock_sensor_commands}"
+                com_port="${com_port}"
+                baudrate="${baudrate}"
+                gripper_speed_multiplier="${gripper_speed_multiplier}"
+                gripper_force_multiplier="${gripper_force_multiplier}"
+                gripper_max_speed="${gripper_max_speed}"
+                gripper_max_force="${gripper_max_force}"
+                gripper_closed_position="${gripper_closed_position}"/>
 
             <!-- Joint interfaces -->
             <!-- With Gazebo or Hardware, they handle mimic joints, so we only need this command interface activated -->
@@ -78,36 +64,11 @@
             </joint>
             <!-- When simulating we need to include the rest of the gripper joints -->
             <xacro:if value="${sim_isaac or sim_gazebo}">
-                <joint name="${prefix}robotiq_85_right_knuckle_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}robotiq_85_left_inner_knuckle_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}robotiq_85_right_inner_knuckle_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}robotiq_85_left_finger_tip_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
-                <joint name="${prefix}robotiq_85_right_finger_tip_joint">
-                    <xacro:unless value="${sim_gazebo}">
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
-                    </xacro:unless>
-                </joint>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}robotiq_85_right_knuckle_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}robotiq_85_left_inner_knuckle_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}robotiq_85_right_inner_knuckle_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}robotiq_85_left_finger_tip_joint" sim_gazebo="${sim_gazebo}"/>
+                <xacro:robotiq_2f_sim_mimic_joint name="${prefix}robotiq_85_right_finger_tip_joint" sim_gazebo="${sim_gazebo}"/>
             </xacro:if>
 
             <!-- Only add this with fake hardware mode -->

--- a/grippers/robotiq_description/urdf/2f_common.ros2_control.xacro
+++ b/grippers/robotiq_description/urdf/2f_common.ros2_control.xacro
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+    <!-- The <hardware> block is the same for every 2F model: only the joint
+         names and the per-model defaults differ, and those stay in
+         2f_85.ros2_control.xacro / 2f_140.ros2_control.xacro. -->
+    <xacro:macro name="robotiq_2f_hardware" params="
+        sim_gazebo
+        sim_isaac
+        isaac_joint_commands
+        isaac_joint_states
+        use_fake_hardware
+        mock_sensor_commands
+        com_port
+        baudrate
+        gripper_speed_multiplier
+        gripper_force_multiplier
+        gripper_max_speed
+        gripper_max_force
+        gripper_closed_position">
+
+        <hardware>
+
+            <!-- Set use_dummy to true to connect to a dummy driver for testing purposes. -->
+            <param name="use_dummy">false</param>
+
+            <xacro:if value="${sim_isaac}">
+                <plugin>topic_based_ros2_control/TopicBasedSystem</plugin>
+                <param name="joint_commands_topic">${isaac_joint_commands}</param>
+                <param name="joint_states_topic">${isaac_joint_states}</param>
+                <param name="trigger_joint_command_threshold">0.02</param>
+            </xacro:if>
+            <xacro:if value="${sim_gazebo}">
+                <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+            </xacro:if>
+            <xacro:if value="${use_fake_hardware}">
+                <plugin>mock_components/GenericSystem</plugin>
+                <param name="mock_sensor_commands">${mock_sensor_commands}</param>
+                <param name="state_following_offset">0.0</param>
+            </xacro:if>
+            <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_isaac}">
+                <plugin>robotiq_driver/RobotiqGripperHardwareInterface</plugin>
+                <param name="gripper_closed_position">${gripper_closed_position}</param>
+                <param name="COM_port">${com_port}</param>
+                <param name="baudrate">${baudrate}</param>
+                <param name="gripper_speed_multiplier">${gripper_speed_multiplier}</param>
+                <param name="gripper_force_multiplier">${gripper_force_multiplier}</param>
+                <param name="gripper_max_speed">${gripper_max_speed}</param>
+                <param name="gripper_max_force">${gripper_max_force}</param>
+            </xacro:unless>
+        </hardware>
+    </xacro:macro>
+
+    <!-- A mimic joint the simulator owns: declared so /joint_states carries it,
+         but never commanded. Gazebo derives mimic joints itself, so it gets no
+         state interfaces either. -->
+    <xacro:macro name="robotiq_2f_sim_mimic_joint" params="name sim_gazebo">
+        <joint name="${name}">
+            <xacro:unless value="${sim_gazebo}">
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </xacro:unless>
+        </joint>
+    </xacro:macro>
+
+</robot>

--- a/grippers/robotiq_description/urdf/robotiq_2f_140_gripper.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_140_gripper.urdf.xacro
@@ -1,15 +1,5 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro" name="robotiq_gripper">
-    <!-- parameters -->
-    <xacro:arg name="use_fake_hardware" default="true" />
-    <xacro:arg name="com_port" default="/dev/ttyUSB0" />
-    <xacro:arg name="baudrate" default="115200" />
-
-    <!-- Import macros -->
-    <xacro:include filename="$(find robotiq_description)/urdf/robotiq_2f_140_macro.urdf.xacro" />
-
-    <link name="world" />
-    <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg com_port)" baudrate="$(arg baudrate)">
-        <origin xyz="0 0 0" rpy="0 0 0" />
-    </xacro:robotiq_gripper>
+    <xacro:arg name="model" default="2f_140" />
+    <xacro:include filename="$(find robotiq_description)/urdf/robotiq_2f_gripper.urdf.xacro" />
 </robot>

--- a/grippers/robotiq_description/urdf/robotiq_2f_85_gripper.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_85_gripper.urdf.xacro
@@ -1,15 +1,5 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro" name="robotiq_gripper">
-    <!-- parameters -->
-    <xacro:arg name="use_fake_hardware" default="true" />
-    <xacro:arg name="com_port" default="/dev/ttyUSB0" />
-    <xacro:arg name="baudrate" default="115200" />
-
-    <!-- Import macros -->
-    <xacro:include filename="$(find robotiq_description)/urdf/robotiq_2f_85_macro.urdf.xacro" />
-
-    <link name="world" />
-    <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg com_port)" baudrate="$(arg baudrate)">
-        <origin xyz="0 0 0" rpy="0 0 0" />
-    </xacro:robotiq_gripper>
+    <xacro:arg name="model" default="2f_85" />
+    <xacro:include filename="$(find robotiq_description)/urdf/robotiq_2f_gripper.urdf.xacro" />
 </robot>

--- a/grippers/robotiq_description/urdf/robotiq_2f_gripper.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_gripper.urdf.xacro
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://wiki.ros.org/xacro" name="robotiq_gripper">
+    <!-- parameters -->
+    <xacro:arg name="model" default="2f_85" />
+    <xacro:arg name="use_fake_hardware" default="true" />
+    <xacro:arg name="com_port" default="/dev/ttyUSB0" />
+    <xacro:arg name="baudrate" default="115200" />
+
+    <!-- Import macros -->
+    <xacro:include filename="$(find robotiq_description)/urdf/robotiq_$(arg model)_macro.urdf.xacro" />
+
+    <link name="world" />
+    <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg com_port)" baudrate="$(arg baudrate)">
+        <origin xyz="0 0 0" rpy="0 0 0" />
+    </xacro:robotiq_gripper>
+</robot>


### PR DESCRIPTION
## Summary
- Both controller configs hardcoded the 2F-85's `robotiq_85_left_knuckle_joint` (as `joint`, `max_effort_interface`, `max_velocity_interface`), so a 2F-140 launch loaded `robotiq_gripper_controller` against a joint that does not exist and it never activated. Found while testing #48.
- The configs now name the joint through `$(var gripper_joint)`, resolved by `launch_ros` `ParameterFile(allow_substs=True)` for `ros2_control_node` and for each spawner's `--param-file`.
- New `gripper_joint` launch argument. Default: the 2F-85 joint, or `finger_joint` when the `model` path names a 2F-140, so the one-argument 2F-140 bringup the README describes actually works. Custom descriptions set it explicitly.
- README: the 2F-140 paragraph said to pass `description_file`; the argument is `model`. Fixed and documents `gripper_joint`.

## Behaviour change
The config files are no longer usable on their own: fed straight to `ros2_control_node` or a spawner without going through `robotiq_control.launch.py`, the joint stays the literal `$(var gripper_joint)` and the controller does not activate. Nothing in this repo does that (the tactile launch includes the control launch), but a downstream launch file pointing at our YAML would have to pass through the launch or set the joint itself.

Stacked on #48 (its two commits show here until it merges; GitHub cannot base a fork PR on another fork branch). #47 is rebased onto this.

## Test plan
- [x] `pytest test/` in `robotiq_description`: 30 passed, including a new check that the configs no longer hardcode the joint, that the launch defaults it from the model path, and that the launch description builds (the last one catches missing imports that only surface under `ros2 launch`)
- [x] `ros2 launch robotiq_description robotiq_control.launch.py use_fake_hardware:=true` in the `robotiq_ros2:jazzy` image (this branch's `urdf/`, `launch/`, `config/` mounted over the installed package): all three controllers `active`
- [x] same with `model:=.../robotiq_2f_140_gripper.urdf.xacro`: all three controllers `active` (was `inactive` for `robotiq_gripper_controller` on `main`); `ros2 param get /robotiq_gripper_controller joint` reads `finger_joint`
- [x] Humble: `ros:humble-ros-base` + `ros-humble-ros2-control` / `ros-humble-ros2-controllers`, `robotiq_controllers` and `robotiq_description` built from this branch. Both models with `use_fake_hardware:=true`: all three controllers `active` (`position_controllers/GripperActionController` from `gripper_controllers`); `joint` reads `robotiq_85_left_knuckle_joint` for the 2F-85 and `finger_joint` for the 2F-140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

