### PR TITLE
feat(robotiq_description): let the sim_isaac / sim_gazebo plugins activate from the launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,9 +257,24 @@ ros2 launch robotiq_description robotiq_control.launch.py                    # r
 ros2 launch robotiq_description robotiq_control.launch.py use_fake_hardware:=true   # ros2_control mock
 ros2 launch robotiq_description robotiq_control.launch.py launch_rviz:=true         # + RViz visualization
 ros2 launch robotiq_description robotiq_control.launch.py baudrate:=<rate>
+ros2 launch robotiq_description robotiq_control.launch.py sim_gazebo:=true        # gz_ros2_control
+ros2 launch robotiq_description robotiq_control.launch.py sim_isaac:=true \
+  isaac_joint_commands:=/isaac_joint_commands isaac_joint_states:=/isaac_joint_states  # topic_based_ros2_control
 ```
 
 This activates `joint_state_broadcaster`, `robotiq_gripper_controller`, and `robotiq_activation_controller`.
+
+`sim_gazebo` and `sim_isaac` swap the hardware plugin for `gz_ros2_control/GazeboSimSystem` or
+`topic_based_ros2_control/TopicBasedSystem` (any simulator that exchanges `sensor_msgs/JointState`
+on two topics — Isaac Sim is the usual one, hence the argument names). Both plugins export only the
+standard joint interfaces, so the launch loads `config/robotiq_controllers.sim.yaml` for them
+(per-goal `effort`/`velocity` are accepted and ignored; stall detection is tuned for a loop that
+runs over a topic) and skips `robotiq_activation_controller`, whose `reactivate_gripper` GPIO only
+the driver and the mock declare. `TopicBasedSystem` matches joints to the simulator's `JointState`
+**by name**, so the simulator must publish this description's joint names (`robotiq_85_left_knuckle_joint`
+and the five mimic joints, with your `prefix`), or nothing moves. Neither plugin is a dependency of
+this package — install `ros-$ROS_DISTRO-gz-ros2-control` or build
+[topic_based_ros2_control](https://github.com/PickNikRobotics/topic_based_ros2_control) yourself.
 
 ### Commanding the gripper
 

--- a/README.md
+++ b/README.md
@@ -257,24 +257,25 @@ ros2 launch robotiq_description robotiq_control.launch.py                    # r
 ros2 launch robotiq_description robotiq_control.launch.py use_fake_hardware:=true   # ros2_control mock
 ros2 launch robotiq_description robotiq_control.launch.py launch_rviz:=true         # + RViz visualization
 ros2 launch robotiq_description robotiq_control.launch.py baudrate:=<rate>
-ros2 launch robotiq_description robotiq_control.launch.py sim_gazebo:=true        # gz_ros2_control
 ros2 launch robotiq_description robotiq_control.launch.py sim_isaac:=true \
   isaac_joint_commands:=/isaac_joint_commands isaac_joint_states:=/isaac_joint_states  # topic_based_ros2_control
 ```
 
 This activates `joint_state_broadcaster`, `robotiq_gripper_controller`, and `robotiq_activation_controller`.
 
