### PR TITLE
feat(mcp): backend protocol and mock backend

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,4 +7,5 @@ select = E,F,W,C,B590
 # Ignore W503 - Line break occurred before a binary operator - because this error is introduced by Black formatter.
 # Ignore E203 - whitespace before ':' - because Black includes spaces in formatting slice expressions.
 # Ignore E501 - line too long - in favor of B590, which is more forgiving of long strings and comments that would be silly to break up.
-extend-ignore = W503, E203, E501
+# Ignore E704 - multiple statements on one line (def) - because Black puts `...`-only stubs (Protocol methods) on one line.
+extend-ignore = W503, E203, E501, E704

--- a/mcp/gripper_mcp/backend.py
+++ b/mcp/gripper_mcp/backend.py
@@ -1,0 +1,52 @@
+"""What a gripper backend has to provide.
+
+Backends speak the controller's domain, the command joint's position in radians
+(0 = open), and know nothing about millimetres, pydantic or MCP; the service
+layer owns that translation. This is what lets the same tool surface sit on the
+ROS driver, real or simulated, or on a mock without any of them leaking into the
+tool signatures.
+
+The vocabulary is the `gripper_cmd` action's: a position and a max effort in,
+`reached_goal` and `stalled` out. A stall on a close is how the driver reports
+an object between the fingers, so backends pass it through untouched and never
+decide for the caller whether it was wanted.
+"""
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class BackendState:
+    position_rad: float
+    force_n: float | None = None
+
+
+@dataclass(frozen=True)
+class BackendMotion:
+    final_position_rad: float
+    reached_goal: bool
+    stalled: bool
+    refused: bool = False
+    timed_out: bool = False
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class BackendHealth:
+    reachable: bool
+    controller_active: bool | None = None
+    detail: str = ""
+
+
+@runtime_checkable
+class GripperBackend(Protocol):
+    name: str
+
+    def read_state(self) -> BackendState: ...
+
+    def move_to(
+        self, position_rad: float, max_effort_n: float, timeout_s: float
+    ) -> BackendMotion: ...
+
+    def health(self) -> BackendHealth: ...

--- a/mcp/gripper_mcp/backend.py
+++ b/mcp/gripper_mcp/backend.py
@@ -3,13 +3,20 @@
 Backends speak the controller's domain, the command joint's position in radians
 (0 = open), and know nothing about millimetres, pydantic or MCP; the service
 layer owns that translation. This is what lets the same tool surface sit on the
-ROS driver, real or simulated, or on a mock without any of them leaking into the
-tool signatures.
+ROS driver, real or simulated, or on a test double without any of them leaking
+into the tool signatures.
 
 The vocabulary is the `gripper_cmd` action's: a position and a max effort in,
 `reached_goal` and `stalled` out. A stall on a close is how the driver reports
 an object between the fingers, so backends pass it through untouched and never
