### PR TITLE
fix(robotiq_description): take the gripper joint from the launch so the 2F-140 activates

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,11 @@ In the combined launch the pad frames are TF-mounted on the gripper fingertip li
 ROS 2 `ros2_control` driver for Robotiq 2F adaptive grippers, under [`grippers/`](grippers/).
 
 Descriptions ship for the **2F-85** and the **2F-140**; `robotiq_control.launch.py` defaults to the
-2F-85, so pass `description_file` for a 2F-140. Hardware validation to date is on a 2F-85 — the
-2F-140 description ships untested against hardware.
+2F-85, so pass `model:=$(ros2 pkg prefix robotiq_description)/share/robotiq_description/urdf/robotiq_2f_140_gripper.urdf.xacro`
+for a 2F-140. The controller configs take the driven joint from the `gripper_joint` launch argument,
+which defaults to the 2F-85's `robotiq_85_left_knuckle_joint`, or to `finger_joint` when the model
+path names a 2F-140; set it explicitly for a custom description. Hardware validation to date is on a
+2F-85 — the 2F-140 description ships untested against hardware.
 
 The driver itself is model-agnostic: it needs a serial link and the `gripper_closed_position` of
 whatever is attached. A **Hand-E** therefore works once you supply a URDF for it, but no Hand-E

--- a/README.md
+++ b/README.md
@@ -133,11 +133,12 @@ In the combined launch the pad frames are TF-mounted on the gripper fingertip li
 ROS 2 `ros2_control` driver for Robotiq 2F adaptive grippers, under [`grippers/`](grippers/).
 
 Descriptions ship for the **2F-85** and the **2F-140**; `robotiq_control.launch.py` defaults to the
-2F-85, so pass `model:=$(ros2 pkg prefix robotiq_description)/share/robotiq_description/urdf/robotiq_2f_140_gripper.urdf.xacro`
-for a 2F-140. The controller configs take the driven joint from the `gripper_joint` launch argument,
-which defaults to the 2F-85's `robotiq_85_left_knuckle_joint`, or to `finger_joint` when the model
-path names a 2F-140; set it explicitly for a custom description. Hardware validation to date is on a
-2F-85 — the 2F-140 description ships untested against hardware.
+2F-85, so pass `gripper_model:=2f_140` for a 2F-140. That argument selects the gripper macro in the
+xacro and the joint the controller drives (`robotiq_85_left_knuckle_joint` or `finger_joint`); a
+custom description keeps `model:=<path>` and sets `gripper_joint` explicitly. The controller configs
+in `config/` write that joint as `$(var gripper_joint)`, which only the launch resolves — loaded
+directly into your own `ros2_control_node` they are not valid as they stand. Hardware validation to
+date is on a 2F-85 — the 2F-140 description ships untested against hardware.
 
 The driver itself is model-agnostic: it needs a serial link and the `gripper_closed_position` of
 whatever is attached. A **Hand-E** therefore works once you supply a URDF for it, but no Hand-E

--- a/grippers/robotiq_description/config/robotiq_controllers.humble.yaml
+++ b/grippers/robotiq_description/config/robotiq_controllers.humble.yaml
@@ -27,7 +27,7 @@ controller_manager:
 
 robotiq_gripper_controller:
   ros__parameters:
-    joint: robotiq_85_left_knuckle_joint
+    joint: $(var gripper_joint)
 
     max_effort: 50.0   # TODO tune
 

--- a/grippers/robotiq_description/config/robotiq_controllers.yaml
+++ b/grippers/robotiq_description/config/robotiq_controllers.yaml
@@ -14,14 +14,14 @@ controller_manager:
 
 robotiq_gripper_controller:
   ros__parameters:
-    joint: robotiq_85_left_knuckle_joint
+    joint: $(var gripper_joint)
 
     # Enable effort control (replacement for use_effort_interface)
-    max_effort_interface: "robotiq_85_left_knuckle_joint/set_gripper_max_effort"
+    max_effort_interface: "$(var gripper_joint)/set_gripper_max_effort"
     max_effort: 50.0   # TODO tune
 
     # Enable velocity/speed control (replacement for use_speed_interface)
