### PR TITLE
feat(mcp): ROS backend on rclpy

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -10,7 +10,7 @@ hardware and against a simulator launched with `sim_topic_based:=true`.
 | Tool | What it does |
 |---|---|
 | `gripper_list_grippers` | Discover configured gripper names |
-| `gripper_get_state` | Opening (mm, fraction, joint rad) and grip force |
+| `gripper_get_state` | Opening (mm, fraction, joint rad); the driver reports no force |
 | `gripper_open` | Open fully; optional `max_effort_n` |
 | `gripper_close` | Close fully; optional `max_effort_n` |
 | `gripper_move_to` | Move to a specific position, in mm of opening; optional `max_effort_n` |
@@ -40,13 +40,22 @@ The server is then at `http://127.0.0.1:8300/mcp` (streamable-http); point any
 MCP client at it. The tools carry no authentication: anything that can reach
 the port can close a gripper. The default binds localhost only; pass
 `--host 0.0.0.0` to serve the cell network, and firewall the port when you do.
-The tool surface is complete in this build; the backend that
-talks to `robotiq_gripper_controller` lands in the next one, so until then
-`build_service` refuses every wiring entry by name. Without hardware, run the
-driver on ros2_control's fake hardware (`use_fake_hardware`) rather than a
-Python stand-in: that exercises the driver, the controller and the action,
-which a mock never will. The unit tests use a scripted double under
-`tests/fakes/`.
+Without hardware, run the driver on ros2_control's fake hardware
+(`use_fake_hardware:=true`) rather than a Python stand-in: that exercises the
+driver, the controller and the action, which a mock never will. The unit tests
+use a scripted double under `tests/fakes/`.
+
+## With the driver
+
+The backend talks to `robotiq_gripper_controller` through rclpy: it sends
+`gripper_cmd` goals and reads `joint_states` under the gripper's `namespace`
+from `grippers.yaml`. Source your ROS 2 install before starting the server so
+`rclpy` and `control_msgs` import. The action type is whatever the running
+controller advertises (`ParallelGripperCommand` from Jazzy's controller,
+`GripperCommand` from Humble's), read off the graph rather than guessed from
+the distro. The controller's `stalled` flag is passed through in the result but
+the outcome is read from where the fingers ended up (see `service.py`), because
+the driver sets that flag on every goal (robotiq/ros#29).
 
 ### Connecting an agent
 

--- a/mcp/gripper_mcp/robot_description.py
+++ b/mcp/gripper_mcp/robot_description.py
@@ -1,0 +1,58 @@
+"""Find the gripper's command joint in a robot description, with no ROS imports.
+
+A Robotiq 2F is one actuated joint plus finger joints that `<mimic>` it, so the
+command joint is the one the others point at. That holds whatever `prefix` the
+xacro was expanded with, which is why the name is read here rather than kept in
+a datasheet. The joint's lower limit is the open angle. The closed angle is the
+driver's, not the joint's: the hardware interface scales the register to
+`gripper_closed_position` (0.7929 on a 2F-85, against a limit of 0.8), which
+the description carries as a `<hardware>` param of the `<ros2_control>` block
+that lists the joint. Where that block has no such param (the fake hardware,
+the topic-based sim) the mock mirrors commands and the limit is as good as
+anything, so it is the fallback.
+"""
+
+from xml.etree import ElementTree
+
+from gripper_mcp.units import JointGeometry
+
+
+def command_joint(urdf_xml: str) -> JointGeometry:
+    robot = ElementTree.fromstring(urdf_xml)
+    joints = {joint.attrib["name"]: joint for joint in robot.findall("joint")}
+    name = mimicked_joint(robot, set(joints))
+    rad_open, limit_upper = limits(joints[name])
+    return JointGeometry(name, rad_open, closed_angle(robot, name, limit_upper))
+
+
+def mimicked_joint(robot: ElementTree.Element, joint_names: set[str]) -> str:
+    mimicked = sorted(
+        {mimic.attrib["joint"] for mimic in robot.iter("mimic")} & joint_names
+    )
+    if len(mimicked) != 1:
+        raise ValueError(
+            "Expected exactly one joint mimicked by the finger joints, found "
+            f"{len(mimicked)}: {', '.join(mimicked) or '(none)'}. Is this the "
+            "description of a single Robotiq 2F gripper?"
+        )
+    return mimicked[0]
+
+
+def closed_angle(robot: ElementTree.Element, joint: str, limit_upper: float) -> float:
+    for block in robot.iter("ros2_control"):
+        if block.find(f"joint[@name='{joint}']") is None:
+            continue
+        param = block.find("hardware/param[@name='gripper_closed_position']")
+        if param is not None and param.text:
+            return float(param.text)
+    return limit_upper
+
+
+def limits(joint: ElementTree.Element) -> tuple[float, float]:
+    limit = joint.find("limit")
+    try:
+        return float(limit.attrib["lower"]), float(limit.attrib["upper"])
+    except (AttributeError, KeyError) as error:
+        raise ValueError(
+            f"Joint '{joint.attrib['name']}' has no <limit lower= upper=> in the URDF"
+        ) from error

--- a/mcp/gripper_mcp/ros_backend.py
+++ b/mcp/gripper_mcp/ros_backend.py
@@ -1,0 +1,311 @@
+"""Gripper backend on the ROS 2 driver, through rclpy.
+
+One node per gripper, created inside the gripper's namespace so that
+`robotiq_gripper_controller/gripper_cmd`, `joint_states` and `robot_description`
+resolve to that gripper's controller. All nodes share one executor spinning in a
+background thread; the MCP tools run in their own threads and wait on futures.
+
+The command joint's name and range are read from `robot_description`, the URDF
+robot_state_publisher latches for the cell, so a prefixed cell resolves by itself
+and nothing is copied from a datasheet. It is resolved on first use and kept.
+
+The action type is whatever the running controller advertises for `gripper_cmd`:
+`ParallelGripperCommand` from Jazzy's parallel_gripper_action_controller,
+`GripperCommand` from Humble's position_controllers one. It is read off the graph
+rather than guessed from the distro or from what imports, because recent
+control_msgs releases ship both types on every distro.
+
+Calls on one gripper are serialised: FastMCP runs tools on worker threads and an
+agent may issue two moves at once, and two goals in flight on one controller
+resolve in whatever order it likes. One deadline covers the whole call, from goal
+response to result, so the tool-level ceiling is the datasheet's timeout. A goal
+that outlives it is cancelled and the cancel's answer is reported, because a
+rejected cancel means the gripper is still moving after the tool said it failed.
+
+`force_n` is never filled. `joint_states.effort` would be a joint torque in N m,
+and no shipped description exports an effort interface anyway; the gripper
+reports motor current (gCU), and turning that into a fingertip force needs a
+calibration nobody has done. The commanded force is the honest number.
+"""
+
+import threading
+import time
+from collections.abc import Callable
+
+import rclpy
+from control_msgs.action import GripperCommand, ParallelGripperCommand
+from rclpy.action import ActionClient
+from rclpy.action.graph import get_action_names_and_types
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, QoSProfile
+from sensor_msgs.msg import JointState
+from std_msgs.msg import String
+
+from gripper_mcp.backend import BackendHealth, BackendMotion, BackendState
+from gripper_mcp.robot_description import command_joint
+from gripper_mcp.units import JointGeometry
+from gripper_mcp.ros_messages import (
+    advertised_type,
+    cancel_note,
+    motion_from_result,
+    position_of,
+    refused,
+    timed_out,
+)
+
+ACTION_NAME = "robotiq_gripper_controller/gripper_cmd"
+ACTION_TYPES = {
+    "control_msgs/action/ParallelGripperCommand": ParallelGripperCommand,
+    "control_msgs/action/GripperCommand": GripperCommand,
+}
+JOINT_STATES_TOPIC = "joint_states"
+DESCRIPTION_TOPIC = "robot_description"
+LATCHED = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
+SERVER_WAIT_S = 2.0
+DESCRIPTION_WAIT_S = 2.0
+STATE_WAIT_S = 2.0
+STALE_STATE_S = 2.0
+POLL_S = 0.05
+
+
+class RosGraph:
+    _lock = threading.Lock()
+    _executor: MultiThreadedExecutor | None = None
+
+    @classmethod
+    def executor(cls) -> MultiThreadedExecutor:
+        with cls._lock:
+            if cls._executor is None:
+                if not rclpy.ok():
+                    rclpy.init()
+                cls._executor = MultiThreadedExecutor()
+                threading.Thread(
+                    target=cls._executor.spin, name="rclpy-spin", daemon=True
+                ).start()
+            return cls._executor
+
+    @classmethod
+    def shutdown(cls) -> None:
+        with cls._lock:
+            if cls._executor is not None:
+                cls._executor.shutdown()
+                rclpy.shutdown()
+                cls._executor = None
+
+
+def wait_for(future, timeout_s: float):
+    done = threading.Event()
+    future.add_done_callback(lambda _: done.set())
+    if not done.wait(timeout_s):
+        return None
+    return future.result()
+
+
+def poll_until(probe: Callable[[], object], timeout_s: float):
+    deadline = time.monotonic() + timeout_s
+    while True:
+        found = probe()
+        if found is not None or time.monotonic() >= deadline:
+            return found
+        time.sleep(POLL_S)
+
+
+def remaining(deadline: float) -> float:
+    return max(0.0, deadline - time.monotonic())
+
+
+def cancel_when_accepted(goal_future) -> None:
+    def cancel(done) -> None:
+        handle = done.result()
+        if handle.accepted:
+            handle.cancel_goal_async()
+
+    goal_future.add_done_callback(cancel)
+
+
+class JointStateFeed:
+    def __init__(self, node: Node) -> None:
+        self.latest: JointState | None = None
+        self.latest_at = 0.0
+        self._joint_name: str | None = None
+        node.create_subscription(
+            JointState, JOINT_STATES_TOPIC, self._on_joint_states, 10
+        )
+
+    def follow(self, joint_name: str) -> None:
+        self._joint_name = joint_name
+
+    def _on_joint_states(self, message: JointState) -> None:
+        if self._joint_name is not None and self._joint_name in message.name:
+            self.latest = message
+            self.latest_at = time.monotonic()
+
+
+class RosGripperBackend:
+    name = "ros"
+
+    def __init__(self, gripper_name: str, namespace: str) -> None:
+        executor = RosGraph.executor()
+        self._node = Node(f"gripper_mcp_{gripper_name}", namespace=namespace or "/")
+        self._description: str | None = None
+        self._node.create_subscription(
+            String, DESCRIPTION_TOPIC, self._on_description, LATCHED
+        )
+        self._states = JointStateFeed(self._node)
+        self._joint: JointGeometry | None = None
+        self._client: ActionClient | None = None
+        self._action_type = None
+        self._client_lock = threading.Lock()
+        self._motion_lock = threading.Lock()
+        executor.add_node(self._node)
+
+    def joint_geometry(self) -> JointGeometry:
+        if self._joint is None:
+            if not self._await_description():
+                raise RuntimeError(
+                    f"No {DESCRIPTION_TOPIC} under '{self._node.get_namespace()}' "
+                    f"within {DESCRIPTION_WAIT_S:.0f} s; is robot_state_publisher "
+                    "running there?"
+                )
+            self._joint = command_joint(self._description)
+            self._states.follow(self._joint.name)
+        return self._joint
+
+    def read_state(self) -> BackendState:
+        joint = self.joint_geometry().name
+        if not self._await_state():
+            raise RuntimeError(
+                f"No {JOINT_STATES_TOPIC} naming '{joint}' under "
+                f"'{self._node.get_namespace()}' within {STATE_WAIT_S:.0f} s; "
+                "is the controller running?"
+            )
+        return BackendState(position_rad=position_of(self._states.latest, joint, 0.0))
+
+    def move_to(
+        self, position_rad: float, max_effort_n: float, timeout_s: float
+    ) -> BackendMotion:
+        with self._motion_lock:
+            return self._move_to(position_rad, max_effort_n, timeout_s)
+
+    def _move_to(
+        self, position_rad: float, max_effort_n: float, timeout_s: float
+    ) -> BackendMotion:
+        deadline = time.monotonic() + timeout_s
+        self.joint_geometry()
+        here = self._position_or(position_rad)
+        client = self._ready_client()
+        if client is None:
+            return refused(
+                here,
+                f"No {ACTION_NAME} action server under "
+                f"'{self._node.get_namespace()}'; is the controller active?",
+            )
+
+        goal = self._goal(position_rad, max_effort_n)
+        sent = client.send_goal_async(goal)
+        handle = wait_for(sent, remaining(deadline))
+        if handle is None:
+            cancel_when_accepted(sent)
+            return timed_out(here, timeout_s, "goal response")
+        if not handle.accepted:
+            return refused(here, "The controller rejected the goal.")
+
+        wrapped = wait_for(handle.get_result_async(), remaining(deadline))
+        if wrapped is None:
+            cancelled = wait_for(handle.cancel_goal_async(), STATE_WAIT_S)
+            return timed_out(
+                self._position_or(here), timeout_s, "result", cancel_note(cancelled)
+            )
+
+        here = self._position_or(here)
+        return motion_from_result(
+            wrapped.status,
+            self._result_position(wrapped.result, here),
+            wrapped.result.stalled,
+            wrapped.result.reached_goal,
+        )
+
+    def health(self) -> BackendHealth:
+        client = self._ready_client()
+        state_fresh = (
+            self._joint_known()
+            and self._await_state()
+            and time.monotonic() - self._states.latest_at < STALE_STATE_S
+        )
+        return BackendHealth(
+            reachable=client is not None or state_fresh,
+            controller_active=client is not None,
+            detail=(
+                f"{ACTION_NAME} {self._describe(client)}, "
+                f"{JOINT_STATES_TOPIC} {'fresh' if state_fresh else 'stale'}, "
+                f"{DESCRIPTION_TOPIC} "
+                f"{'received' if self._description else 'absent'} "
+                f"under '{self._node.get_namespace()}'."
+            ),
+        )
+
+    def _joint_known(self) -> bool:
+        try:
+            self.joint_geometry()
+        except (RuntimeError, ValueError):
+            return False
+        return True
+
+    def _on_description(self, message: String) -> None:
+        self._description = message.data
+
+    def _position_or(self, fallback: float) -> float:
+        latest = self._states.latest
+        if latest is None:
+            return fallback
+        return position_of(latest, self._joint.name, fallback)
+
+    def _await_description(self) -> bool:
+        return poll_until(lambda: self._description, DESCRIPTION_WAIT_S) is not None
+
+    def _await_state(self) -> bool:
+        return poll_until(lambda: self._states.latest, STATE_WAIT_S) is not None
+
+    def _ready_client(self) -> ActionClient | None:
+        with self._client_lock:
+            if self._client is None:
+                type_name = poll_until(self._advertised_type, SERVER_WAIT_S)
+                if type_name is None:
+                    return None
+                self._action_type = ACTION_TYPES[type_name]
+                self._client = ActionClient(self._node, self._action_type, ACTION_NAME)
+        if not self._client.wait_for_server(timeout_sec=SERVER_WAIT_S):
+            return None
+        return self._client
+
+    def _advertised_type(self) -> str | None:
+        return advertised_type(
+            get_action_names_and_types(self._node),
+            self._resolved_action_name(),
+            ACTION_TYPES,
+        )
+
+    def _resolved_action_name(self) -> str:
+        return self._node.get_namespace().rstrip("/") + "/" + ACTION_NAME
+
+    def _describe(self, client: ActionClient | None) -> str:
+        if client is None:
+            return "absent"
+        return f"ready ({self._action_type.__name__})"
+
+    def _goal(self, position_rad: float, max_effort_n: float):
+        goal = self._action_type.Goal()
+        if self._action_type is ParallelGripperCommand:
+            goal.command.name = [self._joint.name]
+            goal.command.position = [position_rad]
+            goal.command.effort = [max_effort_n]
+        else:
+            goal.command.position = position_rad
+            goal.command.max_effort = max_effort_n
+        return goal
+
+    def _result_position(self, result, fallback: float) -> float:
+        if self._action_type is ParallelGripperCommand:
+            return position_of(result.state, self._joint.name, fallback)
+        return result.position

--- a/mcp/gripper_mcp/ros_messages.py
+++ b/mcp/gripper_mcp/ros_messages.py
@@ -1,0 +1,90 @@
+"""What a finished `gripper_cmd` goal means, with no ROS imports so it is testable anywhere.
+
+The action's terminal status and its result fields are folded into one
+BackendMotion. The case that matters: with `allow_stalling: false` (the sim
+controller configs) the controller ABORTS a goal that stalls, and the result
+still says `stalled: true`. That abort is how the driver reports fingers stopped
+on an object, so it comes through as a stall, not as a failure.
+"""
+
+from gripper_mcp.backend import BackendMotion
+
+STATUS_SUCCEEDED = 4
+STATUS_CANCELED = 5
+STATUS_ABORTED = 6
+
+STATUS_NAMES = {
+    STATUS_SUCCEEDED: "succeeded",
+    STATUS_CANCELED: "canceled",
+    STATUS_ABORTED: "aborted",
+}
+
+
+def motion_from_result(
+    status: int, position_rad: float, stalled: bool, reached_goal: bool
+) -> BackendMotion:
+    name = STATUS_NAMES.get(status, f"status {status}")
+    if status == STATUS_CANCELED:
+        return BackendMotion(
+            final_position_rad=position_rad,
+            reached_goal=False,
+            stalled=False,
+            timed_out=True,
+            detail="Goal canceled before it finished.",
+        )
+    return BackendMotion(
+        final_position_rad=position_rad,
+        reached_goal=reached_goal,
+        stalled=stalled,
+        detail=f"Goal {name}: stalled={stalled}, reached_goal={reached_goal}.",
+    )
+
+
+def refused(position_rad: float, detail: str) -> BackendMotion:
+    return BackendMotion(
+        final_position_rad=position_rad,
+        reached_goal=False,
+        stalled=False,
+        refused=True,
+        detail=detail,
+    )
+
+
+def timed_out(
+    position_rad: float, timeout_s: float, stage: str, cancel_note: str = ""
+) -> BackendMotion:
+    return BackendMotion(
+        final_position_rad=position_rad,
+        reached_goal=False,
+        stalled=False,
+        timed_out=True,
+        detail=f"No {stage} from the controller within {timeout_s:.1f} s.{cancel_note}",
+    )
+
+
+CANCEL_ACCEPTED = 0
+
+
+def cancel_note(response) -> str:
+    if response is None:
+        return " The cancel went unanswered; the gripper may still be moving."
+    if response.return_code != CANCEL_ACCEPTED:
+        return " The controller rejected the cancel; the gripper may still be moving."
+    return " The goal was canceled."
+
+
+def advertised_type(names_and_types, action_name: str, known: dict) -> str | None:
+    for name, type_names in names_and_types:
+        if name != action_name:
+            continue
+        for type_name in type_names:
+            if type_name in known:
+                return type_name
+    return None
+
+
+def position_of(state, joint: str, fallback: float) -> float:
+    names = list(state.name)
+    if joint not in names:
+        return fallback
+    return state.position[names.index(joint)]

--- a/mcp/gripper_mcp/server.py
+++ b/mcp/gripper_mcp/server.py
@@ -67,12 +67,20 @@ def describe(text: str) -> str:
 
 
 BackendFactory = Callable[[GripperConfig, GripperModelSpec], GripperBackend]
+SHUTDOWN_HOOKS: list[Callable[[], None]] = []
 
 
 def build_backend(config: GripperConfig, spec: GripperModelSpec) -> GripperBackend:
-    raise NotImplementedError(
-        f"Gripper '{config.name}' needs the ROS backend, which is not in this build."
-    )
+    try:
+        from gripper_mcp.ros_backend import RosGraph, RosGripperBackend
+    except ImportError as error:
+        raise RuntimeError(
+            f"Gripper '{config.name}' needs a sourced ROS 2 install with rclpy and "
+            f"control_msgs: {error}"
+        ) from error
+    if RosGraph.shutdown not in SHUTDOWN_HOOKS:
+        SHUTDOWN_HOOKS.append(RosGraph.shutdown)
+    return RosGripperBackend(config.name, config.namespace)
 
 
 def build_service(
@@ -228,7 +236,11 @@ def main() -> None:
     args = parser.parse_args()
 
     mcp = build_mcp(build_service(args.config, args.spec_dir))
-    mcp.run(transport="http", host=args.host, port=args.port)
+    try:
+        mcp.run(transport="http", host=args.host, port=args.port)
+    finally:
+        for hook in SHUTDOWN_HOOKS:
+            hook()
 
 
 if __name__ == "__main__":

--- a/mcp/tests/test_robot_description.py
+++ b/mcp/tests/test_robot_description.py
@@ -1,0 +1,130 @@
+import pytest
+
+from gripper_mcp.robot_description import command_joint
+
+LIMIT_2F_85_RAD = 0.8
+LIMIT_2F_140_RAD = 0.7
+DRIVER_CLOSED_2F_85_RAD = 0.7929
+
+REAL_HARDWARE = """
+      <hardware>
+        <param name="use_dummy">false</param>
+        <plugin>robotiq_driver/RobotiqGripperHardwareInterface</plugin>
+        <param name="gripper_closed_position">0.7929</param>
+        <param name="COM_port">/dev/ttyUSB0</param>
+      </hardware>"""
+FAKE_HARDWARE = """
+      <hardware>
+        <param name="use_dummy">false</param>
+        <plugin>mock_components/GenericSystem</plugin>
+        <param name="state_following_offset">0.0</param>
+      </hardware>"""
+
+
+def ros2_control(hardware, joint="robotiq_85_left_knuckle_joint"):
+    return f"""
+    <ros2_control name="RobotiqGripperHardwareInterface" type="system">{hardware}
+      <joint name="{joint}">
+        <command_interface name="position"/>
+        <state_interface name="position">
+          <param name="initial_value">0.7929</param>
+        </state_interface>
+      </joint>
+    </ros2_control>"""
+
+
+def gripper_urdf(
+    prefix="", lower="0.0", upper=LIMIT_2F_85_RAD, with_limit=True, control=""
+):
+    limit = f'<limit lower="{lower}" upper="{upper}" effort="50" velocity="0.5"/>'
+    return f"""
+    <robot name="cell">{control}
+      <joint name="{prefix}robotiq_85_base_joint" type="fixed"/>
+      <joint name="{prefix}robotiq_85_left_knuckle_joint" type="revolute">
+        {limit if with_limit else ""}
+      </joint>
+      <joint name="{prefix}robotiq_85_right_knuckle_joint" type="revolute">
+        <limit lower="-0.8" upper="0.0" effort="50" velocity="0.5"/>
+        <mimic joint="{prefix}robotiq_85_left_knuckle_joint" multiplier="-1"/>
+      </joint>
+      <joint name="{prefix}robotiq_85_left_finger_tip_joint" type="revolute">
+        <limit lower="-0.8" upper="0.0" effort="50" velocity="0.5"/>
+        <mimic joint="{prefix}robotiq_85_left_knuckle_joint" multiplier="-1"/>
+      </joint>
+    </robot>
+    """
+
+
+def test_the_command_joint_is_the_one_the_fingers_mimic():
+    joint = command_joint(gripper_urdf())
+
+    assert joint.name == "robotiq_85_left_knuckle_joint"
+    assert joint.rad_open == 0.0
+
+
+def test_the_closed_angle_is_the_drivers_not_the_joint_limit():
+    joint = command_joint(gripper_urdf(control=ros2_control(REAL_HARDWARE)))
+
+    assert joint.rad_closed == DRIVER_CLOSED_2F_85_RAD
+
+
+def test_a_control_block_emitted_after_the_joints_does_not_shadow_them():
+    control_last = gripper_urdf().replace(
+        "</robot>", ros2_control(REAL_HARDWARE) + "</robot>"
+    )
+
+    joint = command_joint(control_last)
+
+    assert joint.rad_open == 0.0
+    assert joint.rad_closed == DRIVER_CLOSED_2F_85_RAD
+
+
+def test_fake_hardware_falls_back_to_the_joint_limit():
+    joint = command_joint(gripper_urdf(control=ros2_control(FAKE_HARDWARE)))
+
+    assert joint.rad_closed == LIMIT_2F_85_RAD
+
+
+def test_a_control_block_for_another_joint_is_ignored():
+    arm = ros2_control(REAL_HARDWARE, joint="shoulder_pan_joint")
+
+    joint = command_joint(gripper_urdf(control=arm))
+
+    assert joint.rad_closed == LIMIT_2F_85_RAD
+
+
+def test_a_description_without_ros2_control_uses_the_limit():
+    assert command_joint(gripper_urdf()).rad_closed == LIMIT_2F_85_RAD
+
+
+def test_a_prefixed_cell_resolves_to_the_prefixed_name():
+    joint = command_joint(gripper_urdf(prefix="left_"))
+
+    assert joint.name == "left_robotiq_85_left_knuckle_joint"
+
+
+def test_a_2f_140_style_range_comes_through():
+    joint = command_joint(gripper_urdf(upper=LIMIT_2F_140_RAD))
+
+    assert joint.rad_closed == LIMIT_2F_140_RAD
+
+
+def test_an_arm_only_description_is_refused_by_name():
+    arm = '<robot name="arm"><joint name="shoulder" type="revolute"/></robot>'
+
+    with pytest.raises(ValueError, match="found 0"):
+        command_joint(arm)
+
+
+def test_two_grippers_in_one_description_are_refused_with_both_named():
+    two = gripper_urdf(prefix="left_").replace("</robot>", "") + gripper_urdf(
+        prefix="right_"
+    ).replace('<robot name="cell">', "")
+
+    with pytest.raises(ValueError, match="left_robotiq.*right_robotiq"):
+        command_joint(two)
+
+
+def test_a_command_joint_without_limits_is_refused():
+    with pytest.raises(ValueError, match="no <limit"):
+        command_joint(gripper_urdf(with_limit=False))

--- a/mcp/tests/test_ros_messages.py
+++ b/mcp/tests/test_ros_messages.py
@@ -1,0 +1,140 @@
+from gripper_mcp.ros_messages import (
+    STATUS_ABORTED,
+    STATUS_CANCELED,
+    STATUS_SUCCEEDED,
+    advertised_type,
+    cancel_note,
+    motion_from_result,
+    position_of,
+    refused,
+    timed_out,
+)
+
+ACTION = "/left/robotiq_gripper_controller/gripper_cmd"
+PARALLEL = "control_msgs/action/ParallelGripperCommand"
+HUMBLE = "control_msgs/action/GripperCommand"
+KNOWN = {PARALLEL: object(), HUMBLE: object()}
+
+HALFWAY_RAD = 0.4
+
+
+def test_a_goal_that_succeeds_reached_its_position():
+    motion = motion_from_result(
+        STATUS_SUCCEEDED, HALFWAY_RAD, stalled=False, reached_goal=True
+    )
+
+    assert motion.reached_goal is True
+    assert motion.stalled is False
+    assert motion.final_position_rad == HALFWAY_RAD
+    assert motion.timed_out is False
+
+
+def test_an_aborted_goal_that_stalled_is_a_stall_not_a_failure():
+    motion = motion_from_result(
+        STATUS_ABORTED, HALFWAY_RAD, stalled=True, reached_goal=False
+    )
+
+    assert motion.stalled is True
+    assert motion.reached_goal is False
+    assert motion.refused is False
+    assert motion.timed_out is False
+    assert "aborted" in motion.detail
+
+
+def test_a_succeeded_goal_that_stalled_is_still_a_stall():
+    motion = motion_from_result(
+        STATUS_SUCCEEDED, HALFWAY_RAD, stalled=True, reached_goal=False
+    )
+
+    assert motion.stalled is True
+    assert motion.reached_goal is False
+
+
+def test_a_canceled_goal_timed_out():
+    motion = motion_from_result(
+        STATUS_CANCELED, HALFWAY_RAD, stalled=False, reached_goal=False
+    )
+
+    assert motion.timed_out is True
+    assert motion.stalled is False
+
+
+def test_a_refusal_keeps_the_fingers_where_they_were():
+    motion = refused(HALFWAY_RAD, "no server")
+
+    assert motion.refused is True
+    assert motion.final_position_rad == HALFWAY_RAD
+    assert motion.detail == "no server"
+
+
+def test_a_timeout_names_the_stage_and_the_budget():
+    motion = timed_out(HALFWAY_RAD, 10.0, "result")
+
+    assert motion.timed_out is True
+    assert "result" in motion.detail
+    assert "10.0 s" in motion.detail
+
+
+def test_the_action_type_is_whatever_the_server_advertises():
+    graph = [("/left/joint_states", ["sensor_msgs/msg/JointState"]), (ACTION, [HUMBLE])]
+
+    assert advertised_type(graph, ACTION, KNOWN) == HUMBLE
+
+
+def test_a_server_under_another_namespace_does_not_count():
+    graph = [("/right/robotiq_gripper_controller/gripper_cmd", [PARALLEL])]
+
+    assert advertised_type(graph, ACTION, KNOWN) is None
+
+
+def test_an_unknown_action_type_is_not_picked():
+    graph = [(ACTION, ["some_pkg/action/Other"])]
+
+    assert advertised_type(graph, ACTION, KNOWN) is None
+
+
+KNUCKLE_RAD = 0.4
+FALLBACK_RAD = 9.0
+
+
+class FakeState:
+    def __init__(self, names, positions):
+        self.name = names
+        self.position = positions
+
+
+def test_the_position_is_looked_up_by_joint_name_not_index():
+    state = FakeState(["finger_joint", "knuckle_joint"], [0.1, KNUCKLE_RAD])
+
+    assert position_of(state, "knuckle_joint", FALLBACK_RAD) == KNUCKLE_RAD
+
+
+def test_a_state_without_the_joint_yields_the_fallback():
+    state = FakeState(["finger_joint"], [0.1])
+
+    assert position_of(state, "knuckle_joint", FALLBACK_RAD) == FALLBACK_RAD
+
+
+class FakeCancelResponse:
+    def __init__(self, return_code):
+        self.return_code = return_code
+
+
+def test_an_unanswered_cancel_warns_the_gripper_may_still_move():
+    assert "unanswered" in cancel_note(None)
+    assert "still be moving" in cancel_note(None)
+
+
+def test_a_rejected_cancel_warns_the_gripper_may_still_move():
+    assert "rejected" in cancel_note(FakeCancelResponse(return_code=1))
+
+
+def test_an_accepted_cancel_says_so():
+    assert cancel_note(FakeCancelResponse(return_code=0)) == " The goal was canceled."
+
+
+def test_a_timeout_carries_the_cancel_note():
+    motion = timed_out(HALFWAY_RAD, 1.0, "result", cancel_note(None))
+
+    assert motion.detail.startswith("No result from the controller within 1.0 s.")
+    assert motion.detail.endswith("may still be moving.")

--- a/mcp/tests/test_server.py
+++ b/mcp/tests/test_server.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 
 import pytest
 import yaml
@@ -107,6 +108,8 @@ def test_the_listing_names_the_configured_gripper(mcp):
     assert entry.max_opening_mm == pytest.approx(85.0)
 
 
-def test_the_default_backend_factory_names_the_missing_ros_backend(tmp_path):
-    with pytest.raises(NotImplementedError, match="ROS backend"):
+def test_a_wiring_entry_names_the_missing_ros_install(tmp_path, monkeypatch):
+    monkeypatch.setitem(sys.modules, "rclpy", None)
+
+    with pytest.raises(RuntimeError, match="rclpy"):
         build_service(write_wiring(tmp_path))


### PR DESCRIPTION
## Change

Seventh PR of the `mcp/` series (stacked on #60, now merged). The backend that drives the real driver, in three commits, bottom-up:

`robot_description.py` and `units.py` are a stopgap: the MCP needs millimetres and the driver speaks knuckle radians until #70 lands, so the backend reads the driver's own description to convert. Both files go away with #70 (robotiq/grippers#16).

1. **`robot_description.py`** — the command joint and its angles, read from the `robot_description` the backend is connected to, with no ROS imports. A Robotiq 2F is one actuated joint plus finger joints that `<mimic>` it, so the command joint is the one the others point at, whatever `prefix` the xacro was expanded with. Its lower limit is the open angle. The closed angle is the **driver's**, not the joint's: the hardware interface scales the register to `gripper_closed_position` (0.7929 on a 2F-85, against a limit of 0.8), which the description carries as a `<hardware>` param of the `<ros2_control>` block that lists the joint. The limit is the fallback where that block has no such param (fake hardware, topic-based sim). Reading the limit would have put a fully closed gripper at 0.75 mm open.
2. **`ros_messages.py`** — folds the goal's terminal status and result into a `BackendMotion`, and picks the advertised action type, with no ROS imports so both run in CI. The case that matters: with `allow_stalling: false` (the sim controller configs from #52) the controller **aborts** a goal that stalls and the result still says `stalled: true`. That abort is how the driver reports fingers stopped on an object, so it comes through as a finished motion with `stalled: true`, and the service (#59) reads the outcome from where the fingers ended up. Canceled goals are timeouts, rejected goals refusals.
3. **`ros_backend.py`** — `RosGripperBackend` on rclpy. One node per gripper, created inside the gripper's `namespace` from `grippers.yaml`, so `robotiq_gripper_controller/gripper_cmd`, `joint_states` and the latched `robot_description` resolve to that gripper. All nodes share one `MultiThreadedExecutor` spinning in a daemon thread; the MCP tools, which FastMCP runs in worker threads, wait on futures with the datasheet's motion timeout. Calls on one gripper are serialised by a per-instance lock, one deadline covers the whole call from goal response to result, and a goal that outlives it is cancelled with the cancel's answer put in `detail`, so a late result cannot land on the next call and a rejected cancel is visible. The action type is whatever the running controller advertises for `gripper_cmd`: `ParallelGripperCommand` (Jazzy's `parallel_gripper_action_controller`) or `GripperCommand` (Humble's `position_controllers`), read off the graph rather than guessed from the distro or from what imports, because recent `control_msgs` releases ship both types on every distro. Discovery is polled up to the server-wait budget, so a `health()` right after start-up does not report a controller absent that is merely undiscovered yet. `build_backend` imports it lazily; without a sourced ROS install a wiring entry fails at startup with a message naming rclpy. README gains a "With the driver" section.
4. **Review round** (Eric, mbegin) — folded into the three commits: `command_joint` uses `findall("joint")` so a `<ros2_control>` block emitted after the joints no longer shadows them; `measured_effort` is deleted and `force_n` stays `None` (no description exports an effort interface, and a joint effort would be a torque anyway); the result fallback is the last known `joint_states` position, never the commanded one; `rclpy.init()` is guarded on `rclpy.ok()`; `RosGraph.shutdown` runs from `main()`'s exit path.

Deliberately not in the protocol: activation, fault codes, speed. `gripper_cmd` offers none of them. Effort the hardware reports as NaN (mock components do) is surfaced as `null`, not NaN.

## Verification

- `uv run pytest`: 119 passed (26 new): mimicked joint found, prefixed cell, closed angle 0.7929 from the real-hardware expansion and 0.8 from the fake-hardware one, another joint's `ros2_control` block ignored, `<ros2_control>` emitted after the joints, arm-only / two-gripper / no-limit descriptions refused by name; succeeded, aborted-with-stall, succeeded-with-stall, canceled, refusal, timeout with the cancel accepted / rejected / unanswered, type picked from the advertised list, other namespace ignored, unknown type ignored; the missing-rclpy startup message.
- **Live, driver on ros2_control's fake hardware**, `robotiq_description` from this branch, in the repo's own `docker/Dockerfile` images:

  | Image | Model | Bound type | health | move 0.4 / 0.0 |
  |---|---|---|---|---|
  | `robotiq_ros2:jazzy` | 2F-85, 2F-140 | `ParallelGripperCommand` | ready, fresh | succeeded, `reached_goal` |
  | `robotiq_ros2:humble` | 2F-85, 2F-140 | `GripperCommand` | ready, fresh | succeeded, `reached_goal` |

  `read_state()` follows each move; `force_n` is `None` on fake hardware. Lyrical/Rolling share Jazzy's code path.
- Not yet exercised: abort-on-stall against Isaac Sim (needs the twin running). The mapping is unit-tested.
- `pre-commit run --all-files`: green.

## Stack
#60 is merged; this PR shows its own 3 commits.

## Next
ros#70 (driver on the SDK's SI conversions) makes the driver speak metres; the closed-angle reading and `units.py` then go away together.