-decide for the caller whether it was wanted.
+decide for the caller whether it was wanted. `refused` is set when the backend
+rejected the goal before any motion, typically the action server turning it
+down; `timed_out` when the motion outlived its deadline.
+
+This contract is not MCP-specific: every Python client of the ROS driver wants
+"move to a position with a max effort, report reached or stalled". Its home is
+a ros client package alongside the ROS backend once that backend lands; it sits
+here until then, with the MCP as its first consumer.
 """
 
 from dataclasses import dataclass

--- a/mcp/gripper_mcp/mock_backend.py
+++ b/mcp/gripper_mcp/mock_backend.py
@@ -1,0 +1,120 @@
+"""Pure-Python mock gripper, the CI default backend.
+
+It exists to exercise the behaviours the service layer has to get right and a
+unit test cannot reach through the real driver: a close that stalls on an
+object, travel time, and a goal that outlives its timeout. An optional virtual
+object of a given width sits between the fingers; closing past it stalls there.
+
+Travel is simulated through an injected `sleep_fn` so tests run instantly while
+a container still moves in something like real time.
+"""
+
+import time
+from typing import Callable
+
+from gripper_mcp.backend import BackendHealth, BackendMotion, BackendState
+from gripper_mcp.units import (
+    GripperGeometry,
+    clamp,
+    knuckle_rad_to_opening_mm,
+    opening_mm_to_knuckle_rad,
+)
+
+MOCK_GEOMETRY = GripperGeometry(
+    max_opening_mm=85.0,
+    min_opening_mm=0.0,
+    knuckle_rad_open=0.0,
+    knuckle_rad_closed=0.8,
+)
+
+NOMINAL_TRAVEL_SPEED_MM_S = 150.0
+
+
+class MockGripperBackend:
+    name = "mock"
+
+    def __init__(
+        self,
+        object_width_mm: float | None = None,
+        travel_speed_mm_s: float = NOMINAL_TRAVEL_SPEED_MM_S,
+        sleep_fn: Callable[[float], None] = time.sleep,
+        geometry: GripperGeometry = MOCK_GEOMETRY,
+    ) -> None:
+        self._object_width_mm = object_width_mm
+        self._travel_speed_mm_s = travel_speed_mm_s
+        self._sleep = sleep_fn
+        self._geometry = geometry
+
+        self._position_rad = geometry.knuckle_rad_open
+        self._holding_force_n = 0.0
+
+    def opening_mm_for(self, position_rad: float) -> float:
+        return knuckle_rad_to_opening_mm(position_rad, self._geometry)
+
+    def position_rad_for(self, opening_mm: float) -> float:
+        return opening_mm_to_knuckle_rad(opening_mm, self._geometry)
+
+    def read_state(self) -> BackendState:
+        return BackendState(
+            position_rad=self._position_rad, force_n=self._holding_force_n
+        )
+
+    def move_to(
+        self, position_rad: float, max_effort_n: float, timeout_s: float
+    ) -> BackendMotion:
+        target = clamp(
+            position_rad,
+            self._geometry.knuckle_rad_open,
+            self._geometry.knuckle_rad_closed,
+        )
+        stop_at, stalled = self._resolve_stop(target)
+
+        travel_mm = abs(
+            self.opening_mm_for(stop_at) - self.opening_mm_for(self._position_rad)
+        )
+        duration_s = travel_mm / self._travel_speed_mm_s
+        if duration_s > timeout_s:
+            self._sleep(timeout_s)
+            return BackendMotion(
+                final_position_rad=self._position_rad,
+                reached_goal=False,
+                stalled=False,
+                timed_out=True,
+                detail=(
+                    f"Motion did not complete within {timeout_s:.3f} s "
+                    f"(needs {duration_s:.3f} s)."
+                ),
+            )
+
+        self._sleep(duration_s)
+        self._position_rad = stop_at
+        self._holding_force_n = max_effort_n if stalled else 0.0
+
+        return BackendMotion(
+            final_position_rad=stop_at,
+            reached_goal=not stalled,
+            stalled=stalled,
+            detail=(
+                "Stopped early against an object."
+                if stalled
+                else "Reached the commanded position."
+            ),
+        )
+
+    def health(self) -> BackendHealth:
+        opening_mm = self.opening_mm_for(self._position_rad)
+        return BackendHealth(
+            reachable=True,
+            controller_active=True,
+            detail=f"Mock gripper at {opening_mm:.1f} mm.",
+        )
+
+    def _resolve_stop(self, target: float) -> tuple[float, bool]:
+        closing = target > self._position_rad
+        if not closing or self._object_width_mm is None:
+            return target, False
+
+        obstruction = self.position_rad_for(self._object_width_mm)
+        if target <= obstruction:
+            return target, False
+        return obstruction, True

--- a/mcp/tests/fakes/gripper.py
+++ b/mcp/tests/fakes/gripper.py
@@ -1,16 +1,22 @@
-"""Pure-Python mock gripper, the CI default backend.
+"""Pure-Python mock gripper, a test double for the service layer.
 
 It exists to exercise the behaviours the service layer has to get right and a
 unit test cannot reach through the real driver: a close that stalls on an
 object, travel time, and a goal that outlives its timeout. An optional virtual
 object of a given width sits between the fingers; closing past it stalls there.
+A width outside the stroke is refused up front, since a real gripper cannot
+stall before it starts moving.
+
+It is deliberately not part of the shipped package. Running the MCP without
+hardware is the ROS driver's job, on the SDK's fake gripper (`use_dummy`), so
+that the driver, the controller and the action are exercised too.
 
 Travel is simulated through an injected `sleep_fn` so tests run instantly while
 a container still moves in something like real time.
 """
 
 import time