-    max_velocity_interface: "robotiq_85_left_knuckle_joint/set_gripper_max_velocity"
+    max_velocity_interface: "$(var gripper_joint)/set_gripper_max_velocity"
     max_velocity: 0.5    # TODO tune
 
     # Optional (recommended)

--- a/grippers/robotiq_description/launch/robotiq_control.launch.py
+++ b/grippers/robotiq_description/launch/robotiq_control.launch.py
@@ -27,14 +27,17 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import launch
+from launch.substitution import Substitution
 from launch.substitutions import (
     Command,
     FindExecutable,
     LaunchConfiguration,
     PathJoinSubstitution,
+    PythonExpression,
 )
 from launch.conditions import IfCondition
 import launch_ros
+from launch_ros.parameter_descriptions import ParameterFile
 import os
 
 # Humble has no parallel_gripper_controller package, so it needs its own
@@ -46,6 +49,25 @@ HUMBLE_CONTROLLERS_FILE = "robotiq_controllers.humble.yaml"
 def controllers_file_for_distro(distro):
     """Return the controller config file name to load on ROS distro `distro`."""
     return HUMBLE_CONTROLLERS_FILE if distro == "humble" else JAZZY_CONTROLLERS_FILE
+
+
+class ParameterFilePath(Substitution):
+    def __init__(self, parameter_file):
+        super().__init__()
+        self.parameter_file = parameter_file
+
+    def perform(self, context):
+        return str(self.parameter_file.evaluate(context))
+
+
+def default_gripper_joint():
+    return PythonExpression(
+        [
+            "'finger_joint' if '2f_140' in '",
+            LaunchConfiguration("model"),
+            "' else 'robotiq_85_left_knuckle_joint'",
+        ]
+    )
 
 
 def generate_launch_description():
@@ -77,6 +99,13 @@ def generate_launch_description():
     args.append(
         launch.actions.DeclareLaunchArgument(
             name="launch_rviz", default_value="false", description="Launch RViz?"
+        )
+    )
+    args.append(
+        launch.actions.DeclareLaunchArgument(
+            name="gripper_joint",
+            default_value=default_gripper_joint(),
+            description="Joint the gripper controller drives; defaults from the model",
         )
     )
     args.append(
@@ -125,8 +154,9 @@ def generate_launch_description():
     }
 
     controllers_file = controllers_file_for_distro(os.environ.get("ROS_DISTRO"))
-    initial_joint_controllers = PathJoinSubstitution(
-        [description_pkg_share, "config", controllers_file]
+    initial_joint_controllers = ParameterFile(
+        PathJoinSubstitution([description_pkg_share, "config", controllers_file]),
+        allow_substs=True,
     )
 
     control_node = launch_ros.actions.Node(
@@ -169,7 +199,7 @@ def generate_launch_description():
                 "--controller-manager",
                 "/controller_manager",
                 "--param-file",
-                initial_joint_controllers,
+                ParameterFilePath(initial_joint_controllers),
             ],
         )
 

--- a/grippers/robotiq_description/launch/robotiq_control.launch.py
+++ b/grippers/robotiq_description/launch/robotiq_control.launch.py
@@ -33,7 +33,6 @@ from launch.substitutions import (
     FindExecutable,
     LaunchConfiguration,
     PathJoinSubstitution,
-    PythonExpression,
 )
 from launch.conditions import IfCondition
 import launch_ros
@@ -60,12 +59,42 @@ class ParameterFilePath(Substitution):
         return str(self.parameter_file.evaluate(context))
 
 
