### PR TITLE
feat(mcp): service layer and outcome classification

### DIFF
--- a/mcp/gripper_mcp/config.py
+++ b/mcp/gripper_mcp/config.py
@@ -12,8 +12,8 @@ Two kinds of files, deliberately split:
   example to copy.
 
 The only backend is the ROS driver. Running without hardware is the driver's
-job too, on the SDK's fake gripper (`use_dummy`), so the wiring has no mock
-entry to offer.
+job too, on ros2_control's fake hardware (`use_fake_hardware`), so the wiring
+has no mock entry to offer.
 
 Every model refuses unknown keys: these files are hand-edited per host, and a
 typo that silently dropped a field would point the server at the wrong robot.

--- a/mcp/gripper_mcp/datasheets/robotiq_2f_140.yaml
+++ b/mcp/gripper_mcp/datasheets/robotiq_2f_140.yaml
@@ -5,6 +5,12 @@ model: robotiq_2f_140
 stroke:
   max_opening_mm: 140.0
   min_opening_mm: 0.0
+  # Fallback margin for "the fingers met": an opening within this of
+  # min_opening_mm counts as closed on nothing. A real 2F-85 wearing TSF
+  # fingers settles 0.75 mm short of the description's closed angle, and one
+  # position-register count is stroke/227 (0.62 mm on this model), so a
+  # close can legitimately land a count or two short of the stop.
+  closed_tolerance_mm: 1.5
 
 grip_force:
   min_n: 10.0

--- a/mcp/gripper_mcp/datasheets/robotiq_2f_140.yaml
+++ b/mcp/gripper_mcp/datasheets/robotiq_2f_140.yaml
@@ -5,12 +5,12 @@ model: robotiq_2f_140
 stroke:
   max_opening_mm: 140.0
   min_opening_mm: 0.0
-  # Fallback margin for "the fingers met": an opening within this of
-  # min_opening_mm counts as closed on nothing. One position-register count
-  # is stroke/227 = 0.62 mm on this model, so two counts is 1.23 mm; the
-  # driver truncates and can land a close a count short of the stop. 1.5 mm
-  # sits above two counts with room for mechanical settle, which nobody has
-  # measured on a 2F-140 yet.
+  # Margin for every position comparison the service makes: a move that
+  # ends within this of its target reached it, a close that ends further
+  # than this from the stop found something. One position-register count
+  # is stroke/227 = 0.62 mm on this model and the driver truncates, so a
+  # correct move can land a count or two off; 1.5 mm sits above two counts
+  # with room for mechanical settle, which nobody has measured on a 2F-140.
   closed_tolerance_mm: 1.5
 
 grip_force:

--- a/mcp/gripper_mcp/datasheets/robotiq_2f_140.yaml
+++ b/mcp/gripper_mcp/datasheets/robotiq_2f_140.yaml
@@ -6,10 +6,11 @@ stroke:
   max_opening_mm: 140.0
   min_opening_mm: 0.0
   # Fallback margin for "the fingers met": an opening within this of
-  # min_opening_mm counts as closed on nothing. A real 2F-85 wearing TSF
-  # fingers settles 0.75 mm short of the description's closed angle, and one
-  # position-register count is stroke/227 (0.62 mm on this model), so a
-  # close can legitimately land a count or two short of the stop.
+  # min_opening_mm counts as closed on nothing. One position-register count
+  # is stroke/227 = 0.62 mm on this model, so two counts is 1.23 mm; the
+  # driver truncates and can land a close a count short of the stop. 1.5 mm
+  # sits above two counts with room for mechanical settle, which nobody has
+  # measured on a 2F-140 yet.
   closed_tolerance_mm: 1.5
 
 grip_force:

--- a/mcp/gripper_mcp/datasheets/robotiq_2f_85.yaml
+++ b/mcp/gripper_mcp/datasheets/robotiq_2f_85.yaml
@@ -12,11 +12,13 @@ model: robotiq_2f_85
 stroke:
   max_opening_mm: 85.0
   min_opening_mm: 0.0
-  # Fallback margin for "the fingers met": an opening within this of
-  # min_opening_mm counts as closed on nothing. A real 2F-85 wearing TSF
-  # fingers settles 0.75 mm short of the description's closed angle, and one
-  # position-register count is stroke/227 (0.37 mm on this model), so a
-  # close can legitimately land a count or two short of the stop.
+  # Margin for every position comparison the service makes: a move that
+  # ends within this of its target reached it, a close that ends further
+  # than this from the stop found something. One position-register count
+  # is stroke/227 = 0.37 mm on this model and the driver truncates, so a
+  # correct move can land a count or two off; 1.5 mm sits above two counts
+  # and covers a real 2F-85 wearing TSF fingers, which settles 0.75 mm short
+  # of the description's closed angle.
   closed_tolerance_mm: 1.5
 
 # Rated grip force, product datasheet. Distinct from the URDF's joint effort

--- a/mcp/gripper_mcp/datasheets/robotiq_2f_85.yaml
+++ b/mcp/gripper_mcp/datasheets/robotiq_2f_85.yaml
@@ -12,6 +12,12 @@ model: robotiq_2f_85
 stroke:
   max_opening_mm: 85.0
   min_opening_mm: 0.0
+  # Fallback margin for "the fingers met": an opening within this of
+  # min_opening_mm counts as closed on nothing. A real 2F-85 wearing TSF
+  # fingers settles 0.75 mm short of the description's closed angle, and one
+  # position-register count is stroke/227 (0.37 mm on this model), so a
+  # close can legitimately land a count or two short of the stop.
+  closed_tolerance_mm: 1.5
 
 # Rated grip force, product datasheet. Distinct from the URDF's joint effort
 # limit, which is a torque in N-m.