-from typing import Callable
+from collections.abc import Callable
 
 from gripper_mcp.backend import BackendHealth, BackendMotion, BackendState
 from gripper_mcp.units import (
@@ -40,6 +46,14 @@ class MockGripperBackend:
         sleep_fn: Callable[[float], None] = time.sleep,
         geometry: GripperGeometry = MOCK_GEOMETRY,
     ) -> None:
+        if object_width_mm is not None and not (
+            geometry.min_opening_mm < object_width_mm < geometry.max_opening_mm
+        ):
+            raise ValueError(
+                f"object_width_mm={object_width_mm} is outside the stroke "
+                f"({geometry.min_opening_mm}, {geometry.max_opening_mm}) mm"
+            )
+
         self._object_width_mm = object_width_mm
         self._travel_speed_mm_s = travel_speed_mm_s
         self._sleep = sleep_fn

--- a/mcp/tests/test_mock_backend.py
+++ b/mcp/tests/test_mock_backend.py
@@ -1,0 +1,108 @@
+import pytest
+
+from gripper_mcp.backend import GripperBackend
+from gripper_mcp.mock_backend import MOCK_GEOMETRY, MockGripperBackend
+
+CLOSED = MOCK_GEOMETRY.knuckle_rad_closed
+OPEN = MOCK_GEOMETRY.knuckle_rad_open
+MAX_EFFORT_N = 50.0
+GENEROUS_TIMEOUT_S = 30.0
+CUBE_WIDTH_MM = 40.0
+
+
+def instant_mock(**kwargs) -> MockGripperBackend:
+    return MockGripperBackend(sleep_fn=lambda _seconds: None, **kwargs)
+
+
+def test_the_mock_satisfies_the_backend_protocol():
+    assert isinstance(instant_mock(), GripperBackend)
+
+
+def test_a_fresh_mock_starts_open():
+    assert instant_mock().read_state().position_rad == OPEN
+
+
+def test_closing_on_empty_space_reaches_the_goal():
+    motion = instant_mock().move_to(CLOSED, MAX_EFFORT_N, GENEROUS_TIMEOUT_S)
+
+    assert motion.reached_goal is True
+    assert motion.stalled is False
+    assert motion.final_position_rad == CLOSED
+
+
+def test_closing_on_a_virtual_object_stalls():
+    backend = instant_mock(object_width_mm=CUBE_WIDTH_MM)
+
+    motion = backend.move_to(CLOSED, MAX_EFFORT_N, GENEROUS_TIMEOUT_S)
+
+    assert motion.stalled is True
+    assert motion.reached_goal is False
+
+
+def test_a_stall_stops_at_the_object_width():
+    backend = instant_mock(object_width_mm=CUBE_WIDTH_MM)
+
+    motion = backend.move_to(CLOSED, MAX_EFFORT_N, GENEROUS_TIMEOUT_S)
+
+    assert backend.opening_mm_for(motion.final_position_rad) == pytest.approx(
+        CUBE_WIDTH_MM
+    )
+
+
+def test_a_stall_reports_the_commanded_effort_as_grip_force():
+    backend = instant_mock(object_width_mm=CUBE_WIDTH_MM)
+
+    backend.move_to(CLOSED, MAX_EFFORT_N, GENEROUS_TIMEOUT_S)
+
+    assert backend.read_state().force_n == MAX_EFFORT_N
+
+
+def test_an_object_narrower_than_the_target_does_not_stall():
+    backend = instant_mock(object_width_mm=10.0)
+
+    motion = backend.move_to(
+        backend.position_rad_for(50.0), MAX_EFFORT_N, GENEROUS_TIMEOUT_S
+    )
+
+    assert motion.reached_goal is True
+    assert motion.stalled is False
+
+
+def test_opening_after_a_grasp_releases_without_stalling():
+    backend = instant_mock(object_width_mm=CUBE_WIDTH_MM)
+    backend.move_to(CLOSED, MAX_EFFORT_N, GENEROUS_TIMEOUT_S)
+
+    motion = backend.move_to(OPEN, MAX_EFFORT_N, GENEROUS_TIMEOUT_S)
+
+    assert motion.reached_goal is True
+    assert motion.final_position_rad == OPEN
+    assert backend.read_state().force_n == 0.0
+
+
+def test_a_target_past_the_stroke_is_clamped():
+    motion = instant_mock().move_to(CLOSED + 1.0, MAX_EFFORT_N, GENEROUS_TIMEOUT_S)
+
+    assert motion.final_position_rad == CLOSED
+
+
+def test_a_move_slower_than_its_timeout_reports_timed_out_and_stays_put():
+    backend = instant_mock(travel_speed_mm_s=100.0)
+
+    motion = backend.move_to(CLOSED, MAX_EFFORT_N, timeout_s=0.001)
+
+    assert motion.timed_out is True
+    assert motion.reached_goal is False
+    assert backend.read_state().position_rad == OPEN
+
+
+def test_travel_time_grows_with_distance():
+    slept: list[float] = []
+    backend = MockGripperBackend(sleep_fn=slept.append)
+
+    backend.move_to(backend.position_rad_for(60.0), MAX_EFFORT_N, GENEROUS_TIMEOUT_S)
+    short = sum(slept)
+    slept.clear()
+    backend.move_to(CLOSED, MAX_EFFORT_N, GENEROUS_TIMEOUT_S)
+    long = sum(slept)
+
+    assert long > short