-def default_gripper_joint():
-    return PythonExpression(
+# Joint carrying the position command, per gripper_model. The launch argument
+# is restricted to these keys, so an unknown model fails at launch instead of
+# as a controller that never activates.
+GRIPPER_JOINTS = {
+    "2f_85": "robotiq_85_left_knuckle_joint",
+    "2f_140": "finger_joint",
+}
+
+
+class DefaultGripperJoint(Substitution):
+    def __init__(self, gripper_model):
+        super().__init__()
+        self.gripper_model = gripper_model
+
+    def perform(self, context):
+        return GRIPPER_JOINTS[self.gripper_model.perform(context)]
+
+
+def xacro_command():
+    return Command(
         [
-            "'finger_joint' if '2f_140' in '",
+            PathJoinSubstitution([FindExecutable(name="xacro")]),
+            " ",
             LaunchConfiguration("model"),
-            "' else 'robotiq_85_left_knuckle_joint'",
+            " ",
+            "gripper_model:=",
+            LaunchConfiguration("gripper_model"),
+            " ",
+            "use_fake_hardware:=",
+            LaunchConfiguration("use_fake_hardware"),
+            " ",
+            "com_port:=",
+            LaunchConfiguration("com_port"),
+            " ",
+            "baudrate:=",
+            LaunchConfiguration("baudrate"),
         ]
     )
 
@@ -103,9 +132,17 @@ def generate_launch_description():
     )
     args.append(
         launch.actions.DeclareLaunchArgument(
+            name="gripper_model",
+            default_value="2f_85",
+            choices=sorted(GRIPPER_JOINTS),
+            description="Gripper the description and the controller are built for",
+        )
+    )
+    args.append(
+        launch.actions.DeclareLaunchArgument(
             name="gripper_joint",
-            default_value=default_gripper_joint(),
-            description="Joint the gripper controller drives; defaults from the model",
+            default_value=DefaultGripperJoint(LaunchConfiguration("gripper_model")),
+            description="Joint the gripper controller drives; defaults from gripper_model",
         )
     )
     args.append(
@@ -130,26 +167,9 @@ def generate_launch_description():
         )
     )
 
-    robot_description_content = Command(
-        [
-            PathJoinSubstitution([FindExecutable(name="xacro")]),
-            " ",
-            LaunchConfiguration("model"),
-            " ",
-            "use_fake_hardware:=",
-            LaunchConfiguration("use_fake_hardware"),
-            " ",
-            "com_port:=",
-            LaunchConfiguration("com_port"),
-            " ",
-            "baudrate:=",
-            LaunchConfiguration("baudrate"),
-        ]
-    )
-
     robot_description_param = {
         "robot_description": launch_ros.parameter_descriptions.ParameterValue(
-            robot_description_content, value_type=str
+            xacro_command(), value_type=str
         )
     }
 

--- a/grippers/robotiq_description/test/test_controller_config.py
+++ b/grippers/robotiq_description/test/test_controller_config.py
@@ -41,11 +41,16 @@ from pathlib import Path
 
 import pytest
 import yaml
+from launch import LaunchContext
 
 CONFIG_DIR = Path(__file__).parents[1] / "config"
 JAZZY_CONFIG = CONFIG_DIR / "robotiq_controllers.yaml"
 HUMBLE_CONFIG = CONFIG_DIR / "robotiq_controllers.humble.yaml"
 ALL_CONFIGS = (JAZZY_CONFIG, HUMBLE_CONFIG)
+
+# The configs name the joint through this launch placeholder so one file serves
+# both models; robotiq_control.launch.py resolves it via ParameterFile.
+JOINT_PLACEHOLDER = "$(var gripper_joint)"
 
 # Names exported by robotiq_driver's hardware interface. Kept in sync by
 # robotiq_driver's test_robotiq_gripper_hardware_interface, which asserts the
@@ -80,8 +85,18 @@ def load(config):
         return yaml.safe_load(f)
 
 
-def gripper_controller_params(config):
-    return load(config)["robotiq_gripper_controller"]["ros__parameters"]
+def gripper_controller_params(config, joint=JOINT):
+    params = load(config)["robotiq_gripper_controller"]["ros__parameters"]
+    return {
+        k: v.replace(JOINT_PLACEHOLDER, joint) if isinstance(v, str) else v
+        for k, v in params.items()
+    }
+
+
+def perform(substitution, **launch_configurations):
+    context = LaunchContext()
+    context.launch_configurations.update(launch_configurations)
+    return substitution.perform(context)
 
 
 def test_max_effort_interface_is_exported():