--- a/mcp/gripper_mcp/models.py
+++ b/mcp/gripper_mcp/models.py
@@ -16,6 +16,7 @@ Backend = Literal["ros", "mock"]
 Outcome = Literal[
     "reached",
     "grasped",
+    "closed_without_object",
     "stalled_unexpectedly",
     "incomplete",
     "not_supported",
@@ -54,7 +55,8 @@ class GripperMotionResult(BaseModel):
     reached_goal: bool
     stalled: bool = Field(description="Stopped early against resistance")
     object_grasped: bool | None = Field(
-        default=None, description="Set by gripper_grasp: a stalled close is a grasp"
+        default=None,
+        description="Set by gripper_grasp: stopped on something before fully closing",
     )
     outcome: Outcome
     detail: str = Field(description="Verbatim backend message; never invented")

--- a/mcp/gripper_mcp/service.py
+++ b/mcp/gripper_mcp/service.py
@@ -1,0 +1,171 @@
+"""Translation between the MCP tool surface and the backends.
+
+Backends speak the command joint's angle; tools speak millimetres. Everything in
+between, unit conversion, outcome classification, per-gripper dispatch, lives
+here so it can be tested without a FastMCP server or a ROS graph.
+
+The one piece of domain judgement in this file is `classify`: a close that
+stalls before the fingers meet is a *successful grasp*, not a failure, and a
+close that stalls with the fingers together grasped nothing. That semantic used
+to live as prose in an agent prompt, where it can be forgotten; here it is in
+the type system.
+"""
+
+from datetime import datetime, timezone
+
+from gripper_mcp.backend import BackendMotion, GripperBackend
+from gripper_mcp.config import GripperConfig, GripperModelSpec
+from gripper_mcp.models import (
+    GripperHealth,
+    GripperInfo,
+    GripperMotionResult,
+    GripperState,
+    Outcome,
+)
+from gripper_mcp.units import (
+    GripperGeometry,
+    clamp_opening_mm,
+    knuckle_rad_to_opening_mm,
+    opening_mm_to_fraction,
+    opening_mm_to_knuckle_rad,
+)
+
+OPENING_TOLERANCE_MM = 0.5
+
+
+class UnknownGripperError(Exception):
+    pass
+
+
+class GripperService:
+    def __init__(
+        self,
+        specs: dict[str, GripperModelSpec],
+        configs: dict[str, GripperConfig],
+        backends: dict[str, GripperBackend],
+    ) -> None:
+        self._specs = specs
+        self._configs = configs
+        self._backends = backends
+
+    def list_grippers(self) -> list[GripperInfo]:
+        return [
+            GripperInfo(
+                robot_name=name,
+                model=config.model,
+                backend=self._backends[name].name,
+                description=config.description,
+            )
+            for name, config in self._configs.items()
+        ]
+
+    def get_state(self, robot_name: str) -> GripperState:
+        backend = self._backend(robot_name)
+        geometry = self._spec(robot_name).geometry
+        state = backend.read_state()
+        opening_mm = knuckle_rad_to_opening_mm(state.position_rad, geometry)
+
+        return GripperState(
+            robot_name=robot_name,
+            opening_mm=round(opening_mm, 2),
+            opening_fraction=round(opening_mm_to_fraction(opening_mm, geometry), 4),
+            knuckle_rad=round(state.position_rad, 4),
+            force_n=state.force_n,
+            backend=backend.name,
+            measured_at=datetime.now(timezone.utc),
+        )
+
+    def open_fully(self, robot_name: str) -> GripperMotionResult:
+        geometry = self._spec(robot_name).geometry
+        return self.move_to_opening(robot_name, geometry.max_opening_mm)
+
+    def close_fully(self, robot_name: str) -> GripperMotionResult:
+        geometry = self._spec(robot_name).geometry
+        return self.move_to_opening(robot_name, geometry.min_opening_mm)
+
+    def grasp(
+        self, robot_name: str, max_effort_n: float | None = None
+    ) -> GripperMotionResult:
+        geometry = self._spec(robot_name).geometry
+        return self.move_to_opening(
+            robot_name, geometry.min_opening_mm, max_effort_n, is_grasp=True
+        )
+
+    def move_to_opening(
+        self,
+        robot_name: str,
+        opening_mm: float,
+        max_effort_n: float | None = None,
+        is_grasp: bool = False,
+    ) -> GripperMotionResult:
+        backend = self._backend(robot_name)
+        spec = self._spec(robot_name)
+        target_mm = clamp_opening_mm(opening_mm, spec.geometry)
+        motion = backend.move_to(
+            position_rad=opening_mm_to_knuckle_rad(target_mm, spec.geometry),
+            max_effort_n=(
+                spec.defaults.max_effort_n if max_effort_n is None else max_effort_n
+            ),
+            timeout_s=spec.defaults.motion_timeout_s,
+        )
+        achieved_mm = knuckle_rad_to_opening_mm(
+            motion.final_position_rad, spec.geometry
+        )
+        stopped_on_object = stopped_on_something(motion, achieved_mm, spec.geometry)
+
+        return GripperMotionResult(
+            robot_name=robot_name,
+            commanded_opening_mm=round(target_mm, 2),
+            achieved_opening_mm=None if motion.refused else round(achieved_mm, 2),
+            reached_goal=motion.reached_goal,
+            stalled=motion.stalled,
+            object_grasped=stopped_on_object if is_grasp else None,
+            outcome=classify(motion, stopped_on_object, is_grasp),
+            detail=motion.detail,
+            backend=backend.name,
+        )
+
+    def get_health(self, robot_name: str) -> GripperHealth:
+        backend = self._backend(robot_name)
+        health = backend.health()
+
+        return GripperHealth(
+            robot_name=robot_name,
+            reachable=health.reachable,
+            controller_active=health.controller_active,
+            detail=health.detail,
+            backend=backend.name,
+        )
+
+    def _backend(self, robot_name: str) -> GripperBackend:
+        if robot_name not in self._backends:
+            available = ", ".join(self._backends) or "(none)"
+            raise UnknownGripperError(
+                f"Unknown gripper '{robot_name}'. Available: {available}"
+            )
+        return self._backends[robot_name]
+
+    def _spec(self, robot_name: str) -> GripperModelSpec:
+        return self._specs[self._configs[robot_name].model]
+
+
+def stopped_on_something(
+    motion: BackendMotion, achieved_mm: float, geometry: GripperGeometry
+) -> bool:
+    return (
+        motion.stalled and achieved_mm > geometry.min_opening_mm + OPENING_TOLERANCE_MM
+    )
+
+
+def classify(motion: BackendMotion, stopped_on_object: bool, is_grasp: bool) -> Outcome:
+    if motion.refused:
+        return "refused"
+    if motion.timed_out:
+        return "incomplete"
+    if is_grasp and (motion.stalled or motion.reached_goal):
+        return "grasped" if stopped_on_object else "closed_without_object"
+    if motion.stalled:
+        return "stalled_unexpectedly"
+    if motion.reached_goal:
+        return "reached"
+    return "incomplete"

--- a/mcp/gripper_mcp/service.py
+++ b/mcp/gripper_mcp/service.py
@@ -143,15 +143,19 @@ class GripperService:
             backend=backend.name,
         )
 
