### PR TITLE
feat(mcp): tactile protocol, baseline maths and mock tactile source

### DIFF
--- a/mcp/gripper_mcp/mock_tactile_backend.py
+++ b/mcp/gripper_mcp/mock_tactile_backend.py
@@ -1,0 +1,81 @@
+"""Pure-Python tactile source, the CI default alongside the mock gripper.
+
+Pressure is derived from how far the fingers have closed past a virtual object,
+the same device the mock gripper uses to decide when to stall. Nothing here
+models the sensor's physics; it models its behaviour well enough to drive and
+test a contact loop: no signal until contact, a rise that grows with
+penetration, a centre that reads harder than the edges, and saturation.
+
+Its `object_width_mm` is configured independently of the mock gripper's. That
+is the point: a gripper that stalls while the pads stay quiet is the "stopped on
+something outside the pads" case, and it has to be reachable in a test.
+"""
+
+from typing import Callable
+
+from gripper_mcp.tactile_backend import TactileLayout, TactilePad, TactileReading
+
+TSF_85_LAYOUT = TactileLayout(rows=7, cols=4, pad_names=("left", "right"))
+
+REST_COUNTS = 9
+TAXEL_MAX_COUNTS = 110
+STIFFNESS_COUNTS_PER_MM = 6.9
+
+
+class MockTactileBackend:
+    name = "mock"
+
+    def __init__(
+        self,
+        read_opening_mm: Callable[[], float],
+        object_width_mm: float | None = None,
+        layout: TactileLayout = TSF_85_LAYOUT,
+        rest_counts: int = REST_COUNTS,
+        stiffness_counts_per_mm: float = STIFFNESS_COUNTS_PER_MM,
+    ) -> None:
+        self._read_opening_mm = read_opening_mm
+        self._object_width_mm = object_width_mm
+        self._layout = layout
+        self._rest_counts = rest_counts
+        self._stiffness_counts_per_mm = stiffness_counts_per_mm
+        self._weights = contact_patch_weights(layout.rows, layout.cols)
+
+    def read_tactile(self) -> TactileReading:
+        taxels = self._taxels_for(self._penetration_mm())
+
+        return TactileReading(
+            pads=tuple(
+                TactilePad(name=name, taxels=taxels) for name in self._layout.pad_names
+            ),
+            layout=self._layout,
+        )
+
+    def _penetration_mm(self) -> float:
+        if self._object_width_mm is None:
+            return 0.0
+        return max(0.0, self._object_width_mm - self._read_opening_mm())
+
+    def _taxels_for(self, penetration_mm: float) -> tuple[int, ...]:
+        rise = penetration_mm * self._stiffness_counts_per_mm
+
+        return tuple(
+            min(TAXEL_MAX_COUNTS, self._rest_counts + round(rise * weight))
+            for weight in self._weights
+        )
+
+
+def contact_patch_weights(rows: int, cols: int) -> tuple[float, ...]:
+    weights = [
+        axis_weight(row, rows) * axis_weight(col, cols)
+        for row in range(rows)
+        for col in range(cols)
+    ]
+    peak = max(weights)
+
+    return tuple(weight / peak for weight in weights)
+
+
+def axis_weight(index: int, count: int) -> float:
+    centre = (count - 1) / 2.0
+
+    return 1.0 - abs(index - centre) / count