@@ -105,6 +120,33 @@ def test_humble_config_claims_no_unsupported_interfaces():
 @pytest.mark.parametrize("config", ALL_CONFIGS)
 def test_joint_matches_exported_interfaces(config):
     assert gripper_controller_params(config)["joint"] == JOINT
+
+
+@pytest.mark.parametrize("config", ALL_CONFIGS)
+def test_joint_is_left_to_the_launch(config):
+    # Hardcoding the 2F-85 joint here is why a 2F-140 launch used to fail to
+    # activate robotiq_gripper_controller.
+    raw = load(config)["robotiq_gripper_controller"]["ros__parameters"]
+    assert raw["joint"] == JOINT_PLACEHOLDER
+    assert JOINT not in yaml.safe_dump(raw)
+
+
+def test_launch_description_builds():
+    # Import errors in the launch file only surface when `ros2 launch` runs it.
+    load_launch_module().generate_launch_description()
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("/opt/share/urdf/robotiq_2f_85_gripper.urdf.xacro", JOINT),
+        ("/opt/share/urdf/robotiq_2f_140_gripper.urdf.xacro", "finger_joint"),
+        ("/home/me/my_cell.urdf.xacro", JOINT),
+    ],
+)
+def test_launch_defaults_the_joint_from_the_model(model, expected):
+    launch_module = load_launch_module()
+    assert perform(launch_module.default_gripper_joint(), model=model) == expected
 
 
 @pytest.mark.parametrize("config", ALL_CONFIGS)

--- a/grippers/robotiq_description/test/test_controller_config.py
+++ b/grippers/robotiq_description/test/test_controller_config.py
@@ -42,6 +42,8 @@ from pathlib import Path
 import pytest
 import yaml
 from launch import LaunchContext
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 
 CONFIG_DIR = Path(__file__).parents[1] / "config"
 JAZZY_CONFIG = CONFIG_DIR / "robotiq_controllers.yaml"
@@ -137,16 +139,41 @@ def test_launch_description_builds():
 
 
 @pytest.mark.parametrize(
-    "model,expected",
-    [
-        ("/opt/share/urdf/robotiq_2f_85_gripper.urdf.xacro", JOINT),
-        ("/opt/share/urdf/robotiq_2f_140_gripper.urdf.xacro", "finger_joint"),
-        ("/home/me/my_cell.urdf.xacro", JOINT),
-    ],
+    "gripper_model,expected",
+    [("2f_85", JOINT), ("2f_140", "finger_joint")],
 )
-def test_launch_defaults_the_joint_from_the_model(model, expected):
+def test_launch_defaults_the_joint_from_the_gripper_model(gripper_model, expected):
     launch_module = load_launch_module()
-    assert perform(launch_module.default_gripper_joint(), model=model) == expected
+    joint = launch_module.DefaultGripperJoint(LaunchConfiguration("gripper_model"))
+    assert perform(joint, gripper_model=gripper_model) == expected
+
+
+def test_launch_restricts_gripper_model_to_the_known_joints():
+    launch_module = load_launch_module()
+    description = launch_module.generate_launch_description()
+    declared = {
+        action.name: action
+        for action in description.entities
+        if isinstance(action, DeclareLaunchArgument)
+    }
+    assert declared["gripper_model"].choices == sorted(launch_module.GRIPPER_JOINTS)
+
+
+def test_launch_forwards_the_gripper_model_to_xacro():
+    # The xacro-level gripper_model selects the macro, so the launch-level one
+    # has to reach it or the two could name different grippers.
+    launch_module = load_launch_module()
+    command = launch_module.xacro_command()
+    context = LaunchContext()
+    context.launch_configurations.update(
+        model="/x/gripper.urdf.xacro",
+        gripper_model="2f_140",
+        use_fake_hardware="true",
+        com_port="/dev/null",
+        baudrate="115200",
+    )
+    rendered = "".join(s.perform(context) for s in command.command)
+    assert "gripper_model:=2f_140" in rendered
 
 
 @pytest.mark.parametrize("config", ALL_CONFIGS)