-    def _backend(self, robot_name: str) -> GripperBackend:
-        if robot_name not in self._backends:
-            available = ", ".join(self._backends) or "(none)"
+    def assert_known(self, robot_name: str) -> None:
+        if robot_name not in self._configs:
+            available = ", ".join(self._configs) or "(none)"
             raise UnknownGripperError(
                 f"Unknown gripper '{robot_name}'. Available: {available}"
             )
+
+    def _backend(self, robot_name: str) -> GripperBackend:
+        self.assert_known(robot_name)
         return self._backends[robot_name]
 
     def _spec(self, robot_name: str) -> GripperModelSpec:
+        self.assert_known(robot_name)
         return self._specs[self._configs[robot_name].model]
 
     def _geometry(self, robot_name: str):

--- a/mcp/gripper_mcp/service.py
+++ b/mcp/gripper_mcp/service.py
@@ -61,7 +61,7 @@ class GripperService:
 
     def get_state(self, robot_name: str) -> GripperState:
         backend = self._backend(robot_name)
-        geometry = self._spec(robot_name).geometry
+        geometry = self._geometry(robot_name)
         state = backend.read_state()
         opening_mm = knuckle_rad_to_opening_mm(state.position_rad, geometry)
 
@@ -76,19 +76,19 @@ class GripperService:
         )
 
     def open_fully(self, robot_name: str) -> GripperMotionResult:
-        geometry = self._spec(robot_name).geometry
-        return self.move_to_opening(robot_name, geometry.max_opening_mm)
+        stroke = self._spec(robot_name).stroke
+        return self.move_to_opening(robot_name, stroke.max_opening_mm)
 
     def close_fully(self, robot_name: str) -> GripperMotionResult:
-        geometry = self._spec(robot_name).geometry
-        return self.move_to_opening(robot_name, geometry.min_opening_mm)
+        stroke = self._spec(robot_name).stroke
+        return self.move_to_opening(robot_name, stroke.min_opening_mm)
 
     def grasp(
         self, robot_name: str, max_effort_n: float | None = None
     ) -> GripperMotionResult:
-        geometry = self._spec(robot_name).geometry
+        stroke = self._spec(robot_name).stroke
         return self.move_to_opening(
-            robot_name, geometry.min_opening_mm, max_effort_n, is_grasp=True
+            robot_name, stroke.min_opening_mm, max_effort_n, is_grasp=True
         )
 
     def move_to_opening(
@@ -100,18 +100,17 @@ class GripperService:
     ) -> GripperMotionResult:
         backend = self._backend(robot_name)
         spec = self._spec(robot_name)
-        target_mm = clamp_opening_mm(opening_mm, spec.geometry)
+        geometry = self._geometry(robot_name)
+        target_mm = clamp_opening_mm(opening_mm, geometry)
         motion = backend.move_to(
-            position_rad=opening_mm_to_knuckle_rad(target_mm, spec.geometry),
+            position_rad=opening_mm_to_knuckle_rad(target_mm, geometry),
             max_effort_n=(
                 spec.defaults.max_effort_n if max_effort_n is None else max_effort_n
             ),
             timeout_s=spec.defaults.motion_timeout_s,
         )