--- a/mcp/gripper_mcp/tactile.py
+++ b/mcp/gripper_mcp/tactile.py
@@ -1,0 +1,122 @@
+"""Baseline subtraction and contact-signal arithmetic over raw taxel counts.
+
+Raw counts carry a large, drifting rest offset, so nothing is meaningful until a
+baseline is subtracted. The baseline is the mean of many samples, matching the
+tactile SDK's `findBaseline()`, which averages 1000.
+
+Pads are matched to their baseline by name, never by position, so a source that
+reports its pads in a different order cannot have one pad's rest subtracted from
+the other's counts.
+
+Per-taxel rises clamp at zero. Without that clamp a pad reading below its
+baseline, ordinary drift, would subtract from the contact detected on the other
+pad, and a firm one-sided grasp could report no contact at all.
+
+`contact_signal` is normalised across both pads: 1.0 means every taxel on both
+pads sits at the working ceiling, so a firm one-sided contact reads about half
+of what the same force spread over both pads reads. Thresholds against it are
+in those units.
+"""
+
+from dataclasses import dataclass
+
+from gripper_mcp.tactile_backend import TactilePad, TactileReading
+
+
+class TactileShapeMismatch(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class TactileBaseline:
+    pad_names: tuple[str, ...]
+    pads: tuple[tuple[float, ...], ...]
+
+    def rests_for(self, pad_name: str) -> tuple[float, ...]:
+        return self.pads[self.pad_names.index(pad_name)]
+
+
+def average_readings(readings: list[TactileReading]) -> TactileBaseline:
+    if not readings:
+        raise ValueError("Cannot average an empty list of tactile readings.")
+
+    first = readings[0]
+    for reading in readings:
+        _require_same_shape(reading, first)
+
+    pad_names = tuple(pad.name for pad in first.pads)
+
+    return TactileBaseline(
+        pad_names=pad_names,
+        pads=tuple(_average_pad(readings, name) for name in pad_names),
+    )
+
+
+def pad_sums(reading: TactileReading, baseline: TactileBaseline) -> tuple[float, ...]:
+    return tuple(sum(rises) for rises in _rises(reading, baseline))
+
+
+def peak_rise(reading: TactileReading, baseline: TactileBaseline) -> float:
+    return max(
+        (rise for rises in _rises(reading, baseline) for rise in rises), default=0.0
+    )
+
+
+def contact_signal(
+    reading: TactileReading, baseline: TactileBaseline, full_scale_counts: float
+) -> float:
+    if full_scale_counts <= 0.0:
+        raise ValueError(
+            f"full_scale_counts must be positive, got {full_scale_counts}."
+        )
+
+    return sum(pad_sums(reading, baseline)) / full_scale_counts
+
+
+def _average_pad(readings: list[TactileReading], pad_name: str) -> tuple[float, ...]:
+    samples = zip(*(_pad(reading, pad_name).taxels for reading in readings))
+
+    return tuple(sum(taxels) / len(readings) for taxels in samples)
+
+
+def _rises(
+    reading: TactileReading, baseline: TactileBaseline
+) -> tuple[tuple[float, ...], ...]:
+    _require_matching_baseline(reading, baseline)
+
+    return tuple(
+        tuple(
+            max(0.0, taxel - rest)
+            for taxel, rest in zip(pad.taxels, baseline.rests_for(pad.name))
+        )
+        for pad in reading.pads
+    )
+
+
+def _pad(reading: TactileReading, pad_name: str) -> TactilePad:
+    return next(pad for pad in reading.pads if pad.name == pad_name)
+
+
+def _require_same_shape(reading: TactileReading, other: TactileReading) -> None:
+    same = reading.layout == other.layout and _taxel_counts(reading) == _taxel_counts(
+        other
+    )
+    if not same:
+        raise TactileShapeMismatch(
+            "Tactile readings differ in shape; they cannot be averaged together."
+        )
+
+
+def _require_matching_baseline(
+    reading: TactileReading, baseline: TactileBaseline
+) -> None:
+    covered = dict(zip(baseline.pad_names, (len(rests) for rests in baseline.pads)))
+    if _taxel_counts(reading) != covered:
+        raise TactileShapeMismatch(
+            f"Baseline covers pads {sorted(covered)} but the reading has "
+            f"{sorted(_taxel_counts(reading))}; re-tare before reading."
+        )
+
+
+def _taxel_counts(reading: TactileReading) -> dict[str, int]:
+    return {pad.name: len(pad.taxels) for pad in reading.pads}

--- a/mcp/gripper_mcp/tactile_backend.py
+++ b/mcp/gripper_mcp/tactile_backend.py
@@ -1,0 +1,45 @@
+"""What a tactile source has to provide.
+
+Deliberately separate from `GripperBackend`. The TSF-85 pads are their own
+device with their own driver (`robotiq_tsf`), a bare 2F-85 has no pads at all,
+and a simulator may model the fingers without modelling touch. Tactile is an
+optional capability wired alongside a gripper, never a method every gripper
+backend has to refuse.
+
+Taxel counts are raw and uncalibrated, exactly as the sensor reports them. They
+only mean something once a baseline is subtracted; that arithmetic lives in
+`tactile.py`, in one place, so no source does it differently.
+"""
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class TactileLayout:
+    rows: int
+    cols: int
+    pad_names: tuple[str, ...]
+
+    @property
+    def taxels_per_pad(self) -> int:
+        return self.rows * self.cols
+
+
+@dataclass(frozen=True)
+class TactilePad:
+    name: str
+    taxels: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class TactileReading:
+    pads: tuple[TactilePad, ...]
+    layout: TactileLayout
+
+
+@runtime_checkable
+class TactileBackend(Protocol):
+    name: str
+
+    def read_tactile(self) -> TactileReading: ...

--- a/mcp/tests/fakes/tactile.py
+++ b/mcp/tests/fakes/tactile.py
@@ -1,23 +1,34 @@
-"""Pure-Python tactile source, the CI default alongside the mock gripper.
+"""Pure-Python tactile source, the test double alongside the mock gripper.
 
 Pressure is derived from how far the fingers have closed past a virtual object,
 the same device the mock gripper uses to decide when to stall. Nothing here
 models the sensor's physics; it models its behaviour well enough to drive and
-test a contact loop: no signal until contact, a rise that grows with
-penetration, a centre that reads harder than the edges, and saturation.
+test a contact loop: no signal until contact, a light touch the moment the
+fingers reach the object (the pads are soft, and the mock gripper stalls exactly
+there), a rise that grows with penetration, and saturation. Every taxel of a pad
+rises by the same amount.
+
+The constants are arbitrary test values, not the TSF-85's figures: a rest level
+to subtract, a touch rise, a ceiling to saturate at, and a rise per millimetre
+steep enough that a few millimetres of penetration clear any sensible threshold.
 
 Its `object_width_mm` is configured independently of the mock gripper's. That
 is the point: a gripper that stalls while the pads stay quiet is the "stopped on
 something outside the pads" case, and it has to be reachable in a test.
+
+Like the mock gripper it is not part of the shipped package: without TSF pads
+there is nothing for the tactile tools to read, and inventing a signal in
+production would be worse than reporting none.
 """
 
-from typing import Callable
+from collections.abc import Callable
 
 from gripper_mcp.tactile_backend import TactileLayout, TactilePad, TactileReading
 
 TSF_85_LAYOUT = TactileLayout(rows=7, cols=4, pad_names=("left", "right"))
 
 REST_COUNTS = 9
+TOUCH_COUNTS = 20
 TAXEL_MAX_COUNTS = 110
 STIFFNESS_COUNTS_PER_MM = 6.9
 
@@ -38,10 +49,9 @@ class MockTactileBackend:
         self._layout = layout
         self._rest_counts = rest_counts
         self._stiffness_counts_per_mm = stiffness_counts_per_mm
-        self._weights = contact_patch_weights(layout.rows, layout.cols)
 
     def read_tactile(self) -> TactileReading:
-        taxels = self._taxels_for(self._penetration_mm())
+        taxels = (self._taxel_counts(),) * self._layout.taxels_per_pad
 
         return TactileReading(
             pads=tuple(
@@ -50,32 +60,16 @@ class MockTactileBackend:
             layout=self._layout,
         )
 
-    def _penetration_mm(self) -> float:
+    def _taxel_counts(self) -> int:
+        penetration_mm = self._penetration_mm()
+        if penetration_mm is None:
+            return self._rest_counts
+        rise = TOUCH_COUNTS + penetration_mm * self._stiffness_counts_per_mm
+
+        return min(TAXEL_MAX_COUNTS, self._rest_counts + round(rise))
+
+    def _penetration_mm(self) -> float | None:
         if self._object_width_mm is None:
-            return 0.0
-        return max(0.0, self._object_width_mm - self._read_opening_mm())
-
-    def _taxels_for(self, penetration_mm: float) -> tuple[int, ...]:
-        rise = penetration_mm * self._stiffness_counts_per_mm
-
-        return tuple(
-            min(TAXEL_MAX_COUNTS, self._rest_counts + round(rise * weight))
-            for weight in self._weights
-        )
-
-
-def contact_patch_weights(rows: int, cols: int) -> tuple[float, ...]:
-    weights = [
-        axis_weight(row, rows) * axis_weight(col, cols)
-        for row in range(rows)
-        for col in range(cols)
-    ]
-    peak = max(weights)
-
-    return tuple(weight / peak for weight in weights)
-
-
-def axis_weight(index: int, count: int) -> float:
-    centre = (count - 1) / 2.0
-
-    return 1.0 - abs(index - centre) / count
+            return None
+        penetration = self._object_width_mm - self._read_opening_mm()
+        return None if penetration < 0.0 else penetration

--- a/mcp/tests/test_mock_tactile_backend.py
+++ b/mcp/tests/test_mock_tactile_backend.py
@@ -1,0 +1,95 @@
+from gripper_mcp.mock_tactile_backend import (
+    REST_COUNTS,
+    TAXEL_MAX_COUNTS,
+    TSF_85_LAYOUT,
+    MockTactileBackend,
+)
+from gripper_mcp.tactile_backend import TactileBackend
+
+OBJECT_WIDTH_MM = 40.0
+FULLY_OPEN_MM = 85.0
+JUST_TOUCHING_MM = 40.0
+LIGHTLY_PRESSED_MM = 38.0
+FIRMLY_PRESSED_MM = 30.0
+CRUSHED_MM = 0.0
+
+CENTRE_INDEX = 3 * TSF_85_LAYOUT.cols + 1
+EDGE_INDEX = 0
+
+
+def backend(opening_mm: float, object_width_mm: float | None) -> MockTactileBackend:
+    return MockTactileBackend(
+        read_opening_mm=lambda: opening_mm, object_width_mm=object_width_mm
+    )
+
+
+def all_resting(reading) -> bool:
+    return all(taxel == REST_COUNTS for pad in reading.pads for taxel in pad.taxels)
+
+
+def test_the_mock_satisfies_the_tactile_protocol():
+    assert isinstance(backend(FULLY_OPEN_MM, OBJECT_WIDTH_MM), TactileBackend)
+
+
+def test_fingers_wider_than_the_object_leave_every_taxel_at_rest():
+    assert all_resting(backend(FULLY_OPEN_MM, OBJECT_WIDTH_MM).read_tactile())
+
+
+def test_closing_fully_on_nothing_leaves_every_taxel_at_rest():
+    assert all_resting(backend(CRUSHED_MM, None).read_tactile())
+
+
+def test_fingers_exactly_at_the_object_read_no_pressure_yet():
+    assert all_resting(backend(JUST_TOUCHING_MM, OBJECT_WIDTH_MM).read_tactile())
+
+
+def test_closing_past_the_object_raises_the_taxels():
+    reading = backend(LIGHTLY_PRESSED_MM, OBJECT_WIDTH_MM).read_tactile()
+
+    assert reading.pads[0].taxels[CENTRE_INDEX] > REST_COUNTS
+
+
+def test_deeper_penetration_reads_higher():
+    light = backend(LIGHTLY_PRESSED_MM, OBJECT_WIDTH_MM).read_tactile()
+    firm = backend(FIRMLY_PRESSED_MM, OBJECT_WIDTH_MM).read_tactile()
+
+    assert firm.pads[0].taxels[CENTRE_INDEX] > light.pads[0].taxels[CENTRE_INDEX]
+
+
+def test_both_pads_agree_on_a_symmetric_object():
+    reading = backend(FIRMLY_PRESSED_MM, OBJECT_WIDTH_MM).read_tactile()
+
+    assert reading.pads[0].taxels == reading.pads[1].taxels
+
+
+def test_the_pad_centre_reads_harder_than_its_edge():
+    taxels = backend(FIRMLY_PRESSED_MM, OBJECT_WIDTH_MM).read_tactile().pads[0].taxels
+
+    assert taxels[CENTRE_INDEX] > taxels[EDGE_INDEX]
+
+
+def test_extreme_penetration_saturates():
+    reading = backend(CRUSHED_MM, OBJECT_WIDTH_MM).read_tactile()
+
+    assert max(reading.pads[0].taxels) == TAXEL_MAX_COUNTS
+
+
+def test_the_reading_has_the_configured_layout():
+    reading = backend(FULLY_OPEN_MM, OBJECT_WIDTH_MM).read_tactile()
+
+    assert reading.layout == TSF_85_LAYOUT
+    assert [pad.name for pad in reading.pads] == list(TSF_85_LAYOUT.pad_names)
+    assert all(len(pad.taxels) == TSF_85_LAYOUT.taxels_per_pad for pad in reading.pads)
+
+
+def test_the_reading_follows_the_live_opening():
+    opening = {"mm": FULLY_OPEN_MM}
+    live = MockTactileBackend(
+        read_opening_mm=lambda: opening["mm"], object_width_mm=OBJECT_WIDTH_MM
+    )
+    before = live.read_tactile()
+
+    opening["mm"] = FIRMLY_PRESSED_MM
+    after = live.read_tactile()
+
+    assert all_resting(before) and not all_resting(after)

--- a/mcp/tests/test_mock_tactile_backend.py
+++ b/mcp/tests/test_mock_tactile_backend.py
@@ -1,6 +1,7 @@
-from gripper_mcp.mock_tactile_backend import (
+from fakes.tactile import (
     REST_COUNTS,
     TAXEL_MAX_COUNTS,
+    TOUCH_COUNTS,
     TSF_85_LAYOUT,
     MockTactileBackend,
 )
@@ -12,9 +13,6 @@ JUST_TOUCHING_MM = 40.0
 LIGHTLY_PRESSED_MM = 38.0
 FIRMLY_PRESSED_MM = 30.0
 CRUSHED_MM = 0.0
-
-CENTRE_INDEX = 3 * TSF_85_LAYOUT.cols + 1
-EDGE_INDEX = 0
 
 
 def backend(opening_mm: float, object_width_mm: float | None) -> MockTactileBackend:
@@ -39,33 +37,33 @@ def test_closing_fully_on_nothing_leaves_every_taxel_at_rest():
     assert all_resting(backend(CRUSHED_MM, None).read_tactile())
 
 
-def test_fingers_exactly_at_the_object_read_no_pressure_yet():
-    assert all_resting(backend(JUST_TOUCHING_MM, OBJECT_WIDTH_MM).read_tactile())
+def test_fingers_exactly_at_the_object_register_a_light_touch():
+    reading = backend(JUST_TOUCHING_MM, OBJECT_WIDTH_MM).read_tactile()
+
+    assert all(
+        taxel == REST_COUNTS + TOUCH_COUNTS
+        for pad in reading.pads
+        for taxel in pad.taxels
+    )
 
 
-def test_closing_past_the_object_raises_the_taxels():
+def test_closing_past_the_object_raises_every_taxel():
     reading = backend(LIGHTLY_PRESSED_MM, OBJECT_WIDTH_MM).read_tactile()
 
-    assert reading.pads[0].taxels[CENTRE_INDEX] > REST_COUNTS
+    assert all(taxel > REST_COUNTS for pad in reading.pads for taxel in pad.taxels)
 
 
 def test_deeper_penetration_reads_higher():
     light = backend(LIGHTLY_PRESSED_MM, OBJECT_WIDTH_MM).read_tactile()
     firm = backend(FIRMLY_PRESSED_MM, OBJECT_WIDTH_MM).read_tactile()
 
-    assert firm.pads[0].taxels[CENTRE_INDEX] > light.pads[0].taxels[CENTRE_INDEX]
+    assert firm.pads[0].taxels[0] > light.pads[0].taxels[0]
 
 
 def test_both_pads_agree_on_a_symmetric_object():
     reading = backend(FIRMLY_PRESSED_MM, OBJECT_WIDTH_MM).read_tactile()
 
     assert reading.pads[0].taxels == reading.pads[1].taxels
-
-
-def test_the_pad_centre_reads_harder_than_its_edge():
-    taxels = backend(FIRMLY_PRESSED_MM, OBJECT_WIDTH_MM).read_tactile().pads[0].taxels
-
-    assert taxels[CENTRE_INDEX] > taxels[EDGE_INDEX]
 
 
 def test_extreme_penetration_saturates():

--- a/mcp/tests/test_tactile.py
+++ b/mcp/tests/test_tactile.py
@@ -1,0 +1,186 @@
+import pytest
+
+from gripper_mcp.tactile import (
+    TactileShapeMismatch,
+    average_readings,
+    contact_signal,
+    pad_sums,
+    peak_rise,
+)
+from gripper_mcp.tactile_backend import TactileLayout, TactilePad, TactileReading
+
+LAYOUT = TactileLayout(rows=7, cols=4, pad_names=("left", "right"))
+TAXELS_PER_PAD = LAYOUT.taxels_per_pad
+
+REST_COUNTS = 100
+PRESSED_COUNTS = 300
+RISE_COUNTS = PRESSED_COUNTS - REST_COUNTS
+FULL_SCALE_COUNTS = float(RISE_COUNTS * TAXELS_PER_PAD * 2)
+HOT_TAXEL_COUNTS = 900
+DRIFTED_LOW_COUNTS = 40
+
+
+def reading(left_counts: int, right_counts: int) -> TactileReading:
+    return TactileReading(
+        pads=(
+            TactilePad(name="left", taxels=(left_counts,) * TAXELS_PER_PAD),
+            TactilePad(name="right", taxels=(right_counts,) * TAXELS_PER_PAD),
+        ),
+        layout=LAYOUT,
+    )
+
+
+def swapped(base: TactileReading) -> TactileReading:
+    return TactileReading(pads=tuple(reversed(base.pads)), layout=base.layout)
+
+
+def with_hot_taxel(base: TactileReading, counts: int) -> TactileReading:
+    first = base.pads[0]
+    spiked = TactilePad(name=first.name, taxels=(counts,) + first.taxels[1:])
+    return TactileReading(pads=(spiked,) + base.pads[1:], layout=base.layout)
+
+
+def resting_baseline():
+    return average_readings([reading(REST_COUNTS, REST_COUNTS)])
+
+
+def test_the_layout_knows_its_taxel_count():
+    assert TAXELS_PER_PAD == LAYOUT.rows * LAYOUT.cols
+
+
+def test_identical_readings_average_to_themselves():
+    baseline = average_readings([reading(REST_COUNTS, REST_COUNTS)] * 3)
+
+    assert baseline.pads == ((float(REST_COUNTS),) * TAXELS_PER_PAD,) * 2
+
+
+def test_the_baseline_is_the_mean_of_the_samples():
+    baseline = average_readings(
+        [reading(REST_COUNTS, REST_COUNTS), reading(PRESSED_COUNTS, PRESSED_COUNTS)]
+    )
+
+    assert baseline.pads[0][0] == pytest.approx((REST_COUNTS + PRESSED_COUNTS) / 2)
+
+
+def test_the_baseline_remembers_which_pad_is_which():
+    baseline = average_readings([reading(REST_COUNTS, PRESSED_COUNTS)])
+
+    assert baseline.rests_for("left") == (float(REST_COUNTS),) * TAXELS_PER_PAD
+    assert baseline.rests_for("right") == (float(PRESSED_COUNTS),) * TAXELS_PER_PAD
+
+
+def test_samples_are_averaged_by_pad_name_not_position():
+    baseline = average_readings(
+        [
+            reading(REST_COUNTS, PRESSED_COUNTS),
+            swapped(reading(REST_COUNTS, PRESSED_COUNTS)),
+        ]
+    )
+
+    assert baseline.rests_for("left") == (float(REST_COUNTS),) * TAXELS_PER_PAD
+    assert baseline.rests_for("right") == (float(PRESSED_COUNTS),) * TAXELS_PER_PAD
+
+
+def test_averaging_nothing_is_an_error():
+    with pytest.raises(ValueError, match="empty"):
+        average_readings([])
+
+
+def test_averaging_readings_of_different_layouts_is_an_error():
+    other = TactileLayout(rows=1, cols=1, pad_names=("left", "right"))
+    odd = TactileReading(
+        pads=(
+            TactilePad(name="left", taxels=(REST_COUNTS,)),
+            TactilePad(name="right", taxels=(REST_COUNTS,)),
+        ),
+        layout=other,
+    )
+
+    with pytest.raises(TactileShapeMismatch):
+        average_readings([reading(REST_COUNTS, REST_COUNTS), odd])
+
+
+def test_a_reading_at_baseline_has_no_signal():
+    signal = contact_signal(
+        reading(REST_COUNTS, REST_COUNTS), resting_baseline(), FULL_SCALE_COUNTS
+    )
+
+    assert signal == pytest.approx(0.0)
+
+
+def test_both_pads_at_full_scale_read_one():
+    signal = contact_signal(
+        reading(PRESSED_COUNTS, PRESSED_COUNTS), resting_baseline(), FULL_SCALE_COUNTS
+    )
+
+    assert signal == pytest.approx(1.0)
+
+
+def test_one_pressed_pad_reads_half():
+    signal = contact_signal(
+        reading(PRESSED_COUNTS, REST_COUNTS), resting_baseline(), FULL_SCALE_COUNTS
+    )
+
+    assert signal == pytest.approx(0.5)
+
+
+def test_a_non_positive_full_scale_is_an_error():
+    with pytest.raises(ValueError):
+        contact_signal(reading(REST_COUNTS, REST_COUNTS), resting_baseline(), 0.0)
+
+
+def test_a_taxel_below_baseline_clamps_to_zero():
+    sums = pad_sums(reading(DRIFTED_LOW_COUNTS, REST_COUNTS), resting_baseline())
+
+    assert sums == (0.0, 0.0)
+
+
+def test_a_pad_drifted_low_cannot_mask_the_other():
+    sums = pad_sums(reading(DRIFTED_LOW_COUNTS, PRESSED_COUNTS), resting_baseline())
+
+    assert sums[1] == pytest.approx(RISE_COUNTS * TAXELS_PER_PAD)
+
+
+def test_each_pad_reports_its_own_total():
+    sums = pad_sums(reading(PRESSED_COUNTS, REST_COUNTS), resting_baseline())
+
+    assert sums == (pytest.approx(RISE_COUNTS * TAXELS_PER_PAD), pytest.approx(0.0))
+
+
+def test_pads_are_matched_to_their_baseline_by_name_not_position():
+    baseline = average_readings([reading(REST_COUNTS, PRESSED_COUNTS)])
+
+    sums = pad_sums(swapped(reading(REST_COUNTS, PRESSED_COUNTS)), baseline)
+
+    assert sums == (pytest.approx(0.0), pytest.approx(0.0))
+
+
+def test_the_peak_is_the_hottest_taxel_rise():
+    spiked = with_hot_taxel(reading(REST_COUNTS, REST_COUNTS), HOT_TAXEL_COUNTS)
+
+    assert peak_rise(spiked, resting_baseline()) == pytest.approx(
+        HOT_TAXEL_COUNTS - REST_COUNTS
+    )
+
+
+def test_a_baseline_of_the_wrong_shape_is_an_error():
+    single_pad = TactileReading(
+        pads=(TactilePad(name="left", taxels=(REST_COUNTS,) * TAXELS_PER_PAD),),
+        layout=LAYOUT,
+    )
+
+    with pytest.raises(TactileShapeMismatch, match="re-tare"):
+        pad_sums(single_pad, resting_baseline())
+
+
+def test_a_pad_the_baseline_never_saw_is_an_error():
+    renamed = TactileReading(
+        pads=(
+            TactilePad(name="left", taxels=(REST_COUNTS,) * TAXELS_PER_PAD),
+            TactilePad(name="thumb", taxels=(REST_COUNTS,) * TAXELS_PER_PAD),
+        ),
+        layout=LAYOUT,
+    )
+
+    with pytest.raises(TactileShapeMismatch, match="thumb"):
+        pad_sums(renamed, resting_baseline())


### PR DESCRIPTION
## Change

Eighth PR of the `mcp/` series (stacked on #61, now merged). The tactile domain, with no ROS and no tool surface yet:

1. **`tactile_backend.py`** — a second, optional protocol next to `GripperBackend`: `TactileBackend.read_tactile() -> TactileReading`, where a reading is one `TactilePad` per finger (raw `uint16` counts, exactly as `robotiq_tsf/msg/StaticData` publishes them) and a `TactileLayout` (7x4, two pads for the TSF-85). It is separate from the gripper protocol because the pads are their own device with their own driver, a bare 2F has none, and a simulator may model fingers without modelling touch.
2. **`tactile.py`** — the one place raw counts become meaningful: `average_readings` (mean of many samples, what the SDK's `findBaseline()` does over 1000), `pad_sums`/`peak_rise`/`contact_signal` over baseline-subtracted rises. `contact_signal` is normalised across both pads: 1.0 means every taxel on both pads at the working ceiling, so a firm one-sided contact reads about half; thresholds are in those units. Pads are matched to their baseline by name, never by position, so a source that reorders its pads cannot have one pad's rest subtracted from the other's counts. Rises clamp at zero per taxel, so a pad drifting below its rest cannot cancel real contact on the other one. Shape mismatches raise `TactileShapeMismatch` instead of silently zipping short; an empty sample list is a plain `ValueError`.
3. **`tests/fakes/tactile.py`** — the test double for the tactile tests, next to the fake gripper (#57). Pressure follows how far the fingers have closed past a virtual object, read live through a callable so it tracks the fake gripper it sits beside, and every taxel of a pad rises by the same amount, with a light touch registered the moment the fingers reach the object (the mock gripper stalls exactly there, and real pads are soft); its object width is independent of the gripper's on purpose, so "stalled but the pads stayed quiet" is reachable in a test. It does not ship: without TSF pads there is nothing for the tactile tools to read, and a production stand-in inventing a signal would be worse than reporting none.

Nothing in `service.py`/`server.py` changes yet: the tactile datasheet block, `grippers.yaml` wiring, the `gripper_read_tactile`/`gripper_tare_tactile`/`gripper_verify_grasp` tools and the ROS source on `TactileSensor/StaticData` are the next PRs. The pad's `Dynamic` channel is not carried: nothing in the series reads it (Eric's review), so it comes back with its first consumer.

## Verification

- `uv run pytest`: 147 passed (28 new): baseline mean, baseline keyed by pad name, samples averaged by name with pads swapped, empty list is a `ValueError`, shape errors, signal 0 / 0.5 / 1.0, non-positive full scale is a `ValueError`, clamp-at-zero and no-masking, swapped pads still subtract the right rest, a pad the baseline never saw is refused, peak rise, wrong-shape baseline; fake at rest / light touch on reaching the object / pressed / saturated, both pads agree, layout, live opening tracking, protocol conformance.
- `pre-commit run --all-files`: green.

## Stack
#61 is merged; this PR shows its own 3 commits.