--- a/grippers/robotiq_description/test/test_controller_config.py
+++ b/grippers/robotiq_description/test/test_controller_config.py
@@ -54,15 +54,20 @@ ALL_CONFIGS = (JAZZY_CONFIG, HUMBLE_CONFIG)
 # both models; robotiq_control.launch.py resolves it via ParameterFile.
 JOINT_PLACEHOLDER = "$(var gripper_joint)"
 
-# Names exported by robotiq_driver's hardware interface. Kept in sync by
-# robotiq_driver's test_robotiq_gripper_hardware_interface, which asserts the
-# hardware exports exactly these.
+# Names exported by robotiq_driver's hardware interface for the joint it is
+# given. Kept in sync by robotiq_driver's test_robotiq_gripper_hardware_interface,
+# which asserts the hardware exports exactly these.
 JOINT = "robotiq_85_left_knuckle_joint"
-EXPORTED_COMMAND_INTERFACES = {
-    f"{JOINT}/position",
-    f"{JOINT}/set_gripper_max_velocity",
-    f"{JOINT}/set_gripper_max_effort",
-}
+GRIPPER_JOINTS = (JOINT, "finger_joint")
+
+
+def exported_command_interfaces(joint):
+    return {
+        f"{joint}/position",
+        f"{joint}/set_gripper_max_velocity",
+        f"{joint}/set_gripper_max_effort",
+    }
+
 
 # Plugin the launch expects per distro. Humble's stock controller takes a
 # control_msgs/GripperCommand goal, matching PickNik's humble branch; Jazzy and
@@ -101,14 +106,13 @@ def perform(substitution, **launch_configurations):
     return substitution.perform(context)
 
 
-def test_max_effort_interface_is_exported():
-    params = gripper_controller_params(JAZZY_CONFIG)
-    assert params["max_effort_interface"] in EXPORTED_COMMAND_INTERFACES
-
-
-def test_max_velocity_interface_is_exported():
-    params = gripper_controller_params(JAZZY_CONFIG)
-    assert params["max_velocity_interface"] in EXPORTED_COMMAND_INTERFACES
+@pytest.mark.parametrize("joint", GRIPPER_JOINTS)
+def test_claimed_interfaces_follow_the_joint(joint):
+    # The two extra interfaces are named "<joint>/<interface>", so they must
+    # track whichever joint the launch resolves, not the 2F-85's.
+    params = gripper_controller_params(JAZZY_CONFIG, joint)
+    claimed = {params["max_effort_interface"], params["max_velocity_interface"]}
+    assert claimed <= exported_command_interfaces(joint)
 
 
 def test_humble_config_claims_no_unsupported_interfaces():
@@ -117,11 +121,6 @@ def test_humble_config_claims_no_unsupported_interfaces():
     params = gripper_controller_params(HUMBLE_CONFIG)
     assert "max_effort_interface" not in params
     assert "max_velocity_interface" not in params
-
-
-@pytest.mark.parametrize("config", ALL_CONFIGS)
-def test_joint_matches_exported_interfaces(config):
-    assert gripper_controller_params(config)["joint"] == JOINT
 
 
 @pytest.mark.parametrize("config", ALL_CONFIGS)

--- a/grippers/robotiq_description/test/test_ros2_control_urdf.py
+++ b/grippers/robotiq_description/test/test_ros2_control_urdf.py
@@ -157,10 +157,12 @@ def test_gripper_controller_config_interfaces_exist_under_mock():
     params = yaml.safe_load(CONFIG.read_text())["robotiq_gripper_controller"][
         "ros__parameters"
     ]
-    claimed = {params["max_effort_interface"], params["max_velocity_interface"]}
-
     ros2_control = expand("robotiq_2f_85_gripper.urdf.xacro", use_fake_hardware=True)
     joint = MODELS["robotiq_2f_85_gripper.urdf.xacro"]
+    claimed = {
+        params[k].replace("$(var gripper_joint)", joint)
+        for k in ("max_effort_interface", "max_velocity_interface")
+    }
     available = {
         f"{joint}/{name}" for name in command_interfaces_of(ros2_control, joint)
     }