--- a/mcp/tests/test_mock_backend.py
+++ b/mcp/tests/test_mock_backend.py
@@ -1,7 +1,7 @@
 import pytest
 
 from gripper_mcp.backend import GripperBackend
-from gripper_mcp.mock_backend import MOCK_GEOMETRY, MockGripperBackend
+from fakes.gripper import MOCK_GEOMETRY, MockGripperBackend
 
 CLOSED = MOCK_GEOMETRY.knuckle_rad_closed
 OPEN = MOCK_GEOMETRY.knuckle_rad_open
@@ -77,6 +77,11 @@ def test_opening_after_a_grasp_releases_without_stalling():
     assert motion.reached_goal is True
     assert motion.final_position_rad == OPEN
     assert backend.read_state().force_n == 0.0
+
+
+def test_an_object_wider_than_the_stroke_is_refused():
+    with pytest.raises(ValueError, match="outside the stroke"):
+        instant_mock(object_width_mm=MOCK_GEOMETRY.max_opening_mm + 1.0)
 
 
 def test_a_target_past_the_stroke_is_clamped():


### PR DESCRIPTION
## Change

Third PR of the `mcp/` series (stacked on #56). The seam between the tool surface and whatever moves the fingers:

1. **`backend.py`** — the `GripperBackend` protocol and its three result dataclasses. Backends speak the command joint's position in radians and nothing else; the service layer (next PR but one) owns the millimetre conversion and the pydantic models. The vocabulary is the driver's `gripper_cmd` action: position + max effort in, `reached_goal` + `stalled` out. A stall is passed through untouched; deciding whether it was a wanted grasp is the caller's job.
2. **`mock_backend.py`** — the CI default. A virtual object of a given width sits between the fingers: closing past it stalls there and the commanded effort becomes the reported grip force. Travel time comes from an injected sleep so tests run instantly, and a goal slower than its timeout comes back `timed_out` with the fingers where they were.

Not carried over from gripper-mcp, deliberately: the speed byte, activation, fault codes and register domain (the `gripper_cmd` action exposes none of them), and `close()` on the protocol (tearing down an rclpy node belongs to whoever builds the ROS backend, not to the service-facing interface).

## Verification

- `uv run pytest`: 25 passed (11 new). Mock: satisfies the protocol, starts open, reaches the goal on empty space, stalls at the object width with the effort as grip force, a narrower object does not stall, opening after a grasp releases, targets past the stroke clamp, a slow move times out without moving, travel time grows with distance.
- `pre-commit run --all-files`: green.

## Stack
Stacked on #56: this PR shows only its own 2 commits.