-        achieved_mm = knuckle_rad_to_opening_mm(
-            motion.final_position_rad, spec.geometry
-        )
-        stopped_on_object = stopped_on_something(motion, achieved_mm, spec.geometry)
+        achieved_mm = knuckle_rad_to_opening_mm(motion.final_position_rad, geometry)
+        stopped_on_object = stopped_on_something(motion, achieved_mm, geometry)
 
         return GripperMotionResult(
             robot_name=robot_name,
@@ -147,6 +146,13 @@ class GripperService:
 
     def _spec(self, robot_name: str) -> GripperModelSpec:
         return self._specs[self._configs[robot_name].model]
+
+    def _geometry(self, robot_name: str):
+        return geometry_of(self._spec(robot_name), self._backend(robot_name))
+
+
+def geometry_of(spec: GripperModelSpec, backend: GripperBackend) -> GripperGeometry:
+    return GripperGeometry.of(spec.stroke, backend.joint_geometry())
 
 
 def stopped_on_something(

--- a/mcp/gripper_mcp/service.py
+++ b/mcp/gripper_mcp/service.py
@@ -31,6 +31,9 @@ from gripper_mcp.units import (
 )
 
 OPENING_TOLERANCE_MM = 0.5
+MM_DECIMALS = 2
+RAD_DECIMALS = 4
+FRACTION_DECIMALS = 4
 
 
 class UnknownGripperError(Exception):
@@ -67,9 +70,11 @@ class GripperService:
 
         return GripperState(
             robot_name=robot_name,
-            opening_mm=round(opening_mm, 2),
-            opening_fraction=round(opening_mm_to_fraction(opening_mm, geometry), 4),
-            knuckle_rad=round(state.position_rad, 4),
+            opening_mm=round(opening_mm, MM_DECIMALS),
+            opening_fraction=round(
+                opening_mm_to_fraction(opening_mm, geometry), FRACTION_DECIMALS
+            ),
+            knuckle_rad=round(state.position_rad, RAD_DECIMALS),
             force_n=state.force_n,
             backend=backend.name,
             measured_at=datetime.now(timezone.utc),
@@ -114,8 +119,10 @@ class GripperService:
 
         return GripperMotionResult(
             robot_name=robot_name,
-            commanded_opening_mm=round(target_mm, 2),
-            achieved_opening_mm=None if motion.refused else round(achieved_mm, 2),
+            commanded_opening_mm=round(target_mm, MM_DECIMALS),
+            achieved_opening_mm=(
+                None if motion.refused else round(achieved_mm, MM_DECIMALS)
+            ),
             reached_goal=motion.reached_goal,
             stalled=motion.stalled,
             object_grasped=stopped_on_object if is_grasp else None,

--- a/mcp/gripper_mcp/service.py
+++ b/mcp/gripper_mcp/service.py
@@ -24,13 +24,13 @@ from gripper_mcp.models import (
 )
 from gripper_mcp.units import (
     GripperGeometry,
+    Stroke,
     clamp_opening_mm,
     knuckle_rad_to_opening_mm,
     opening_mm_to_fraction,
     opening_mm_to_knuckle_rad,
 )
 
-OPENING_TOLERANCE_MM = 0.5
 MM_DECIMALS = 2
 RAD_DECIMALS = 4
 FRACTION_DECIMALS = 4
@@ -115,7 +115,7 @@ class GripperService:
             timeout_s=spec.defaults.motion_timeout_s,
         )
         achieved_mm = knuckle_rad_to_opening_mm(motion.final_position_rad, geometry)
-        stopped_on_object = stopped_on_something(motion, achieved_mm, geometry)
+        stopped_on_object = stopped_on_something(motion, achieved_mm, spec.stroke)
 
         return GripperMotionResult(
             robot_name=robot_name,
@@ -167,11 +167,9 @@ def geometry_of(spec: GripperModelSpec, backend: GripperBackend) -> GripperGeome
 
 
 def stopped_on_something(
-    motion: BackendMotion, achieved_mm: float, geometry: GripperGeometry
+    motion: BackendMotion, achieved_mm: float, stroke: Stroke
 ) -> bool:
-    return (
-        motion.stalled and achieved_mm > geometry.min_opening_mm + OPENING_TOLERANCE_MM
-    )
+    return motion.stalled and not stroke.fingers_met(achieved_mm)
 
 
 def classify(motion: BackendMotion, stopped_on_object: bool, is_grasp: bool) -> Outcome:

--- a/mcp/gripper_mcp/service.py
+++ b/mcp/gripper_mcp/service.py
@@ -5,10 +5,18 @@ between, unit conversion, outcome classification, per-gripper dispatch, lives
 here so it can be tested without a FastMCP server or a ROS graph.
 
 The one piece of domain judgement in this file is `classify`: a close that
-stalls before the fingers meet is a *successful grasp*, not a failure, and a
-close that stalls with the fingers together grasped nothing. That semantic used
+stops before the fingers meet is a *successful grasp*, not a failure, and a
+close that ends with the fingers together grasped nothing. That semantic used
 to live as prose in an agent prompt, where it can be forgotten; here it is in
 the type system.
+
+The verdict is read from where the fingers ended up against where they were
+sent, never from the controller's `stalled` flag. On the real driver that flag
+is set on every goal (robotiq/ros#29: no velocity is ever computed, so stall
+detection trips at once), so it is reported to the caller as-is but does not
+steer the outcome. This is a stopgap in its own right: the gripper's firmware
+reports object detection outright (gOBJ, the `object_status` state interface)
+and once a broadcaster carries it the position comparison goes too.
 """
 
 from datetime import datetime, timezone
@@ -64,7 +72,7 @@ class GripperService:
 
     def get_state(self, robot_name: str) -> GripperState:
         backend = self._backend(robot_name)
-        geometry = self._geometry(robot_name)
+        geometry = geometry_of(self._spec(robot_name), backend)
         state = backend.read_state()
         opening_mm = knuckle_rad_to_opening_mm(state.position_rad, geometry)
 
@@ -105,7 +113,7 @@ class GripperService:
     ) -> GripperMotionResult:
         backend = self._backend(robot_name)
         spec = self._spec(robot_name)
-        geometry = self._geometry(robot_name)
+        geometry = geometry_of(spec, backend)
         target_mm = clamp_opening_mm(opening_mm, geometry)
         motion = backend.move_to(
             position_rad=opening_mm_to_knuckle_rad(target_mm, geometry),
@@ -115,7 +123,7 @@ class GripperService:
             timeout_s=spec.defaults.motion_timeout_s,
         )
         achieved_mm = knuckle_rad_to_opening_mm(motion.final_position_rad, geometry)
-        stopped_on_object = stopped_on_something(motion, achieved_mm, spec.stroke)
+        stopped_on_object = stopped_on_something(target_mm, achieved_mm, spec.stroke)
 
         return GripperMotionResult(
             robot_name=robot_name,
@@ -126,8 +134,8 @@ class GripperService:
             reached_goal=motion.reached_goal,
             stalled=motion.stalled,
             object_grasped=stopped_on_object if is_grasp else None,
-            outcome=classify(motion, stopped_on_object, is_grasp),
-            detail=motion.detail,
+            outcome=classify(motion, target_mm, achieved_mm, spec.stroke, is_grasp),
+            detail=clamp_note(opening_mm, target_mm) + motion.detail,
             backend=backend.name,
         )
 
@@ -158,29 +166,42 @@ class GripperService:
         self.assert_known(robot_name)
         return self._specs[self._configs[robot_name].model]
 
-    def _geometry(self, robot_name: str):
-        return geometry_of(self._spec(robot_name), self._backend(robot_name))
-
 
 def geometry_of(spec: GripperModelSpec, backend: GripperBackend) -> GripperGeometry:
     return GripperGeometry.of(spec.stroke, backend.joint_geometry())
 
 
+def clamp_note(requested_mm: float, target_mm: float) -> str:
+    if requested_mm == target_mm:
+        return ""
+    return f"Requested {requested_mm:.1f} mm, clamped to {target_mm:.1f} mm. "
+
+
+def missed_target(commanded_mm: float, achieved_mm: float, stroke: Stroke) -> bool:
+    return abs(achieved_mm - commanded_mm) > stroke.closed_tolerance_mm
+
+
 def stopped_on_something(
-    motion: BackendMotion, achieved_mm: float, stroke: Stroke
+    commanded_mm: float, achieved_mm: float, stroke: Stroke
 ) -> bool:
-    return motion.stalled and not stroke.fingers_met(achieved_mm)
+    return achieved_mm - commanded_mm > stroke.closed_tolerance_mm
 
 
-def classify(motion: BackendMotion, stopped_on_object: bool, is_grasp: bool) -> Outcome:
+def classify(
+    motion: BackendMotion,
+    commanded_mm: float,
+    achieved_mm: float,
+    stroke: Stroke,
+    is_grasp: bool,
+) -> Outcome:
     if motion.refused:
         return "refused"
     if motion.timed_out:
         return "incomplete"
-    if is_grasp and (motion.stalled or motion.reached_goal):
-        return "grasped" if stopped_on_object else "closed_without_object"
-    if motion.stalled:
+    if is_grasp:
+        if stopped_on_something(commanded_mm, achieved_mm, stroke):
+            return "grasped"
+        return "closed_without_object"
+    if missed_target(commanded_mm, achieved_mm, stroke):
         return "stalled_unexpectedly"
-    if motion.reached_goal:
-        return "reached"
-    return "incomplete"
+    return "reached"

--- a/mcp/gripper_mcp/units.py
+++ b/mcp/gripper_mcp/units.py
@@ -31,11 +31,23 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class Stroke:
     max_opening_mm: float
+    closed_tolerance_mm: float
     min_opening_mm: float = 0.0
 
     def __post_init__(self) -> None:
         if self.max_opening_mm <= self.min_opening_mm:
             raise ValueError("max_opening_mm must exceed min_opening_mm")
+        if (
+            not 0.0
+            < self.closed_tolerance_mm
+            < self.max_opening_mm - self.min_opening_mm
+        ):
+            raise ValueError(
+                "closed_tolerance_mm must be positive and inside the stroke"
+            )
+
+    def fingers_met(self, opening_mm: float) -> bool:
+        return opening_mm <= self.min_opening_mm + self.closed_tolerance_mm
 
 
 @dataclass(frozen=True)

--- a/mcp/tests/fakes/gripper.py
+++ b/mcp/tests/fakes/gripper.py
@@ -29,7 +29,7 @@ from gripper_mcp.units import (
 )
 
 MOCK_JOINT = JointGeometry(name="mock_knuckle_joint", rad_open=0.0, rad_closed=0.8)
-MOCK_STROKE = Stroke(max_opening_mm=85.0)
+MOCK_STROKE = Stroke(max_opening_mm=85.0, closed_tolerance_mm=1.5)
 MOCK_GEOMETRY = GripperGeometry.of(MOCK_STROKE, MOCK_JOINT)
 
 NOMINAL_TRAVEL_SPEED_MM_S = 150.0

--- a/mcp/tests/fakes/gripper.py
+++ b/mcp/tests/fakes/gripper.py
@@ -8,8 +8,8 @@ A width outside the stroke is refused up front, since a real gripper cannot
 stall before it starts moving.
 
 It is deliberately not part of the shipped package. Running the MCP without
-hardware is the ROS driver's job, on the SDK's fake gripper (`use_dummy`), so
-that the driver, the controller and the action are exercised too.
+hardware is the ROS driver's job, on ros2_control's fake hardware
+(`use_fake_hardware`), so that the controller and the action are exercised too.
 
 Travel is simulated through an injected `sleep_fn` so tests run instantly while
 a container still moves in something like real time.

--- a/mcp/tests/test_mock_backend.py
+++ b/mcp/tests/test_mock_backend.py
@@ -28,7 +28,7 @@ def test_the_mock_reports_its_built_in_joint():
 
 
 def test_the_mock_takes_the_datasheet_stroke_for_its_mm_map():
-    backend = instant_mock(stroke=Stroke(max_opening_mm=140.0))
+    backend = instant_mock(stroke=Stroke(max_opening_mm=140.0, closed_tolerance_mm=1.5))
 
     assert backend.opening_mm_for(OPEN) == pytest.approx(140.0)
     assert backend.opening_mm_for(CLOSED) == pytest.approx(0.0)

--- a/mcp/tests/test_service.py
+++ b/mcp/tests/test_service.py
@@ -7,6 +7,7 @@ from gripper_mcp.service import (
     GripperService,
     UnknownGripperError,
     classify,
+    missed_target,
     stopped_on_something,
 )
 from gripper_mcp.units import Stroke
@@ -176,49 +177,95 @@ def test_each_gripper_opens_to_its_own_model_width():
     assert service.open_fully("wide").commanded_opening_mm == pytest.approx(140.0)
 
 
-@pytest.mark.parametrize(
-    ("result", "stopped_on_object", "is_grasp", "outcome"),
-    [
-        (motion(refused=True), False, True, "refused"),
-        (motion(reached_goal=False, timed_out=True), False, True, "incomplete"),
-        (motion(reached_goal=False, stalled=True), True, True, "grasped"),
-        (
-            motion(reached_goal=False, stalled=True),
-            False,
-            True,
-            "closed_without_object",
-        ),
-        (motion(reached_goal=True), False, True, "closed_without_object"),
-        (motion(reached_goal=False, stalled=True), True, False, "stalled_unexpectedly"),
-        (motion(reached_goal=True), False, False, "reached"),
-        (motion(reached_goal=False), False, False, "incomplete"),
-    ],
-)
-def test_classify_covers_every_way_a_motion_can_end(
-    result, stopped_on_object, is_grasp, outcome
-):
-    assert classify(result, stopped_on_object, is_grasp) == outcome
-
-
 STROKE_2F_140 = Stroke(max_opening_mm=140.0, closed_tolerance_mm=1.5)
 ONE_COUNT_2F_140_MM = 140.0 / 227
 TSF_CLOSED_MM = 0.75
 
 
 @pytest.mark.parametrize(
-    ("result", "achieved_mm", "stopped"),
+    ("result", "commanded_mm", "achieved_mm", "is_grasp", "outcome"),
     [
-        (motion(reached_goal=False, stalled=True), ONE_COUNT_2F_140_MM, False),
-        (motion(reached_goal=False, stalled=True), TSF_CLOSED_MM, False),
-        (motion(reached_goal=False, stalled=True), 40.0, True),
-        (motion(reached_goal=True), 40.0, False),
+        (motion(refused=True), 0.0, 85.0, True, "refused"),
+        (motion(reached_goal=False, timed_out=True), 0.0, 60.0, True, "incomplete"),
+        (motion(reached_goal=False, stalled=True), 0.0, 40.0, True, "grasped"),
+        (
+            motion(reached_goal=False, stalled=True),
+            0.0,
+            0.0,
+            True,
+            "closed_without_object",
+        ),
+        (motion(reached_goal=True), 0.0, 0.0, True, "closed_without_object"),
+        (
+            motion(reached_goal=False, stalled=True),
+            0.0,
+            40.0,
+            False,
+            "stalled_unexpectedly",
+        ),
+        (
+            motion(reached_goal=False, stalled=True),
+            85.0,
+            49.0,
+            False,
+            "stalled_unexpectedly",
+        ),
+        (motion(reached_goal=True), 30.0, 30.0, False, "reached"),
+        (motion(reached_goal=False, stalled=True), 30.0, 30.0, False, "reached"),
+    ],
+    ids=[
+        "refused",
+        "timed out",
+        "grasp stopped on something",
+        "grasp closed on nothing, stalled",
+        "grasp closed on nothing, reached",
+        "close blocked part-way",
+        "open blocked part-way",
+        "move landed",
+        "move landed but the driver says stalled (#29)",
+    ],
+)
+def test_classify_decides_from_position_not_the_stall_flag(
+    result, commanded_mm, achieved_mm, is_grasp, outcome
+):
+    assert (
+        classify(result, commanded_mm, achieved_mm, STROKE_2F_140, is_grasp) == outcome
+    )
+
+
+@pytest.mark.parametrize(
+    ("achieved_mm", "stopped"),
+    [
+        (ONE_COUNT_2F_140_MM, False),
+        (TSF_CLOSED_MM, False),
+        (40.0, True),
     ],
     ids=[
         "a count short of the stop is an empty close",
         "thicker fingers meeting early is an empty close",
-        "a stall well before the stop is a grasp",
-        "no stall is no object",
+        "stopping well before the stop is a grasp",
     ],
 )
-def test_the_closed_tolerance_decides_an_empty_close(result, achieved_mm, stopped):
-    assert stopped_on_something(result, achieved_mm, STROKE_2F_140) is stopped
+def test_the_closed_tolerance_decides_an_empty_close(achieved_mm, stopped):
+    assert stopped_on_something(0.0, achieved_mm, STROKE_2F_140) is stopped
+
+
+def test_a_move_within_the_tolerance_reached_its_target():
+    assert not missed_target(30.0, 30.0 + ONE_COUNT_2F_140_MM, STROKE_2F_140)
+    assert missed_target(30.0, 32.0, STROKE_2F_140)
+
+
+def test_an_out_of_range_request_says_so_in_the_detail():
+    service, _ = service_with()
+
+    result = service.move_to_opening(ARM, 500.0)
+
+    assert result.detail.startswith("Requested 500.0 mm, clamped to 85.0 mm. ")
+
+
+def test_an_in_range_request_keeps_the_backend_detail_verbatim():
+    service, _ = service_with()
+
+    result = service.move_to_opening(ARM, HALF_OPEN_MM)
+
+    assert result.detail == "Reached the commanded position."

--- a/mcp/tests/test_service.py
+++ b/mcp/tests/test_service.py
@@ -47,11 +47,24 @@ def test_a_fresh_gripper_reads_fully_open():
     assert state.knuckle_rad == pytest.approx(0.0)
 
 
-def test_an_unknown_gripper_is_named_with_the_available_ones():
+@pytest.mark.parametrize(
+    "call",
+    [
+        GripperService.get_state,
+        GripperService.open_fully,
+        GripperService.close_fully,
+        GripperService.grasp,
+        GripperService.get_health,
+        lambda service, name: service.move_to_opening(name, HALF_OPEN_MM),
+    ],
+)
+def test_an_unknown_gripper_is_named_with_the_available_ones_from_every_entry_point(
+    call,
+):
     service, _ = service_with()
 
     with pytest.raises(UnknownGripperError, match=ARM):
-        service.get_state("nonexistent")
+        call(service, "nonexistent")
 
 
 def test_closing_on_empty_space_reaches_the_target():

--- a/mcp/tests/test_service.py
+++ b/mcp/tests/test_service.py
@@ -1,8 +1,8 @@
 import pytest
+from fakes.gripper import MockGripperBackend
 
 from gripper_mcp.backend import BackendMotion
 from gripper_mcp.config import SPEC_DIR, GripperConfig, load_model_specs
-from gripper_mcp.mock_backend import MockGripperBackend
 from gripper_mcp.service import GripperService, UnknownGripperError, classify
 
 NARROW = "robotiq_2f_85"
@@ -21,7 +21,11 @@ def service_with(**backend_kwargs) -> tuple[GripperService, MockGripperBackend]:
     backend = MockGripperBackend(sleep_fn=lambda _seconds: None, **backend_kwargs)
     service = GripperService(
         specs=specs,
-        configs={ARM: GripperConfig(name=ARM, model=NARROW, description="left")},
+        configs={
+            ARM: GripperConfig(
+                name=ARM, model=NARROW, namespace="/left", description="left"
+            )
+        },
         backends={ARM: backend},
     )
     return service, backend
@@ -138,8 +142,8 @@ def test_health_passes_the_backend_verdict_through():
 def test_each_gripper_opens_to_its_own_model_width():
     specs = load_model_specs(SPEC_DIR, {NARROW, WIDE})
     configs = {
-        "narrow": GripperConfig(name="narrow", model=NARROW),
-        "wide": GripperConfig(name="wide", model=WIDE),
+        "narrow": GripperConfig(name="narrow", model=NARROW, namespace="/narrow"),
+        "wide": GripperConfig(name="wide", model=WIDE, namespace="/wide"),
     }
     backends = {
         name: MockGripperBackend(

--- a/mcp/tests/test_service.py
+++ b/mcp/tests/test_service.py
@@ -1,0 +1,177 @@
+import pytest
+
+from gripper_mcp.backend import BackendMotion
+from gripper_mcp.config import SPEC_DIR, GripperConfig, load_model_specs
+from gripper_mcp.mock_backend import MockGripperBackend
+from gripper_mcp.service import GripperService, UnknownGripperError, classify
+
+NARROW = "robotiq_2f_85"
+WIDE = "robotiq_2f_140"
+ARM = "left"
+CUBE_WIDTH_MM = 40.0
+FULLY_OPEN_MM = 85.0
+FULLY_CLOSED_MM = 0.0
+HALF_OPEN_MM = 42.5
+DATASHEET_EFFORT_N = 50.0
+GENTLE_EFFORT_N = 20.0
+
+
+def service_with(**backend_kwargs) -> tuple[GripperService, MockGripperBackend]:
+    specs = load_model_specs(SPEC_DIR, {NARROW})
+    backend = MockGripperBackend(sleep_fn=lambda _seconds: None, **backend_kwargs)
+    service = GripperService(
+        specs=specs,
+        configs={ARM: GripperConfig(name=ARM, model=NARROW, description="left")},
+        backends={ARM: backend},
+    )
+    return service, backend
+
+
+def motion(**overrides) -> BackendMotion:
+    fields = dict(final_position_rad=0.0, reached_goal=True, stalled=False)
+    fields.update(overrides)
+    return BackendMotion(**fields)
+
+
+def test_a_fresh_gripper_reads_fully_open():
+    service, _ = service_with()
+
+    state = service.get_state(ARM)
+
+    assert state.opening_mm == pytest.approx(FULLY_OPEN_MM)
+    assert state.opening_fraction == pytest.approx(1.0)
+    assert state.knuckle_rad == pytest.approx(0.0)
+
+
+def test_an_unknown_gripper_is_named_with_the_available_ones():
+    service, _ = service_with()
+
+    with pytest.raises(UnknownGripperError, match=ARM):
+        service.get_state("nonexistent")
+
+
+def test_closing_on_empty_space_reaches_the_target():
+    service, _ = service_with()
+
+    result = service.move_to_opening(ARM, FULLY_CLOSED_MM)
+
+    assert result.outcome == "reached"
+    assert result.achieved_opening_mm == pytest.approx(FULLY_CLOSED_MM)
+
+
+def test_the_state_follows_the_commanded_opening():
+    service, _ = service_with()
+
+    service.move_to_opening(ARM, HALF_OPEN_MM)
+
+    assert service.get_state(ARM).opening_mm == pytest.approx(HALF_OPEN_MM)
+
+
+def test_a_grasp_that_stops_on_an_object_is_a_success_with_reached_goal_false():
+    service, _ = service_with(object_width_mm=CUBE_WIDTH_MM)
+
+    result = service.grasp(ARM)
+
+    assert result.outcome == "grasped"
+    assert result.object_grasped is True
+    assert result.reached_goal is False
+    assert result.stalled is True
+    assert result.achieved_opening_mm == pytest.approx(CUBE_WIDTH_MM)
+
+
+def test_a_grasp_on_empty_space_closes_without_an_object():
+    service, _ = service_with()
+
+    result = service.grasp(ARM)
+
+    assert result.outcome == "closed_without_object"
+    assert result.object_grasped is False
+
+
+def test_a_plain_close_that_stalls_is_unexpected():
+    service, _ = service_with(object_width_mm=CUBE_WIDTH_MM)
+
+    result = service.close_fully(ARM)
+
+    assert result.outcome == "stalled_unexpectedly"
+    assert result.object_grasped is None
+
+
+def test_a_grasp_uses_the_datasheet_effort_unless_told_otherwise():
+    service, backend = service_with(object_width_mm=CUBE_WIDTH_MM)
+
+    service.grasp(ARM)
+    default_force = backend.read_state().force_n
+    service.open_fully(ARM)
+    service.grasp(ARM, max_effort_n=GENTLE_EFFORT_N)
+
+    assert default_force == DATASHEET_EFFORT_N
+    assert backend.read_state().force_n == GENTLE_EFFORT_N
+
+
+def test_an_opening_beyond_the_stroke_is_clamped():
+    service, _ = service_with()
+
+    result = service.move_to_opening(ARM, 500.0)
+
+    assert result.commanded_opening_mm == pytest.approx(FULLY_OPEN_MM)
+
+
+def test_listed_grippers_report_their_backend():
+    service, _ = service_with()
+
+    (entry,) = service.list_grippers()
+
+    assert (entry.robot_name, entry.model, entry.backend) == (ARM, NARROW, "mock")
+
+
+def test_health_passes_the_backend_verdict_through():
+    service, _ = service_with()
+
+    health = service.get_health(ARM)
+
+    assert health.reachable is True
+    assert health.controller_active is True
+    assert health.backend == "mock"
+
+
+def test_each_gripper_opens_to_its_own_model_width():
+    specs = load_model_specs(SPEC_DIR, {NARROW, WIDE})
+    configs = {
+        "narrow": GripperConfig(name="narrow", model=NARROW),
+        "wide": GripperConfig(name="wide", model=WIDE),
+    }
+    backends = {
+        name: MockGripperBackend(
+            sleep_fn=lambda _seconds: None, geometry=specs[config.model].geometry
+        )
+        for name, config in configs.items()
+    }
+    service = GripperService(specs=specs, configs=configs, backends=backends)
+
+    assert service.open_fully("narrow").commanded_opening_mm == pytest.approx(85.0)
+    assert service.open_fully("wide").commanded_opening_mm == pytest.approx(140.0)
+
+
+@pytest.mark.parametrize(
+    ("result", "stopped_on_object", "is_grasp", "outcome"),
+    [
+        (motion(refused=True), False, True, "refused"),
+        (motion(reached_goal=False, timed_out=True), False, True, "incomplete"),
+        (motion(reached_goal=False, stalled=True), True, True, "grasped"),
+        (
+            motion(reached_goal=False, stalled=True),
+            False,
+            True,
+            "closed_without_object",
+        ),
+        (motion(reached_goal=True), False, True, "closed_without_object"),
+        (motion(reached_goal=False, stalled=True), True, False, "stalled_unexpectedly"),
+        (motion(reached_goal=True), False, False, "reached"),
+        (motion(reached_goal=False), False, False, "incomplete"),
+    ],
+)
+def test_classify_covers_every_way_a_motion_can_end(
+    result, stopped_on_object, is_grasp, outcome
+):
+    assert classify(result, stopped_on_object, is_grasp) == outcome

--- a/mcp/tests/test_service.py
+++ b/mcp/tests/test_service.py
@@ -143,7 +143,7 @@ def test_each_gripper_opens_to_its_own_model_width():
     }
     backends = {
         name: MockGripperBackend(
-            sleep_fn=lambda _seconds: None, geometry=specs[config.model].geometry
+            sleep_fn=lambda _seconds: None, stroke=specs[config.model].stroke
         )
         for name, config in configs.items()
     }

--- a/mcp/tests/test_service.py
+++ b/mcp/tests/test_service.py
@@ -3,7 +3,13 @@ from fakes.gripper import MockGripperBackend
 
 from gripper_mcp.backend import BackendMotion
 from gripper_mcp.config import SPEC_DIR, GripperConfig, load_model_specs
-from gripper_mcp.service import GripperService, UnknownGripperError, classify
+from gripper_mcp.service import (
+    GripperService,
+    UnknownGripperError,
+    classify,
+    stopped_on_something,
+)
+from gripper_mcp.units import Stroke
 
 NARROW = "robotiq_2f_85"
 WIDE = "robotiq_2f_140"
@@ -192,3 +198,27 @@ def test_classify_covers_every_way_a_motion_can_end(
     result, stopped_on_object, is_grasp, outcome
 ):
     assert classify(result, stopped_on_object, is_grasp) == outcome
+
+
+STROKE_2F_140 = Stroke(max_opening_mm=140.0, closed_tolerance_mm=1.5)
+ONE_COUNT_2F_140_MM = 140.0 / 227
+TSF_CLOSED_MM = 0.75
+
+
+@pytest.mark.parametrize(
+    ("result", "achieved_mm", "stopped"),
+    [
+        (motion(reached_goal=False, stalled=True), ONE_COUNT_2F_140_MM, False),
+        (motion(reached_goal=False, stalled=True), TSF_CLOSED_MM, False),
+        (motion(reached_goal=False, stalled=True), 40.0, True),
+        (motion(reached_goal=True), 40.0, False),
+    ],
+    ids=[
+        "a count short of the stop is an empty close",
+        "thicker fingers meeting early is an empty close",
+        "a stall well before the stop is a grasp",
+        "no stall is no object",
+    ],
+)
+def test_the_closed_tolerance_decides_an_empty_close(result, achieved_mm, stopped):
+    assert stopped_on_something(result, achieved_mm, STROKE_2F_140) is stopped

--- a/mcp/tests/test_units.py
+++ b/mcp/tests/test_units.py
@@ -9,7 +9,7 @@ from gripper_mcp.units import (
     opening_mm_to_knuckle_rad,
 )
 
-STROKE_2F_85 = Stroke(max_opening_mm=85.0)
+STROKE_2F_85 = Stroke(max_opening_mm=85.0, closed_tolerance_mm=1.5)
 KNUCKLE_2F_85 = JointGeometry(
     name="robotiq_85_left_knuckle_joint", rad_open=0.0, rad_closed=0.8
 )
@@ -27,7 +27,7 @@ def test_a_geometry_is_the_datasheet_stroke_on_the_robot_joint():
 
 def test_a_stroke_with_no_travel_is_rejected():
     with pytest.raises(ValueError, match="max_opening_mm"):
-        Stroke(max_opening_mm=0.0)
+        Stroke(max_opening_mm=0.0, closed_tolerance_mm=1.5)
 
 
 def test_a_joint_with_no_travel_is_rejected():
@@ -89,3 +89,14 @@ def test_opening_round_trips_through_the_knuckle_angle(opening_mm):
     assert knuckle_rad_to_opening_mm(knuckle_rad, GEOMETRY_2F_85) == pytest.approx(
         opening_mm
     )
+
+
+@pytest.mark.parametrize("tolerance_mm", [0.0, -1.0, 85.0])
+def test_a_closed_tolerance_outside_the_stroke_is_rejected(tolerance_mm):
+    with pytest.raises(ValueError, match="closed_tolerance_mm"):
+        Stroke(max_opening_mm=85.0, closed_tolerance_mm=tolerance_mm)
+
+
+def test_the_fingers_have_met_within_the_closed_tolerance():
+    assert STROKE_2F_85.fingers_met(1.4)
+    assert not STROKE_2F_85.fingers_met(1.6)


### PR DESCRIPTION
## Change

Fifth PR of the `mcp/` series (stacked on #58). The layer the MCP tools will call, testable without a server or a ROS graph:

1. **`service.py`** — `GripperService`: per-gripper dispatch by name, millimetre-to-joint-angle conversion both ways through the model's datasheet stroke and the backend's joint, and the outcome classification. `list_grippers`, `get_state`, `open_fully`, `close_fully`, `grasp`, `move_to_opening`, `get_health`. Reported values round to a named precision (`MM_DECIMALS`, `RAD_DECIMALS`, `FRACTION_DECIMALS`).
2. **Outcome classification** — the one piece of domain judgement in the server, previously prose in an agent prompt. For a grasp: stopping before the fingers meet is `grasped` (a success, even though the controller reports `reached_goal: false, stalled: true`); fingers meeting with nothing between them is `closed_without_object`, whether the controller called that a stall or a reached goal. On a plain move a stall is `stalled_unexpectedly`. Refused and timed-out motions map to `refused` and `incomplete`. This is also where "aborted + stalled" from the sim configs (#52, `allow_stalling: false`) lands once the ROS backend (#61) translates it into `stalled: true`.
3. **Models** — `closed_without_object` added to `Outcome`.
4. **Review round 1** — an unknown gripper name raises `UnknownGripperError` from every entry point (one guard both lookups go through). The closed-stop margin is a per-model datasheet field, `stroke.closed_tolerance_mm` (1.5 mm on both shipped models), replacing a single 0.5 mm constant that left the 2F-140 with zero register counts of margin and read a real 2F-85 wearing TSF fingers (settling 0.75 mm short) as holding something. The no-hardware advice points at fake hardware, not the unreachable `use_dummy`.

5. **Classify from position** (Eric's thread) — the outcome is read from the achieved opening against the commanded one, with the datasheet margin; the controller's `stalled` flag is reported but no longer steers it, since on the real driver it is set on every goal (#29). A move that ends off its target in either direction is `stalled_unexpectedly`, which also catches an opening blocked part-way. An out-of-range request is still clamped but the `detail` now says so.

**Known limitation, next round:** the achieved position still comes from the action result, which Eric's bench (2026-09-11) showed echoes the commanded position before the fingers finish moving. The follow-up reads position and gOBJ (`object_status`) from the graph after the motion settles and drops the position inference for the grasp verdict; see mbegin's thread below.

No backend ships with this layer: the tests drive it through the scripted double under `tests/fakes/` (the Python mock moved there on #57).

## Verification

- `uv run pytest`: 87 passed (36 new): classify table over position, clamp note; unknown name from six entry points, tolerance validated inside the stroke, fingers met within the margin. The classifier is table-tested over every way a motion can end; the service tests drive it through the fake: grasp on a 40 mm cube (grasped, 40 mm achieved, reached_goal false), grasp on nothing (closed_without_object), plain close on the cube (stalled_unexpectedly), datasheet effort applied unless overridden, clamping, two grippers of different models opening to their own widths.
- `pre-commit run --all-files`: green.

## Stack
Stacked on #58: this PR shows only its own 9 commits.

## Next
Once ros#70 lands (driver consuming the SDK's SI conversions, robotiq/grippers#32), the rad-to-mm map in `units.py` goes away and the service reads metres from the driver directly.