--- a/grippers/robotiq_description/test/test_ros2_control_urdf.py
+++ b/grippers/robotiq_description/test/test_ros2_control_urdf.py
@@ -150,15 +150,15 @@ def test_mock_publishes_the_same_joints_as_hardware(model, joint):
 
 
 @requires_xacro
-def test_gripper_controller_config_interfaces_exist_under_mock():
+@pytest.mark.parametrize("model,joint", MODELS.items())
+def test_gripper_controller_config_interfaces_exist_under_mock(model, joint):
     # Ties config/robotiq_controllers.yaml to the mock URDF: these two parameters
     # name "<joint>/<interface>" pairs the controller claims, and an unmatched name
     # is why the controller used to fail to activate with use_fake_hardware:=true.
     params = yaml.safe_load(CONFIG.read_text())["robotiq_gripper_controller"][
         "ros__parameters"
     ]
-    ros2_control = expand("robotiq_2f_85_gripper.urdf.xacro", use_fake_hardware=True)
-    joint = MODELS["robotiq_2f_85_gripper.urdf.xacro"]
+    ros2_control = expand(model, use_fake_hardware=True)
     claimed = {
         params[k].replace("$(var gripper_joint)", joint)
         for k in ("max_effort_interface", "max_velocity_interface")


### PR DESCRIPTION
## Summary
- Both controller configs hardcoded the 2F-85's `robotiq_85_left_knuckle_joint` (as `joint`, `max_effort_interface`, `max_velocity_interface`), so a 2F-140 launch loaded `robotiq_gripper_controller` against a joint that does not exist and it never activated. Found while testing #50.
- The configs now name the joint through `$(var gripper_joint)`, resolved by `launch_ros` `ParameterFile(allow_substs=True)` for `ros2_control_node` and for each spawner's `--param-file`.
- New `gripper_model` launch argument (`2f_85` / `2f_140`) selects the gripper macro in the xacro and the joint the controller drives, so a 2F-140 bringup is `gripper_model:=2f_140`. `gripper_joint` still exists for custom descriptions. Replaces an earlier version that sniffed the `model` path for `2f_140`.
- README: the 2F-140 paragraph said to pass `description_file`; the argument is `model`. Fixed and documents `gripper_joint`.

## Behaviour change
The config files are no longer usable on their own: fed straight to `ros2_control_node` or a spawner without going through `robotiq_control.launch.py`, the joint stays the literal `$(var gripper_joint)` and the controller does not activate. Nothing in this repo does that (the tactile launch includes the control launch), but a downstream launch file pointing at our YAML would have to pass through the launch or set the joint itself.

#50 is merged; this PR now sits on `main`. #52 is stacked on this.

## Test plan
- [x] `pytest test/` in `robotiq_description`: 30 passed, including a new check that the configs no longer hardcode the joint, that the launch defaults it from `gripper_model`, forwards `gripper_model` to xacro and restricts it to the known models, and that the launch description builds (the last one catches missing imports that only surface under `ros2 launch`)
- [x] `ros2 launch robotiq_description robotiq_control.launch.py use_fake_hardware:=true` in the `robotiq_ros2:jazzy` image (this branch's `urdf/`, `launch/`, `config/` mounted over the installed package): all three controllers `active`
- [x] same with `gripper_model:=2f_140`: all three controllers `active` (was `inactive` for `robotiq_gripper_controller` on `main`); `ros2 param get /robotiq_gripper_controller joint` reads `finger_joint`
- [x] Humble: `ros:humble-ros-base` + `ros-humble-ros2-control` / `ros-humble-ros2-controllers`, `robotiq_controllers` and `robotiq_description` built from this branch. Both models with `use_fake_hardware:=true`: all three controllers `active` (`position_controllers/GripperActionController` from `gripper_controllers`); `joint` reads `robotiq_85_left_knuckle_joint` for the 2F-85 and `finger_joint` for the 2F-140

🤖 Generated with [Claude Code](https://claude.com/claude-code)