-`sim_gazebo` and `sim_isaac` swap the hardware plugin for `gz_ros2_control/GazeboSimSystem` or
-`topic_based_ros2_control/TopicBasedSystem` (any simulator that exchanges `sensor_msgs/JointState`
-on two topics — Isaac Sim is the usual one, hence the argument names). Both plugins export only the
-standard joint interfaces, so the launch loads `config/robotiq_controllers.sim.yaml` for them
-(per-goal `effort`/`velocity` are accepted and ignored; stall detection is tuned for a loop that
-runs over a topic) and skips `robotiq_activation_controller`, whose `reactivate_gripper` GPIO only
-the driver and the mock declare. `TopicBasedSystem` matches joints to the simulator's `JointState`
-**by name**, so the simulator must publish this description's joint names (`robotiq_85_left_knuckle_joint`
-and the five mimic joints, with your `prefix`), or nothing moves. Neither plugin is a dependency of
-this package — install `ros-$ROS_DISTRO-gz-ros2-control` or build
+`sim_isaac` swaps the hardware plugin for `topic_based_ros2_control/TopicBasedSystem` (any
+simulator that exchanges `sensor_msgs/JointState` on two topics — Isaac Sim is the usual one, hence
+the argument names). That plugin exports only the standard joint interfaces, so the launch loads
+`config/robotiq_controllers.sim.yaml` for it (per-goal `effort`/`velocity` are accepted and ignored;
+stall detection is tuned for a loop that runs over a topic) and skips `robotiq_activation_controller`,
+whose `reactivate_gripper` GPIO only the driver and the mock declare. `TopicBasedSystem` matches
+joints to the simulator's `JointState` **by name**, so the simulator must publish this description's
+joint names (`robotiq_85_left_knuckle_joint` and the five mimic joints, with your `prefix`), or
+nothing moves. The plugin is not a dependency of this package — build
 [topic_based_ros2_control](https://github.com/PickNikRobotics/topic_based_ros2_control) yourself.
+The `ros2_control` xacros also carry a `sim_gazebo` parameter (`gz_ros2_control/GazeboSimSystem`)
+for cells that embed the gripper macro in their own Gazebo description; this launch does not wire
+it, since Gazebo hosts its own `controller_manager`.
 
 ### Commanding the gripper
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,8 @@ This activates `joint_state_broadcaster`, `robotiq_gripper_controller`, and `rob
 simulator that exchanges `sensor_msgs/JointState` on two topics — Isaac Sim is the usual one, hence
 the argument names). That plugin exports only the standard joint interfaces, so the launch loads
 `config/robotiq_controllers.sim.yaml` for it (per-goal `effort`/`velocity` are accepted and ignored;
-stall detection is tuned for a loop that runs over a topic) and skips `robotiq_activation_controller`,
+a stall aborts the goal rather than succeeding, since a simulator that publishes no joint velocities
+would otherwise report every failed grasp as success) and skips `robotiq_activation_controller`,
 whose `reactivate_gripper` GPIO only the driver and the mock declare. `TopicBasedSystem` matches
 joints to the simulator's `JointState` **by name**, so the simulator must publish this description's
 joint names (`robotiq_85_left_knuckle_joint` and the five mimic joints, with your `prefix`), or

--- a/README.md
+++ b/README.md
@@ -271,8 +271,14 @@ a stall aborts the goal rather than succeeding, since a simulator that publishes
 would otherwise report every failed grasp as success) and skips `robotiq_activation_controller`,
 whose `reactivate_gripper` GPIO only the driver and the mock declare. `TopicBasedSystem` matches
 joints to the simulator's `JointState` **by name**, so the simulator must publish this description's
-joint names (`robotiq_85_left_knuckle_joint` and the five mimic joints, with your `prefix`), or
-nothing moves. The plugin is not a dependency of this package — build
+six joint names for the model you launch, each with your `prefix`, or nothing moves:
+
+| `gripper_model` | driven joint | mimic joints |
+|---|---|---|
+| `2f_85` | `robotiq_85_left_knuckle_joint` | `robotiq_85_right_knuckle_joint`, `robotiq_85_left_inner_knuckle_joint`, `robotiq_85_right_inner_knuckle_joint`, `robotiq_85_left_finger_tip_joint`, `robotiq_85_right_finger_tip_joint` |
+| `2f_140` | `finger_joint` | `right_outer_knuckle_joint`, `left_inner_knuckle_joint`, `right_inner_knuckle_joint`, `left_inner_finger_joint`, `right_inner_finger_joint` |
+
+The plugin is not a dependency of this package — build
 [topic_based_ros2_control](https://github.com/PickNikRobotics/topic_based_ros2_control) yourself.
 The `ros2_control` xacros also carry a `sim_gazebo` parameter (`gz_ros2_control/GazeboSimSystem`)
 for cells that embed the gripper macro in their own Gazebo description; this launch does not wire

--- a/grippers/robotiq_description/config/robotiq_controllers.sim.humble.yaml
+++ b/grippers/robotiq_description/config/robotiq_controllers.sim.humble.yaml
@@ -1,0 +1,25 @@
+# Humble controller configuration for the simulated hardware plugins
+# (`sim_isaac:=true` / `sim_gazebo:=true`). Same controller as
+# robotiq_controllers.humble.yaml — Humble's stock
+# position_controllers/GripperActionController, since parallel_gripper_controller
+# only arrived in Jazzy — with the two departures robotiq_controllers.sim.yaml
+# explains: no activation controller (no reactivate GPIO to claim) and stall
+# detection tuned for a plugin fed over a topic.
+controller_manager:
+  ros__parameters:
+    update_rate: 500  # Hz
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+    robotiq_gripper_controller:
+      type: position_controllers/GripperActionController
+
+robotiq_gripper_controller:
+  ros__parameters:
+    joint: $(var gripper_joint)
+
+    max_effort: 50.0
+
+    allow_stalling: true
+    stall_timeout: 0.5
+    stall_velocity_threshold: 0.05
+    goal_tolerance: 0.02

--- a/grippers/robotiq_description/config/robotiq_controllers.sim.humble.yaml
+++ b/grippers/robotiq_description/config/robotiq_controllers.sim.humble.yaml
@@ -1,5 +1,5 @@
-# Humble controller configuration for the simulated hardware plugins
-# (`sim_isaac:=true` / `sim_gazebo:=true`). Same controller as
+# Humble controller configuration for the simulated hardware plugin
+# (`sim_isaac:=true`). Same controller as
 # robotiq_controllers.humble.yaml — Humble's stock
 # position_controllers/GripperActionController, since parallel_gripper_controller
 # only arrived in Jazzy — with the two departures robotiq_controllers.sim.yaml

--- a/grippers/robotiq_description/config/robotiq_controllers.sim.humble.yaml
+++ b/grippers/robotiq_description/config/robotiq_controllers.sim.humble.yaml
@@ -3,8 +3,9 @@
 # robotiq_controllers.humble.yaml — Humble's stock
 # position_controllers/GripperActionController, since parallel_gripper_controller
 # only arrived in Jazzy — with the two departures robotiq_controllers.sim.yaml
-# explains: no activation controller (no reactivate GPIO to claim) and stall
-# detection tuned for a plugin fed over a topic.
+# explains: no activation controller (no reactivate GPIO to claim) and a stall
+# that aborts rather than succeeds (a simulator without joint velocities would
+# otherwise pass every failed grasp).
 controller_manager:
   ros__parameters:
     update_rate: 500  # Hz
@@ -19,7 +20,7 @@ robotiq_gripper_controller:
 
     max_effort: 50.0
 
-    allow_stalling: true
+    allow_stalling: false
     stall_timeout: 0.5
     stall_velocity_threshold: 0.05
     goal_tolerance: 0.02

--- a/grippers/robotiq_description/config/robotiq_controllers.sim.yaml
+++ b/grippers/robotiq_description/config/robotiq_controllers.sim.yaml
@@ -1,0 +1,37 @@
+# Controller configuration for the simulated hardware plugins the description
+# can select: `sim_isaac:=true` (topic_based_ros2_control/TopicBasedSystem) and
+# `sim_gazebo:=true` (gz_ros2_control/GazeboSimSystem). Selected by
+# launch/robotiq_control.launch.py whenever either argument is set; see
+# config/robotiq_controllers.yaml for the hardware and mock config it replaces,
+# and robotiq_controllers.sim.humble.yaml for the Humble variant.
+#
+# It differs from robotiq_controllers.yaml only where the simulated plugins
+# export something different from the driver, so the controller can activate:
+#
+# - No `robotiq_activation_controller`. The `reactivate_gripper` GPIO it claims is
+#   declared for the driver and the mock only (2f_85.ros2_control.xacro); under a
+#   simulated plugin there is nothing to reactivate.
+# - No `max_effort_interface` / `max_velocity_interface`. Both plugins expose the
+#   standard position/velocity/effort interfaces only, never the driver's
+#   `set_gripper_max_*`, and a claimed interface that does not exist stops the
+#   controller from activating. Goal effort/velocity are accepted and ignored.
+# - Stall detection tuned for a plugin fed over a topic rather than a serial
+#   link: a goal needs longer than 0.05 s to show up as joint motion, and
+#   simulated joint velocities carry more noise than the driver's.
+controller_manager:
+  ros__parameters:
+    update_rate: 500  # Hz
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+    robotiq_gripper_controller:
+      type: parallel_gripper_action_controller/GripperActionController
+
+robotiq_gripper_controller:
+  ros__parameters:
+    joint: $(var gripper_joint)
+
+    state_interfaces: ["position", "velocity"]
+    allow_stalling: true
+    stall_timeout: 0.5
+    stall_velocity_threshold: 0.05
+    goal_tolerance: 0.02

--- a/grippers/robotiq_description/config/robotiq_controllers.sim.yaml
+++ b/grippers/robotiq_description/config/robotiq_controllers.sim.yaml
@@ -14,8 +14,12 @@
 #   standard position/velocity/effort interfaces only, never the driver's
 #   `set_gripper_max_*`, and a claimed interface that does not exist stops the
 #   controller from activating. Goal effort/velocity are accepted and ignored.
-# - Stall detection tuned for a plugin fed over a topic rather than a serial
-#   link: a goal needs longer than 0.05 s to show up as joint motion, and
+# - A stall aborts the goal instead of succeeding. A simulator that publishes no
+#   joint velocities leaves the velocity state at 0, which reads as "stalled"
+#   from the first cycle, so allow_stalling would report every out-of-tolerance
+#   goal as succeeded. The client decides whether an aborted, stalled goal means
+#   an object was gripped. The stall window itself is wider than the driver's:
+#   a goal needs longer than 0.05 s to show up as motion over a topic, and
 #   simulated joint velocities carry more noise than the driver's.
 controller_manager:
   ros__parameters:
@@ -30,7 +34,7 @@ robotiq_gripper_controller:
     joint: $(var gripper_joint)
 
     state_interfaces: ["position", "velocity"]
-    allow_stalling: true
+    allow_stalling: false
     stall_timeout: 0.5
     stall_velocity_threshold: 0.05
     goal_tolerance: 0.02

--- a/grippers/robotiq_description/config/robotiq_controllers.sim.yaml
+++ b/grippers/robotiq_description/config/robotiq_controllers.sim.yaml
@@ -1,17 +1,16 @@
-# Controller configuration for the simulated hardware plugins the description
-# can select: `sim_isaac:=true` (topic_based_ros2_control/TopicBasedSystem) and
-# `sim_gazebo:=true` (gz_ros2_control/GazeboSimSystem). Selected by
-# launch/robotiq_control.launch.py whenever either argument is set; see
+# Controller configuration for the simulated hardware plugin the description
+# can select: `sim_isaac:=true` (topic_based_ros2_control/TopicBasedSystem).
+# Selected by launch/robotiq_control.launch.py whenever that argument is set; see
 # config/robotiq_controllers.yaml for the hardware and mock config it replaces,
 # and robotiq_controllers.sim.humble.yaml for the Humble variant.
 #
-# It differs from robotiq_controllers.yaml only where the simulated plugins
-# export something different from the driver, so the controller can activate:
+# It differs from robotiq_controllers.yaml only where the simulated plugin
+# exports something different from the driver, so the controller can activate:
 #
 # - No `robotiq_activation_controller`. The `reactivate_gripper` GPIO it claims is
 #   declared for the driver and the mock only (2f_85.ros2_control.xacro); under a
 #   simulated plugin there is nothing to reactivate.
-# - No `max_effort_interface` / `max_velocity_interface`. Both plugins expose the
+# - No `max_effort_interface` / `max_velocity_interface`. The plugin exposes the
 #   standard position/velocity/effort interfaces only, never the driver's
 #   `set_gripper_max_*`, and a claimed interface that does not exist stops the
 #   controller from activating. Goal effort/velocity are accepted and ignored.

--- a/grippers/robotiq_description/launch/robotiq_control.launch.py
+++ b/grippers/robotiq_description/launch/robotiq_control.launch.py
@@ -33,16 +33,19 @@ from launch.substitutions import (
     FindExecutable,
     LaunchConfiguration,
     PathJoinSubstitution,
-    PythonExpression,
 )
-from launch.conditions import IfCondition, UnlessCondition
+from launch.conditions import (
+    IfCondition,
+    UnlessCondition,
+    evaluate_condition_expression,
+)
 import launch_ros
 from launch_ros.parameter_descriptions import ParameterFile
 import os
 
 # Humble has no parallel_gripper_controller package, so it needs its own
-# controller config, and the simulated plugins (sim_isaac / sim_gazebo) export a
-# different interface set from the driver and the mock, so they need theirs.
+# controller config, and the simulated plugin (sim_isaac) exports a different
+# interface set from the driver and the mock, so it needs its own too.
 # See config/robotiq_controllers*.yaml.
 JAZZY_CONTROLLERS_FILE = "robotiq_controllers.yaml"
 HUMBLE_CONTROLLERS_FILE = "robotiq_controllers.humble.yaml"
@@ -53,11 +56,22 @@ HUMBLE_SIM_CONTROLLERS_FILE = "robotiq_controllers.sim.humble.yaml"
 def controllers_file_for_distro(distro, simulated=False):
     """Return the controller config file name for ROS distro `distro`.
 
-    `simulated` selects the config for the sim_isaac / sim_gazebo hardware plugins.
+    `simulated` selects the config for the sim_isaac hardware plugin.
     """
     if distro == "humble":
         return HUMBLE_SIM_CONTROLLERS_FILE if simulated else HUMBLE_CONTROLLERS_FILE
     return JAZZY_SIM_CONTROLLERS_FILE if simulated else JAZZY_CONTROLLERS_FILE
+
+
+class ControllersFile(Substitution):
+    def __init__(self, distro, simulated):
+        super().__init__()
+        self.distro = distro
+        self.simulated = simulated
+
+    def perform(self, context):
+        simulated = evaluate_condition_expression(context, [self.simulated])
+        return controllers_file_for_distro(self.distro, simulated)
 
 
 class ParameterFilePath(Substitution):
@@ -108,9 +122,6 @@ def xacro_command():
             " ",
             "sim_isaac:=",
             LaunchConfiguration("sim_isaac"),
-            " ",
-            "sim_gazebo:=",
-            LaunchConfiguration("sim_gazebo"),
             " ",
             "isaac_joint_commands:=",
             LaunchConfiguration("isaac_joint_commands"),
@@ -197,13 +208,6 @@ def generate_launch_description():
     )
     args.append(
         launch.actions.DeclareLaunchArgument(
-            name="sim_gazebo",
-            default_value="false",
-            description="Drive Gazebo over gz_ros2_control instead of a real gripper",
-        )
-    )
-    args.append(
-        launch.actions.DeclareLaunchArgument(
             name="isaac_joint_commands",
             default_value="/isaac_joint_commands",
             description="sim_isaac only: JointState topic the simulator takes commands on",
@@ -217,16 +221,7 @@ def generate_launch_description():
         )
     )
 
-    # "True"/"False": a PythonExpression is a string, and IfCondition reads both.
-    simulated = PythonExpression(
-        [
-            "'",
-            LaunchConfiguration("sim_isaac"),
-            "'.lower() in ('true', '1') or '",
-            LaunchConfiguration("sim_gazebo"),
-            "'.lower() in ('true', '1')",
-        ]
-    )
+    simulated = LaunchConfiguration("sim_isaac")
 
     robot_description_param = {
         "robot_description": launch_ros.parameter_descriptions.ParameterValue(
@@ -234,18 +229,7 @@ def generate_launch_description():
         )
     }
 
-    distro = os.environ.get("ROS_DISTRO")
-    controllers_file = PythonExpression(
-        [
-            "'",
-            controllers_file_for_distro(distro, simulated=True),
-            "' if ",
-            simulated,
-            " else '",
-            controllers_file_for_distro(distro),
-            "'",
-        ]
-    )
+    controllers_file = ControllersFile(os.environ.get("ROS_DISTRO"), simulated)
     initial_joint_controllers = ParameterFile(
         PathJoinSubstitution([description_pkg_share, "config", controllers_file]),
         allow_substs=True,
@@ -299,7 +283,7 @@ def generate_launch_description():
     joint_state_broadcaster_spawner = spawner("joint_state_broadcaster")
     robotiq_gripper_controller_spawner = spawner("robotiq_gripper_controller")
     # The reactivate_gripper GPIO this controller claims is declared for the
-    # driver and the mock only; the simulated plugins have nothing to reactivate.
+    # driver and the mock only; the simulated plugin has nothing to reactivate.
     robotiq_activation_controller_spawner = spawner(
         "robotiq_activation_controller", condition=UnlessCondition(simulated)
     )

--- a/grippers/robotiq_description/launch/robotiq_control.launch.py
+++ b/grippers/robotiq_description/launch/robotiq_control.launch.py
@@ -27,6 +27,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import launch
+from launch.actions import OpaqueFunction
 from launch.substitution import Substitution
 from launch.substitutions import (
     Command,
@@ -72,6 +73,23 @@ class ControllersFile(Substitution):
     def perform(self, context):
         simulated = evaluate_condition_expression(context, [self.simulated])
         return controllers_file_for_distro(self.distro, simulated)
+
+
+# The xacro emits one <plugin> per flag that is set, and ros2_control_node
+# accepts only one, so two flags would fail late and obscurely.
+HARDWARE_FLAGS = ("use_fake_hardware", "sim_isaac")
+
+
+def reject_conflicting_hardware_flags(context):
+    enabled = [
+        flag
+        for flag in HARDWARE_FLAGS
+        if evaluate_condition_expression(context, [LaunchConfiguration(flag)])
+    ]
+    if len(enabled) > 1:
+        raise RuntimeError(
+            f"{' and '.join(enabled)} both select a hardware plugin; set at most one"
+        )
 
 
 class ParameterFilePath(Substitution):
@@ -289,6 +307,7 @@ def generate_launch_description():
     )
 
     nodes = [
+        OpaqueFunction(function=reject_conflicting_hardware_flags),
         control_node,
         robot_state_publisher_node,
         joint_state_broadcaster_spawner,

--- a/grippers/robotiq_description/launch/robotiq_control.launch.py
+++ b/grippers/robotiq_description/launch/robotiq_control.launch.py
@@ -33,21 +33,31 @@ from launch.substitutions import (
     FindExecutable,
     LaunchConfiguration,
     PathJoinSubstitution,
+    PythonExpression,
 )
-from launch.conditions import IfCondition
+from launch.conditions import IfCondition, UnlessCondition
 import launch_ros
 from launch_ros.parameter_descriptions import ParameterFile
 import os
 
 # Humble has no parallel_gripper_controller package, so it needs its own
-# controller config. See both config/robotiq_controllers*.yaml.
+# controller config, and the simulated plugins (sim_isaac / sim_gazebo) export a
+# different interface set from the driver and the mock, so they need theirs.
+# See config/robotiq_controllers*.yaml.
 JAZZY_CONTROLLERS_FILE = "robotiq_controllers.yaml"
 HUMBLE_CONTROLLERS_FILE = "robotiq_controllers.humble.yaml"
+JAZZY_SIM_CONTROLLERS_FILE = "robotiq_controllers.sim.yaml"
+HUMBLE_SIM_CONTROLLERS_FILE = "robotiq_controllers.sim.humble.yaml"
 
 
-def controllers_file_for_distro(distro):
-    """Return the controller config file name to load on ROS distro `distro`."""
-    return HUMBLE_CONTROLLERS_FILE if distro == "humble" else JAZZY_CONTROLLERS_FILE
+def controllers_file_for_distro(distro, simulated=False):
+    """Return the controller config file name for ROS distro `distro`.
+
+    `simulated` selects the config for the sim_isaac / sim_gazebo hardware plugins.
+    """
+    if distro == "humble":
+        return HUMBLE_SIM_CONTROLLERS_FILE if simulated else HUMBLE_CONTROLLERS_FILE
+    return JAZZY_SIM_CONTROLLERS_FILE if simulated else JAZZY_CONTROLLERS_FILE
 
 
 class ParameterFilePath(Substitution):
@@ -95,6 +105,18 @@ def xacro_command():
             " ",
             "baudrate:=",
             LaunchConfiguration("baudrate"),
+            " ",
+            "sim_isaac:=",
+            LaunchConfiguration("sim_isaac"),
+            " ",
+            "sim_gazebo:=",
+            LaunchConfiguration("sim_gazebo"),
+            " ",
+            "isaac_joint_commands:=",
+            LaunchConfiguration("isaac_joint_commands"),
+            " ",
+            "isaac_joint_states:=",
+            LaunchConfiguration("isaac_joint_states"),
         ]
     )
 
@@ -166,6 +188,45 @@ def generate_launch_description():
             description="Use ros2_control mock (fake) hardware instead of a real gripper",
         )
     )
+    args.append(
+        launch.actions.DeclareLaunchArgument(
+            name="sim_isaac",
+            default_value="false",
+            description="Drive a simulator over topic_based_ros2_control instead of a real gripper",
+        )
+    )
+    args.append(
+        launch.actions.DeclareLaunchArgument(
+            name="sim_gazebo",
+            default_value="false",
+            description="Drive Gazebo over gz_ros2_control instead of a real gripper",
+        )
+    )
+    args.append(
+        launch.actions.DeclareLaunchArgument(
+            name="isaac_joint_commands",
+            default_value="/isaac_joint_commands",
+            description="sim_isaac only: JointState topic the simulator takes commands on",
+        )
+    )
+    args.append(
+        launch.actions.DeclareLaunchArgument(
+            name="isaac_joint_states",
+            default_value="/isaac_joint_states",
+            description="sim_isaac only: JointState topic the simulator publishes",
+        )
+    )
+
+    # "True"/"False": a PythonExpression is a string, and IfCondition reads both.
+    simulated = PythonExpression(
+        [
+            "'",
+            LaunchConfiguration("sim_isaac"),
+            "'.lower() in ('true', '1') or '",
+            LaunchConfiguration("sim_gazebo"),
+            "'.lower() in ('true', '1')",
+        ]
+    )
 
     robot_description_param = {
         "robot_description": launch_ros.parameter_descriptions.ParameterValue(
@@ -173,7 +234,18 @@ def generate_launch_description():
         )
     }
 
-    controllers_file = controllers_file_for_distro(os.environ.get("ROS_DISTRO"))
+    distro = os.environ.get("ROS_DISTRO")
+    controllers_file = PythonExpression(
+        [
+            "'",
+            controllers_file_for_distro(distro, simulated=True),
+            "' if ",
+            simulated,
+            " else '",
+            controllers_file_for_distro(distro),
+            "'",
+        ]
+    )
     initial_joint_controllers = ParameterFile(
         PathJoinSubstitution([description_pkg_share, "config", controllers_file]),
         allow_substs=True,
@@ -210,7 +282,7 @@ def generate_launch_description():
     # then dies with "parameter 'joint' is not initialized". --param-file has been
     # a spawner option since Humble, and each node reads only its own section of
     # the file, so this is correct on every supported distro.
-    def spawner(controller_name):
+    def spawner(controller_name, condition=None):
         return launch_ros.actions.Node(
             package="controller_manager",
             executable="spawner",
@@ -221,11 +293,16 @@ def generate_launch_description():
                 "--param-file",
                 ParameterFilePath(initial_joint_controllers),
             ],
+            condition=condition,
         )
 
     joint_state_broadcaster_spawner = spawner("joint_state_broadcaster")
     robotiq_gripper_controller_spawner = spawner("robotiq_gripper_controller")
-    robotiq_activation_controller_spawner = spawner("robotiq_activation_controller")
+    # The reactivate_gripper GPIO this controller claims is declared for the
+    # driver and the mock only; the simulated plugins have nothing to reactivate.
+    robotiq_activation_controller_spawner = spawner(
+        "robotiq_activation_controller", condition=UnlessCondition(simulated)
+    )
 
     nodes = [
         control_node,

--- a/grippers/robotiq_description/test/test_controller_config.py
+++ b/grippers/robotiq_description/test/test_controller_config.py
@@ -333,11 +333,14 @@ def test_sim_configs_spawn_no_activation_controller(config):
 def test_sim_config_keeps_the_action_surface_of_its_distro(config):
     # Same controller name, type, joint and goal tolerance as the hardware config
     # for that distro: an action client must not notice which plugin is behind.
+    # Stall handling is the one deliberate difference: a simulator that publishes
+    # no velocities would otherwise pass every failed grasp as a successful stall.
     hardware = gripper_controller_params(config)
     sim = gripper_controller_params(SIM_OF[config])
     assert sim["joint"] == hardware["joint"]
     assert sim["goal_tolerance"] == hardware["goal_tolerance"]
-    assert sim["allow_stalling"] == hardware["allow_stalling"]
+    assert hardware["allow_stalling"] is True
+    assert sim["allow_stalling"] is False
     assert (
         load(SIM_OF[config])["controller_manager"]["ros__parameters"][
             "robotiq_gripper_controller"

--- a/grippers/robotiq_description/test/test_controller_config.py
+++ b/grippers/robotiq_description/test/test_controller_config.py
@@ -54,9 +54,9 @@ ALL_CONFIGS = (JAZZY_CONFIG, HUMBLE_CONFIG)
 # both models; robotiq_control.launch.py resolves it via ParameterFile.
 JOINT_PLACEHOLDER = "$(var gripper_joint)"
 
-# The simulated plugins (sim_isaac / sim_gazebo) export neither the
-# set_gripper_max_* command interfaces nor the reactivate_gripper GPIO, so they
-# get a config of their own per distro, selected by the same launch file.
+# The simulated plugin (sim_isaac) exports neither the set_gripper_max_* command
+# interfaces nor the reactivate_gripper GPIO, so it gets a config of its own per
+# distro, selected by the same launch file.
 JAZZY_SIM_CONFIG = CONFIG_DIR / "robotiq_controllers.sim.yaml"
 HUMBLE_SIM_CONFIG = CONFIG_DIR / "robotiq_controllers.sim.humble.yaml"
 SIM_CONFIGS = (JAZZY_SIM_CONFIG, HUMBLE_SIM_CONFIG)
@@ -183,7 +183,6 @@ def test_launch_forwards_the_gripper_model_to_xacro():
         com_port="/dev/null",
         baudrate="115200",
         sim_isaac="false",
-        sim_gazebo="false",
         isaac_joint_commands="/isaac_joint_commands",
         isaac_joint_states="/isaac_joint_states",
     )
@@ -238,7 +237,6 @@ def spawned_controllers(distro, monkeypatch, **launch_arguments):
     context.launch_configurations.update(
         {
             "sim_isaac": "false",
-            "sim_gazebo": "false",
             "gripper_joint": JOINT,
             **launch_arguments,
         }
@@ -268,10 +266,7 @@ def resolved(config, joint=JOINT):
         (None, JAZZY_CONFIG, JAZZY_SIM_CONFIG),
     ],
 )
-@pytest.mark.parametrize("sim_argument", ["sim_isaac", "sim_gazebo"])
-def test_launch_spawns_per_plugin(
-    distro, hardware_config, sim_config, sim_argument, monkeypatch
-):
+def test_launch_spawns_per_plugin(distro, hardware_config, sim_config, monkeypatch):
     # Every spawner must be handed the same config the controller_manager loaded,
     # and the activation controller only exists where its GPIO does.
     hardware = spawned_controllers(distro, monkeypatch)
@@ -281,7 +276,7 @@ def test_launch_spawns_per_plugin(
         "robotiq_activation_controller": resolved(hardware_config),
     }
 
-    simulated = spawned_controllers(distro, monkeypatch, **{sim_argument: "true"})
+    simulated = spawned_controllers(distro, monkeypatch, sim_isaac="true")
     assert simulated == {
         "joint_state_broadcaster": resolved(sim_config),
         "robotiq_gripper_controller": resolved(sim_config),
@@ -290,8 +285,8 @@ def test_launch_spawns_per_plugin(
 
 @pytest.mark.parametrize("config", SIM_CONFIGS)
 def test_sim_configs_claim_no_driver_only_command_interfaces(config):
-    # TopicBasedSystem and GazeboSimSystem export the standard joint interfaces
-    # only; claiming set_gripper_max_* here is why the sim paths never activated.
+    # TopicBasedSystem exports the standard joint interfaces only; claiming
+    # set_gripper_max_* here is why the sim path never activated.
     params = gripper_controller_params(config)
     assert "max_effort_interface" not in params
     assert "max_velocity_interface" not in params
@@ -299,7 +294,7 @@ def test_sim_configs_claim_no_driver_only_command_interfaces(config):
 
 @pytest.mark.parametrize("config", SIM_CONFIGS)
 def test_sim_configs_spawn_no_activation_controller(config):
-    # No reactivate_gripper GPIO is declared under sim_isaac / sim_gazebo (see
+    # No reactivate_gripper GPIO is declared under sim_isaac (see
     # 2f_85.ros2_control.xacro), so the controller would have nothing to claim.
     controllers = load(config)["controller_manager"]["ros__parameters"]
     assert set(controllers) == {

--- a/grippers/robotiq_description/test/test_controller_config.py
+++ b/grippers/robotiq_description/test/test_controller_config.py
@@ -236,7 +236,12 @@ def spawned_controllers(distro, monkeypatch, **launch_arguments):
         monkeypatch.setenv("ROS_DISTRO", distro)
     context = LaunchContext()
     context.launch_configurations.update(
-        {"sim_isaac": "false", "sim_gazebo": "false", **launch_arguments}
+        {
+            "sim_isaac": "false",
+            "sim_gazebo": "false",
+            "gripper_joint": JOINT,
+            **launch_arguments,
+        }
     )
 
     spawned = {}
@@ -246,8 +251,12 @@ def spawned_controllers(distro, monkeypatch, **launch_arguments):
         if action.condition is not None and not action.condition.evaluate(context):
             continue
         cmd = [perform_substitutions(context, part) for part in action.cmd]
-        spawned[cmd[1]] = Path(cmd[cmd.index("--param-file") + 1]).name
+        spawned[cmd[1]] = Path(cmd[cmd.index("--param-file") + 1]).read_text()
     return spawned
+
+
+def resolved(config, joint=JOINT):
+    return config.read_text().replace(JOINT_PLACEHOLDER, joint)
 
 
 @requires_launch
@@ -267,15 +276,15 @@ def test_launch_spawns_per_plugin(
     # and the activation controller only exists where its GPIO does.
     hardware = spawned_controllers(distro, monkeypatch)
     assert hardware == {
-        "joint_state_broadcaster": hardware_config.name,
-        "robotiq_gripper_controller": hardware_config.name,
-        "robotiq_activation_controller": hardware_config.name,
+        "joint_state_broadcaster": resolved(hardware_config),
+        "robotiq_gripper_controller": resolved(hardware_config),
+        "robotiq_activation_controller": resolved(hardware_config),
     }
 
     simulated = spawned_controllers(distro, monkeypatch, **{sim_argument: "true"})
     assert simulated == {
-        "joint_state_broadcaster": sim_config.name,
-        "robotiq_gripper_controller": sim_config.name,
+        "joint_state_broadcaster": resolved(sim_config),
+        "robotiq_gripper_controller": resolved(sim_config),
     }
 
 

--- a/grippers/robotiq_description/test/test_controller_config.py
+++ b/grippers/robotiq_description/test/test_controller_config.py
@@ -170,6 +170,29 @@ def test_launch_restricts_gripper_model_to_the_known_joints():
     assert declared["gripper_model"].choices == sorted(launch_module.GRIPPER_JOINTS)
 
 
+@pytest.mark.parametrize(
+    "use_fake_hardware,sim_isaac",
+    [("false", "false"), ("true", "false"), ("false", "true")],
+)
+def test_launch_accepts_at_most_one_hardware_flag(use_fake_hardware, sim_isaac):
+    launch_module = load_launch_module()
+    context = LaunchContext()
+    context.launch_configurations.update(
+        use_fake_hardware=use_fake_hardware, sim_isaac=sim_isaac
+    )
+    launch_module.reject_conflicting_hardware_flags(context)
+
+
+def test_launch_rejects_fake_hardware_together_with_sim_isaac():
+    # Both flags set makes the xacro emit two <plugin> elements while the launch
+    # picks the sim config; neither half can work, so fail before anything starts.
+    launch_module = load_launch_module()
+    context = LaunchContext()
+    context.launch_configurations.update(use_fake_hardware="true", sim_isaac="true")
+    with pytest.raises(RuntimeError, match="use_fake_hardware and sim_isaac"):
+        launch_module.reject_conflicting_hardware_flags(context)
+
+
 def test_launch_forwards_the_gripper_model_to_xacro():
     # The xacro-level gripper_model selects the macro, so the launch-level one
     # has to reach it or the two could name different grippers.

--- a/grippers/robotiq_description/test/test_controller_config.py
+++ b/grippers/robotiq_description/test/test_controller_config.py
@@ -182,6 +182,10 @@ def test_launch_forwards_the_gripper_model_to_xacro():
         use_fake_hardware="true",
         com_port="/dev/null",
         baudrate="115200",
+        sim_isaac="false",
+        sim_gazebo="false",
+        isaac_joint_commands="/isaac_joint_commands",
+        isaac_joint_states="/isaac_joint_states",
     )
     rendered = "".join(s.perform(context) for s in command.command)
     assert "gripper_model:=2f_140" in rendered
@@ -210,6 +214,69 @@ def test_launch_selects_the_config_for_the_distro(distro, expected):
     selected = launch_module.controllers_file_for_distro(distro)
     assert selected == expected.name
     assert (CONFIG_DIR / selected).is_file()
+
+    simulated = launch_module.controllers_file_for_distro(distro, simulated=True)
+    assert simulated == SIM_OF[expected].name
+    assert (CONFIG_DIR / simulated).is_file()
+
+
+requires_launch = pytest.mark.skipif(
+    importlib.util.find_spec("launch_ros") is None, reason="launch_ros not importable"
+)
+
+
+def spawned_controllers(distro, monkeypatch, **launch_arguments):
+    from launch import LaunchContext
+    from launch.utilities import perform_substitutions
+    from launch_ros.actions import Node
+
+    if distro is None:
+        monkeypatch.delenv("ROS_DISTRO", raising=False)
+    else:
+        monkeypatch.setenv("ROS_DISTRO", distro)
+    context = LaunchContext()
+    context.launch_configurations.update(
+        {"sim_isaac": "false", "sim_gazebo": "false", **launch_arguments}
+    )
+
+    spawned = {}
+    for action in load_launch_module().generate_launch_description().entities:
+        if not isinstance(action, Node) or action.node_executable != "spawner":
+            continue
+        if action.condition is not None and not action.condition.evaluate(context):
+            continue
+        cmd = [perform_substitutions(context, part) for part in action.cmd]
+        spawned[cmd[1]] = Path(cmd[cmd.index("--param-file") + 1]).name
+    return spawned
+
+
+@requires_launch
+@pytest.mark.parametrize(
+    "distro,hardware_config,sim_config",
+    [
+        ("humble", HUMBLE_CONFIG, HUMBLE_SIM_CONFIG),
+        ("jazzy", JAZZY_CONFIG, JAZZY_SIM_CONFIG),
+        (None, JAZZY_CONFIG, JAZZY_SIM_CONFIG),
+    ],
+)
+@pytest.mark.parametrize("sim_argument", ["sim_isaac", "sim_gazebo"])
+def test_launch_spawns_per_plugin(
+    distro, hardware_config, sim_config, sim_argument, monkeypatch
+):
+    # Every spawner must be handed the same config the controller_manager loaded,
+    # and the activation controller only exists where its GPIO does.
+    hardware = spawned_controllers(distro, monkeypatch)
+    assert hardware == {
+        "joint_state_broadcaster": hardware_config.name,
+        "robotiq_gripper_controller": hardware_config.name,
+        "robotiq_activation_controller": hardware_config.name,
+    }
+
+    simulated = spawned_controllers(distro, monkeypatch, **{sim_argument: "true"})
+    assert simulated == {
+        "joint_state_broadcaster": sim_config.name,
+        "robotiq_gripper_controller": sim_config.name,
+    }
 
 
 @pytest.mark.parametrize("config", SIM_CONFIGS)

--- a/grippers/robotiq_description/test/test_controller_config.py
+++ b/grippers/robotiq_description/test/test_controller_config.py
@@ -54,11 +54,20 @@ ALL_CONFIGS = (JAZZY_CONFIG, HUMBLE_CONFIG)
 # both models; robotiq_control.launch.py resolves it via ParameterFile.
 JOINT_PLACEHOLDER = "$(var gripper_joint)"
 
+# The simulated plugins (sim_isaac / sim_gazebo) export neither the
+# set_gripper_max_* command interfaces nor the reactivate_gripper GPIO, so they
+# get a config of their own per distro, selected by the same launch file.
+JAZZY_SIM_CONFIG = CONFIG_DIR / "robotiq_controllers.sim.yaml"
+HUMBLE_SIM_CONFIG = CONFIG_DIR / "robotiq_controllers.sim.humble.yaml"
+SIM_CONFIGS = (JAZZY_SIM_CONFIG, HUMBLE_SIM_CONFIG)
+SIM_OF = {JAZZY_CONFIG: JAZZY_SIM_CONFIG, HUMBLE_CONFIG: HUMBLE_SIM_CONFIG}
+
 # Names exported by robotiq_driver's hardware interface for the joint it is
 # given. Kept in sync by robotiq_driver's test_robotiq_gripper_hardware_interface,
 # which asserts the hardware exports exactly these.
 JOINT = "robotiq_85_left_knuckle_joint"
 GRIPPER_JOINTS = (JOINT, "finger_joint")
+UPDATE_RATE_HZ = 500
 
 
 def exported_command_interfaces(joint):
@@ -76,6 +85,9 @@ EXPECTED_CONTROLLER_TYPES = {
     JAZZY_CONFIG: "parallel_gripper_action_controller/GripperActionController",
     HUMBLE_CONFIG: "position_controllers/GripperActionController",
 }
+EXPECTED_CONTROLLER_TYPES.update(
+    {SIM_OF[config]: plugin for config, plugin in EXPECTED_CONTROLLER_TYPES.items()}
+)
 
 
 def load_launch_module():
@@ -123,7 +135,7 @@ def test_humble_config_claims_no_unsupported_interfaces():
     assert "max_velocity_interface" not in params
 
 
-@pytest.mark.parametrize("config", ALL_CONFIGS)
+@pytest.mark.parametrize("config", ALL_CONFIGS + SIM_CONFIGS)
 def test_joint_is_left_to_the_launch(config):
     # Hardcoding the 2F-85 joint here is why a 2F-140 launch used to fail to
     # activate robotiq_gripper_controller.
@@ -175,7 +187,7 @@ def test_launch_forwards_the_gripper_model_to_xacro():
     assert "gripper_model:=2f_140" in rendered
 
 
-@pytest.mark.parametrize("config", ALL_CONFIGS)
+@pytest.mark.parametrize("config", ALL_CONFIGS + SIM_CONFIGS)
 def test_controller_type_matches_distro(config):
     controllers = load(config)["controller_manager"]["ros__parameters"]
     assert (
@@ -200,6 +212,48 @@ def test_launch_selects_the_config_for_the_distro(distro, expected):
     assert (CONFIG_DIR / selected).is_file()
 
 
+@pytest.mark.parametrize("config", SIM_CONFIGS)
+def test_sim_configs_claim_no_driver_only_command_interfaces(config):
+    # TopicBasedSystem and GazeboSimSystem export the standard joint interfaces
+    # only; claiming set_gripper_max_* here is why the sim paths never activated.
+    params = gripper_controller_params(config)
+    assert "max_effort_interface" not in params
+    assert "max_velocity_interface" not in params
+
+
+@pytest.mark.parametrize("config", SIM_CONFIGS)
+def test_sim_configs_spawn_no_activation_controller(config):
+    # No reactivate_gripper GPIO is declared under sim_isaac / sim_gazebo (see
+    # 2f_85.ros2_control.xacro), so the controller would have nothing to claim.
+    controllers = load(config)["controller_manager"]["ros__parameters"]
+    assert set(controllers) == {
+        "update_rate",
+        "joint_state_broadcaster",
+        "robotiq_gripper_controller",
+    }
+    assert controllers["update_rate"] == UPDATE_RATE_HZ
+    assert "robotiq_activation_controller" not in load(config)
+
+
+@pytest.mark.parametrize("config", ALL_CONFIGS)
+def test_sim_config_keeps_the_action_surface_of_its_distro(config):
+    # Same controller name, type, joint and goal tolerance as the hardware config
+    # for that distro: an action client must not notice which plugin is behind.
+    hardware = gripper_controller_params(config)
+    sim = gripper_controller_params(SIM_OF[config])
+    assert sim["joint"] == hardware["joint"]
+    assert sim["goal_tolerance"] == hardware["goal_tolerance"]
+    assert sim["allow_stalling"] == hardware["allow_stalling"]
+    assert (
+        load(SIM_OF[config])["controller_manager"]["ros__parameters"][
+            "robotiq_gripper_controller"
+        ]
+        == load(config)["controller_manager"]["ros__parameters"][
+            "robotiq_gripper_controller"
+        ]
+    )
+
+
 @pytest.mark.parametrize("config", ALL_CONFIGS)
 def test_controller_names_and_update_rate_are_identical_across_distros(config):
     # The controller names are the action/service namespaces users depend on
@@ -212,7 +266,7 @@ def test_controller_names_and_update_rate_are_identical_across_distros(config):
         "robotiq_gripper_controller",
         "robotiq_activation_controller",
     }
-    assert controllers["update_rate"] == 500
+    assert controllers["update_rate"] == UPDATE_RATE_HZ
     assert (
         controllers["robotiq_activation_controller"]["type"]
         == "robotiq_controllers/RobotiqActivationController"

--- a/grippers/robotiq_description/test/test_ros2_control_urdf.py
+++ b/grippers/robotiq_description/test/test_ros2_control_urdf.py
@@ -52,6 +52,7 @@ import yaml
 PKG_DIR = Path(__file__).parents[1]
 URDF_DIR = PKG_DIR / "urdf"
 CONFIG = PKG_DIR / "config" / "robotiq_controllers.yaml"
+SIM_CONFIG = PKG_DIR / "config" / "robotiq_controllers.sim.yaml"
 
 # Top-level xacro -> the joint carrying the gripper's position command.
 MODELS = {
@@ -257,3 +258,19 @@ def test_isaac_topics_reach_the_plugin(model):
     default = expand(model, False, "sim_isaac:=true")
     assert hardware_param(default, "joint_commands_topic") == "/isaac_joint_commands"
     assert hardware_param(default, "joint_states_topic") == "/isaac_joint_states"
+
+
+@requires_xacro
+@pytest.mark.parametrize("sim_arg", SIM_ARGS.values())
+def test_sim_controller_config_claims_only_what_the_sim_urdf_declares(sim_arg):
+    # The sim counterpart of test_gripper_controller_config_interfaces_exist_under_mock.
+    params = yaml.safe_load(SIM_CONFIG.read_text())["robotiq_gripper_controller"][
+        "ros__parameters"
+    ]
+    joint = MODELS["robotiq_2f_85_gripper.urdf.xacro"]
+    ros2_control = expand("robotiq_2f_85_gripper.urdf.xacro", False, sim_arg)
+
+    assert params["joint"] == "$(var gripper_joint)"
+    assert "max_effort_interface" not in params
+    assert "max_velocity_interface" not in params
+    assert set(params["state_interfaces"]) <= state_interfaces_of(ros2_control, joint)

--- a/grippers/robotiq_description/test/test_ros2_control_urdf.py
+++ b/grippers/robotiq_description/test/test_ros2_control_urdf.py
@@ -61,6 +61,12 @@ MODELS = {
 
 MOCK_PLUGIN = "mock_components/GenericSystem"
 REAL_PLUGIN = "robotiq_driver/RobotiqGripperHardwareInterface"
+ISAAC_PLUGIN = "topic_based_ros2_control/TopicBasedSystem"
+GAZEBO_PLUGIN = "gz_ros2_control/GazeboSimSystem"
+SIM_ARGS = {ISAAC_PLUGIN: "sim_isaac:=true", GAZEBO_PLUGIN: "sim_gazebo:=true"}
+
+# Every 2F finger joint except the driven knuckle follows it through <mimic>.
+MIMIC_JOINT_COUNT = 5
 
 # Exported by the driver at runtime; needed from the URDF under mock hardware.
 EXTRA_MOCK_COMMAND_INTERFACES = {"set_gripper_max_velocity", "set_gripper_max_effort"}
@@ -194,3 +200,60 @@ def test_baudrate_reaches_the_driver(model):
 
     assert hardware_param(expand(model, False), "baudrate") == "115200"
     assert hardware_param(expand(model, True), "baudrate") is None
+
+
+@requires_xacro
+@pytest.mark.parametrize("model,joint", MODELS.items())
+@pytest.mark.parametrize("plugin,sim_arg", SIM_ARGS.items())
+def test_sim_plugins_declare_only_the_position_command(model, joint, plugin, sim_arg):
+    # Neither simulated plugin knows the driver's set_gripper_max_* interfaces;
+    # config/robotiq_controllers.sim.yaml therefore claims none, and the URDF must
+    # not declare them either or the plugin rejects the joint.
+    ros2_control = expand(model, False, sim_arg)
+    assert plugin_of(ros2_control) == plugin
+    assert command_interfaces_of(ros2_control, joint) == {"position"}
+
+
+@requires_xacro
+@pytest.mark.parametrize("model,joint", MODELS.items())
+@pytest.mark.parametrize("sim_arg", SIM_ARGS.values())
+def test_sim_plugins_declare_no_reactivate_gpio(model, joint, sim_arg):
+    # robotiq_control.launch.py skips robotiq_activation_controller under sim_*;
+    # this is the URDF side of that agreement.
+    assert expand(model, False, sim_arg).find("gpio") is None
+    assert expand(model, False).find("gpio[@name='reactivate_gripper']") is not None
+    assert expand(model, True).find("gpio[@name='reactivate_gripper']") is not None
+
+
+@requires_xacro
+@pytest.mark.parametrize("model,joint", MODELS.items())
+def test_sim_isaac_declares_the_mimic_joints_as_state_only(model, joint):
+    # TopicBasedSystem reports only the joints declared here, and the simulator
+    # owns the mimic joints, so they must be declared for /joint_states to carry
+    # them, but with no command interface: only the knuckle is driven.
+    ros2_control = expand(model, False, "sim_isaac:=true")
+    mimic = joints_of(ros2_control) - {joint}
+    assert len(mimic) == MIMIC_JOINT_COUNT
+    for name in mimic:
+        assert command_interfaces_of(ros2_control, name) == set()
+        assert state_interfaces_of(ros2_control, name) == {"position", "velocity"}
+
+
+@requires_xacro
+@pytest.mark.parametrize("model", MODELS)
+def test_isaac_topics_reach_the_plugin(model):
+    # Same three-file chain as baudrate: a half-forwarded argument only shows up
+    # as a simulator that never hears a command.
+    ros2_control = expand(
+        model,
+        False,
+        "sim_isaac:=true",
+        "isaac_joint_commands:=/sim/cmd",
+        "isaac_joint_states:=/sim/state",
+    )
+    assert hardware_param(ros2_control, "joint_commands_topic") == "/sim/cmd"
+    assert hardware_param(ros2_control, "joint_states_topic") == "/sim/state"
+
+    default = expand(model, False, "sim_isaac:=true")
+    assert hardware_param(default, "joint_commands_topic") == "/isaac_joint_commands"
+    assert hardware_param(default, "joint_states_topic") == "/isaac_joint_states"

--- a/grippers/robotiq_description/test/test_ros2_control_urdf.py
+++ b/grippers/robotiq_description/test/test_ros2_control_urdf.py
@@ -63,8 +63,7 @@ MODELS = {
 MOCK_PLUGIN = "mock_components/GenericSystem"
 REAL_PLUGIN = "robotiq_driver/RobotiqGripperHardwareInterface"
 ISAAC_PLUGIN = "topic_based_ros2_control/TopicBasedSystem"
-GAZEBO_PLUGIN = "gz_ros2_control/GazeboSimSystem"
-SIM_ARGS = {ISAAC_PLUGIN: "sim_isaac:=true", GAZEBO_PLUGIN: "sim_gazebo:=true"}
+SIM_ARG = "sim_isaac:=true"
 
 # Every 2F finger joint except the driven knuckle follows it through <mimic>.
 MIMIC_JOINT_COUNT = 5
@@ -205,23 +204,21 @@ def test_baudrate_reaches_the_driver(model):
 
 @requires_xacro
 @pytest.mark.parametrize("model,joint", MODELS.items())
-@pytest.mark.parametrize("plugin,sim_arg", SIM_ARGS.items())
-def test_sim_plugins_declare_only_the_position_command(model, joint, plugin, sim_arg):
-    # Neither simulated plugin knows the driver's set_gripper_max_* interfaces;
+def test_sim_plugin_declares_only_the_position_command(model, joint):
+    # The simulated plugin does not know the driver's set_gripper_max_* interfaces;
     # config/robotiq_controllers.sim.yaml therefore claims none, and the URDF must
     # not declare them either or the plugin rejects the joint.
-    ros2_control = expand(model, False, sim_arg)
-    assert plugin_of(ros2_control) == plugin
+    ros2_control = expand(model, False, SIM_ARG)
+    assert plugin_of(ros2_control) == ISAAC_PLUGIN
     assert command_interfaces_of(ros2_control, joint) == {"position"}
 
 
 @requires_xacro
 @pytest.mark.parametrize("model,joint", MODELS.items())
-@pytest.mark.parametrize("sim_arg", SIM_ARGS.values())
-def test_sim_plugins_declare_no_reactivate_gpio(model, joint, sim_arg):
-    # robotiq_control.launch.py skips robotiq_activation_controller under sim_*;
+def test_sim_plugin_declares_no_reactivate_gpio(model, joint):
+    # robotiq_control.launch.py skips robotiq_activation_controller under sim_isaac;
     # this is the URDF side of that agreement.
-    assert expand(model, False, sim_arg).find("gpio") is None
+    assert expand(model, False, SIM_ARG).find("gpio") is None
     assert expand(model, False).find("gpio[@name='reactivate_gripper']") is not None
     assert expand(model, True).find("gpio[@name='reactivate_gripper']") is not None
 
@@ -261,14 +258,13 @@ def test_isaac_topics_reach_the_plugin(model):
 
 
 @requires_xacro
-@pytest.mark.parametrize("sim_arg", SIM_ARGS.values())
-def test_sim_controller_config_claims_only_what_the_sim_urdf_declares(sim_arg):
+@pytest.mark.parametrize("model,joint", MODELS.items())
+def test_sim_controller_config_claims_only_what_the_sim_urdf_declares(model, joint):
     # The sim counterpart of test_gripper_controller_config_interfaces_exist_under_mock.
     params = yaml.safe_load(SIM_CONFIG.read_text())["robotiq_gripper_controller"][
         "ros__parameters"
     ]
-    joint = MODELS["robotiq_2f_85_gripper.urdf.xacro"]
-    ros2_control = expand("robotiq_2f_85_gripper.urdf.xacro", False, sim_arg)
+    ros2_control = expand(model, False, SIM_ARG)
 
     assert params["joint"] == "$(var gripper_joint)"
     assert "max_effort_interface" not in params

--- a/grippers/robotiq_description/urdf/robotiq_2f_gripper.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_gripper.urdf.xacro
@@ -9,7 +9,6 @@
     <xacro:arg name="com_port" default="/dev/ttyUSB0" />
     <xacro:arg name="baudrate" default="115200" />
     <xacro:arg name="sim_isaac" default="false" />
-    <xacro:arg name="sim_gazebo" default="false" />
     <xacro:arg name="isaac_joint_commands" default="/isaac_joint_commands" />
     <xacro:arg name="isaac_joint_states" default="/isaac_joint_states" />
 
@@ -18,7 +17,7 @@
 
     <link name="world" />
     <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg com_port)" baudrate="$(arg baudrate)"
-        sim_isaac="$(arg sim_isaac)" sim_gazebo="$(arg sim_gazebo)"
+        sim_isaac="$(arg sim_isaac)"
         isaac_joint_commands="$(arg isaac_joint_commands)" isaac_joint_states="$(arg isaac_joint_states)">
         <origin xyz="0 0 0" rpy="0 0 0" />
     </xacro:robotiq_gripper>

--- a/grippers/robotiq_description/urdf/robotiq_2f_gripper.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_gripper.urdf.xacro
@@ -8,12 +8,18 @@
     <xacro:arg name="use_fake_hardware" default="true" />
     <xacro:arg name="com_port" default="/dev/ttyUSB0" />
     <xacro:arg name="baudrate" default="115200" />
+    <xacro:arg name="sim_isaac" default="false" />
+    <xacro:arg name="sim_gazebo" default="false" />
+    <xacro:arg name="isaac_joint_commands" default="/isaac_joint_commands" />
+    <xacro:arg name="isaac_joint_states" default="/isaac_joint_states" />
 
     <!-- Import macros -->
     <xacro:include filename="$(find robotiq_description)/urdf/robotiq_$(arg gripper_model)_macro.urdf.xacro" />
 
     <link name="world" />
-    <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg com_port)" baudrate="$(arg baudrate)">
+    <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg com_port)" baudrate="$(arg baudrate)"
+        sim_isaac="$(arg sim_isaac)" sim_gazebo="$(arg sim_gazebo)"
+        isaac_joint_commands="$(arg isaac_joint_commands)" isaac_joint_states="$(arg isaac_joint_states)">
         <origin xyz="0 0 0" rpy="0 0 0" />
     </xacro:robotiq_gripper>
 </robot>


### PR DESCRIPTION
## Problem

The gripper xacros have let you pick `sim_isaac` (topic_based_ros2_control) as the hardware plugin for years, but the controller config and the launch file were written for the real driver only. Pick the sim plugin and `robotiq_gripper_controller` never activates: the config claims `set_gripper_max_effort` / `set_gripper_max_velocity`, which only the driver exports, and the launch spawns `robotiq_activation_controller`, whose GPIO the sim URDF does not declare. The launch also never exposed the sim flag at all.

## Change

One commit per layer, oldest first:

1. **xacro** — the top-level 2F-85 / 2F-140 xacros accept and forward `sim_isaac`, `isaac_joint_commands`, `isaac_joint_states` (the macro already had them).
2. **config** — `robotiq_controllers.sim.yaml` (+ Humble variant): same controllers as the hardware config minus the activation controller and the two driver-only command interfaces.
3. **launch** — new arguments, defaulting to today's behaviour; `sim_isaac` selects the sim config and skips the activation spawner.
4. **README** — the sim launch line and a note that `TopicBasedSystem` matches joints by name.
5. **review follow-ups** — `sim_gazebo` dropped from the launch surface (it could not work as wired; the macro-level parameter predates this PR and stays), `use_fake_hardware` + `sim_isaac` together now fails the launch by name, a stall in sim aborts the goal instead of succeeding, and the README lists both models' joint names.

Hardware and mock bringup are unchanged: same files, same controllers, same action surface. The sim plugin does not become a dependency.

## Verification

- 24 → 57 tests in `robotiq_description`; green at every commit. New tests pin what the sim plugin exports, that the sim config claims only that, the launch's own spawner wiring per distro, and the flag-conflict check.
- Jazzy, this tree: `use_fake_hardware:=true` with `gripper_model:=2f_85` and `:=2f_140` activates all three controllers with the right joint; `use_fake_hardware:=true sim_isaac:=true` fails at launch with the conflict message.
- Jazzy: `sim_isaac:=true` exercised live against an Isaac Sim 5.1 twin of a 2F-85 (open, close, close-on-object through `gripper_cmd`) before the stall change. With `allow_stalling: false` a close-on-object is expected to come back as an aborted goal with `stalled: true`, per the controller source; that path is next exercised by the MCP client work that consumes it.
- black, flake8, codespell clean.

## Stack
Stacked on #51: this PR shows only its own 9 commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
