### PR TITLE
Issue 27 38/survive a missing gripper

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,9 +103,10 @@ block. Code that compiles only on the newest distro will fail the matrix — the
 `ros2_control_compat.hpp` shows the pattern. Kilted and other non-LTS releases
 are not targeted.
 
-The one place the distros genuinely differ is the gripper controller — see
-[Supported ROS 2 distros](README.md#supported-ros-2-distros). Keep changes to
-controller configuration working on both sides of that split.
+The distros genuinely differ in two places — see
+[Supported ROS 2 distros](README.md#supported-ros-2-distros): the gripper
+controller, and what a missing gripper does to `ros2_control_node` at bringup.
+Keep changes to controller configuration working on both sides of that split.
 
 **Humble stays a drop-in replacement for PickNik's `humble` branch** (see
 [Migrating from PickNik's ros2_robotiq_gripper](README.md#migrating-from-pickniks-ros2_robotiq_gripper)).

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ is identical across all three. On Humble that makes this repo a drop-in
 replacement for PickNik's `humble` branch — see
 [Migrating from PickNik's ros2_robotiq_gripper](#migrating-from-pickniks-ros2_robotiq_gripper).
 
+The other difference is a gripper that is missing at bringup. On Jazzy and Lyrical
+`ros2_control_node` stays up with the hardware component `unconfigured`, the
+spawners give up after 15 s at most, and the launch prints the two commands that
+recover without a relaunch once the gripper is plugged in. Humble's
+`controller_manager` cannot keep the node alive in that state, so there the launch
+ends and a relaunch is the way back. `shutdown_on_failure:=false` keeps the launch
+running in either case, for launch files that include this one next to nodes that
+should outlive the gripper.
+
 ## Versioning
 
 The repository is versioned as a whole: every package carries the same version

--- a/grippers/robotiq_description/config/robotiq_controllers.yaml
+++ b/grippers/robotiq_description/config/robotiq_controllers.yaml
@@ -4,6 +4,12 @@
 controller_manager:
   ros__parameters:
     update_rate: 500  # Hz
+    # Jazzy defaults this to true and takes ros2_control_node down when the
+    # gripper is not connected; Lyrical defaults to false. Set explicitly so every
+    # distro keeps the node up and the connection can be retried from the CLI.
+    # Humble has no such parameter.
+    hardware_components_initial_state:
+      shutdown_on_initial_state_failure: false
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
     # Jazzy and newer: parallel_gripper_action_controller replaces gripper_controllers package

--- a/grippers/robotiq_description/launch/robotiq_control.launch.py
+++ b/grippers/robotiq_description/launch/robotiq_control.launch.py
@@ -288,8 +288,9 @@ def generate_launch_description():
         launch.actions.DeclareLaunchArgument(
             name="shutdown_on_failure",
             default_value="true",
-            description="End the launch when ros2_control_node exits. Set false when "
-            "including this file next to nodes that should outlive the gripper",
+            description="End the launch when ros2_control_node exits, or, on Humble, when no "
+            "controller could be activated. Set false when including this file next to "
+            "nodes that should outlive the gripper",
         )
     )
 
@@ -301,7 +302,8 @@ def generate_launch_description():
         )
     }
 
-    controllers_file = ControllersFile(os.environ.get("ROS_DISTRO"), topic_based)
+    distro = os.environ.get("ROS_DISTRO")
+    controllers_file = ControllersFile(distro, topic_based)
     initial_joint_controllers = ParameterFile(
         PathJoinSubstitution([description_pkg_share, "config", controllers_file]),
         allow_substs=True,
@@ -354,12 +356,66 @@ def generate_launch_description():
             condition=condition,
         )
 
-    joint_state_broadcaster_spawner = spawner("joint_state_broadcaster")
-    robotiq_gripper_controller_spawner = spawner("robotiq_gripper_controller")
-    # The reactivate_gripper GPIO this controller claims is declared for the
-    # driver and the mock only; the topic_based plugin has nothing to reactivate.
-    robotiq_activation_controller_spawner = spawner(
-        "robotiq_activation_controller", condition=UnlessCondition(topic_based)
+    # The reactivate_gripper GPIO the activation controller claims is declared for
+    # the driver and the mock only; the topic_based plugin has nothing to reactivate.
+    spawned_controllers = {
+        "joint_state_broadcaster": None,
+        "robotiq_gripper_controller": None,
+        "robotiq_activation_controller": UnlessCondition(topic_based),
+    }
+    spawners = [
+        spawner(name, condition) for name, condition in spawned_controllers.items()
+    ]
+
+    def starts(action, context):
+        return action.condition is None or action.condition.evaluate(context)
+
+    def is_set(context, name):
+        return evaluate_condition_expression(context, [LaunchConfiguration(name)])
+
+    # After a failed bringup the last line on screen is otherwise a spawner's
+    # "process has died", which says nothing about the cause or the way out.
+    returncodes = []
+
+    def hint_after_the_last_spawner_exits(event, context):
+        returncodes.append(event.returncode)
+        if context.is_shutdown or len(returncodes) < sum(
+            starts(s, context) for s in spawners
+        ):
+            return None
+        # A negative code is a signal: the spawners were killed, they did not fail.
+        if not any(code > 0 for code in returncodes):
+            return None
+        # Only a real gripper can be unplugged.
+        if any(is_set(context, flag) for flag in HARDWARE_FLAGS):
+            return None
+        if distro == "humble":
+            hint = launch.actions.LogInfo(
+                msg="A controller could not be activated. If the gripper is not "
+                "connected, ros2_control_node did not survive it (see its error above); "
+                "reconnect the gripper and relaunch."
+            )
+            if not is_set(context, "shutdown_on_failure"):
+                return [hint]
+            return [hint, launch.actions.Shutdown(reason="no controller activated")]
+        names = " ".join(
+            name
+            for name, action in zip(spawned_controllers, spawners)
+            if starts(action, context)
+        )
+        return [
+            launch.actions.LogInfo(
+                msg="A controller could not be activated. If the gripper is not "
+                "connected, follow the driver's error above to bring the hardware "
+                f"back, then re-run the spawners: ros2 run controller_manager spawner {names}"
+            )
+        ]
+
+    spawner_hint = launch.actions.RegisterEventHandler(
+        launch.event_handlers.OnProcessExit(
+            target_action=lambda action: action in spawners,
+            on_exit=hint_after_the_last_spawner_exits,
+        )
     )
 
     shutdown_on_control_node_exit = launch.actions.RegisterEventHandler(
@@ -374,11 +430,10 @@ def generate_launch_description():
         OpaqueFunction(function=reject_conflicting_hardware_flags),
         control_node,
         robot_state_publisher_node,
-        joint_state_broadcaster_spawner,
-        robotiq_gripper_controller_spawner,
-        robotiq_activation_controller_spawner,
+        *spawners,
         rviz_node,
         shutdown_on_control_node_exit,
+        spawner_hint,
     ]
 
     return launch.LaunchDescription(

--- a/grippers/robotiq_description/launch/robotiq_control.launch.py
+++ b/grippers/robotiq_description/launch/robotiq_control.launch.py
@@ -41,9 +41,11 @@ from launch.conditions import (
     UnlessCondition,
     evaluate_condition_expression,
 )
+from launch.utilities import normalize_to_list_of_substitutions, perform_substitutions
 import launch_ros
 from launch_ros.parameter_descriptions import ParameterFile
 import os
+import re
 
 # Humble has no parallel_gripper_controller package, so it needs its own
 # controller config, and the topic_based plugin exports a different
@@ -137,6 +139,15 @@ class ParameterFilePath(Substitution):
 
     def perform(self, context):
         return str(self.parameter_file.evaluate(context))
+
+
+CONTROLLER_MANAGER_TIMEOUT = "15"
+
+
+def hardware_component_names(context):
+    """Names of the <ros2_control> components in the description the launch loads."""
+    urdf = perform_substitutions(context, [xacro_command()])
+    return re.findall(r'<ros2_control\s+name="([^"]+)"', urdf)
 
 
 # Joint carrying the position command, per gripper_model. The launch argument
@@ -340,19 +351,22 @@ def generate_launch_description():
     # then dies with "parameter 'joint' is not initialized". --param-file has been
     # a spawner option since Humble, and each node reads only its own section of
     # the file, so this is correct on every supported distro.
+    def spawner_arguments(*controller_names):
+        return [
+            *controller_names,
+            "--controller-manager",
+            "/controller_manager",
+            "--controller-manager-timeout",
+            CONTROLLER_MANAGER_TIMEOUT,
+            "--param-file",
+            ParameterFilePath(initial_joint_controllers),
+        ]
+
     def spawner(controller_name, condition=None):
         return launch_ros.actions.Node(
             package="controller_manager",
             executable="spawner",
-            arguments=[
-                controller_name,
-                "--controller-manager",
-                "/controller_manager",
-                "--controller-manager-timeout",
-                "10",
-                "--param-file",
-                ParameterFilePath(initial_joint_controllers),
-            ],
+            arguments=spawner_arguments(controller_name),
             condition=condition,
         )
 
@@ -373,11 +387,40 @@ def generate_launch_description():
     def is_set(context, name):
         return evaluate_condition_expression(context, [LaunchConfiguration(name)])
 
+    def uses_real_gripper(context):
+        return not any(is_set(context, flag) for flag in HARDWARE_FLAGS)
+
+    relaunch_hint = launch.actions.LogInfo(
+        msg="The bringup failed. If the error above says the gripper could not be "
+        "connected, connect it and relaunch: on Humble, ros2_control_node cannot "
+        "recover from a failed connection without a restart."
+    )
+
+    def recovery_hint(context):
+        """Both halves of the recovery, in order: the hardware, then the controllers.
+
+        Bringing the component back leaves the controllers loaded but inactive;
+        re-running the spawners is what configures and activates them again.
+        """
+        names = [n for n, s in zip(spawned_controllers, spawners) if starts(s, context)]
+        arguments = " ".join(
+            perform_substitutions(context, normalize_to_list_of_substitutions(a))
+            for a in spawner_arguments(*names)
+        )
+        steps = [
+            f"ros2 control set_hardware_component_state {component} active"
+            for component in hardware_component_names(context)
+        ] + [f"ros2 run controller_manager spawner {arguments}"]
+        return launch.actions.LogInfo(
+            msg="A controller could not be activated. If the gripper is not connected, "
+            "reconnect it, then run, in order:\n  " + "\n  ".join(steps)
+        )
+
     # After a failed bringup the last line on screen is otherwise a spawner's
     # "process has died", which says nothing about the cause or the way out.
     returncodes = []
 
-    def hint_after_the_last_spawner_exits(event, context):
+    def on_spawner_exit(event, context):
         returncodes.append(event.returncode)
         if context.is_shutdown or len(returncodes) < sum(
             starts(s, context) for s in spawners
@@ -386,44 +429,36 @@ def generate_launch_description():
         # A negative code is a signal: the spawners were killed, they did not fail.
         if not any(code > 0 for code in returncodes):
             return None
-        # Only a real gripper can be unplugged.
-        if any(is_set(context, flag) for flag in HARDWARE_FLAGS):
-            return None
+        actions = []
         if distro == "humble":
-            hint = launch.actions.LogInfo(
-                msg="A controller could not be activated. If the gripper is not "
-                "connected, ros2_control_node did not survive it (see its error above); "
-                "reconnect the gripper and relaunch."
-            )
-            if not is_set(context, "shutdown_on_failure"):
-                return [hint]
-            return [hint, launch.actions.Shutdown(reason="no controller activated")]
-        names = " ".join(
-            name
-            for name, action in zip(spawned_controllers, spawners)
-            if starts(action, context)
-        )
-        return [
-            launch.actions.LogInfo(
-                msg="A controller could not be activated. If the gripper is not "
-                "connected, follow the driver's error above to bring the hardware "
-                f"back, then re-run the spawners: ros2 run controller_manager spawner {names}"
-            )
-        ]
+            if uses_real_gripper(context):
+                actions.append(relaunch_hint)
+            if is_set(context, "shutdown_on_failure"):
+                actions.append(
+                    launch.actions.Shutdown(reason="no controller activated")
+                )
+        elif uses_real_gripper(context):
+            actions.append(recovery_hint(context))
+        return actions or None
+
+    def on_control_node_exit(_event, context):
+        actions = []
+        if distro == "humble" and uses_real_gripper(context):
+            actions.append(relaunch_hint)
+        if is_set(context, "shutdown_on_failure"):
+            actions.append(launch.actions.Shutdown(reason="ros2_control_node exited"))
+        return actions or None
 
     spawner_hint = launch.actions.RegisterEventHandler(
         launch.event_handlers.OnProcessExit(
-            target_action=lambda action: action in spawners,
-            on_exit=hint_after_the_last_spawner_exits,
+            target_action=lambda action: action in spawners, on_exit=on_spawner_exit
         )
     )
 
     shutdown_on_control_node_exit = launch.actions.RegisterEventHandler(
         launch.event_handlers.OnProcessExit(
-            target_action=control_node,
-            on_exit=[launch.actions.Shutdown(reason="ros2_control_node exited")],
-        ),
-        condition=IfCondition(LaunchConfiguration("shutdown_on_failure")),
+            target_action=control_node, on_exit=on_control_node_exit
+        )
     )
 
     nodes = [

--- a/grippers/robotiq_description/launch/robotiq_control.launch.py
+++ b/grippers/robotiq_description/launch/robotiq_control.launch.py
@@ -284,6 +284,14 @@ def generate_launch_description():
                 description=f"Deprecated since 1.2.0: use {new}",
             )
         )
+    args.append(
+        launch.actions.DeclareLaunchArgument(
+            name="shutdown_on_failure",
+            default_value="true",
+            description="End the launch when ros2_control_node exits. Set false when "
+            "including this file next to nodes that should outlive the gripper",
+        )
+    )
 
     topic_based = LaunchConfiguration("sim_topic_based")
 
@@ -338,6 +346,8 @@ def generate_launch_description():
                 controller_name,
                 "--controller-manager",
                 "/controller_manager",
+                "--controller-manager-timeout",
+                "10",
                 "--param-file",
                 ParameterFilePath(initial_joint_controllers),
             ],
@@ -352,6 +362,14 @@ def generate_launch_description():
         "robotiq_activation_controller", condition=UnlessCondition(topic_based)
     )
 
+    shutdown_on_control_node_exit = launch.actions.RegisterEventHandler(
+        launch.event_handlers.OnProcessExit(
+            target_action=control_node,
+            on_exit=[launch.actions.Shutdown(reason="ros2_control_node exited")],
+        ),
+        condition=IfCondition(LaunchConfiguration("shutdown_on_failure")),
+    )
+
     nodes = [
         OpaqueFunction(function=reject_conflicting_hardware_flags),
         control_node,
@@ -360,6 +378,7 @@ def generate_launch_description():
         robotiq_gripper_controller_spawner,
         robotiq_activation_controller_spawner,
         rviz_node,
+        shutdown_on_control_node_exit,
     ]
 
     return launch.LaunchDescription(

--- a/grippers/robotiq_description/test/test_controller_config.py
+++ b/grippers/robotiq_description/test/test_controller_config.py
@@ -38,6 +38,7 @@
 
 import importlib.util
 import logging
+import re
 from pathlib import Path
 
 import pytest
@@ -476,14 +477,15 @@ def test_humble_config_declares_no_initial_state_policy():
     assert "hardware_components_initial_state" not in controllers
 
 
+ACTIVATION_TIMEOUT_S = 15
+
+
 @requires_launch
-def test_launch_gives_a_slow_gripper_ten_seconds_to_reach_the_controller_manager(
-    monkeypatch,
-):
-    # Bounded so a controller_manager that never answers ends the bringup, wide
-    # enough that a gripper still recovering from a fault is not taken for missing.
+def test_spawners_outwait_a_gripper_recovering_from_a_fault(monkeypatch):
+    timeout = load_launch_module().CONTROLLER_MANAGER_TIMEOUT
+    assert int(timeout) >= ACTIVATION_TIMEOUT_S
     for _, cmd in spawner_commands("jazzy", monkeypatch):
-        assert cmd[cmd.index("--controller-manager-timeout") + 1] == "10"
+        assert cmd[cmd.index("--controller-manager-timeout") + 1] == timeout
 
 
 PROCESS = {"name": "p", "cmd": ["p"], "cwd": None, "env": None, "pid": 1}
@@ -534,7 +536,10 @@ def shutdowns(emitted_per_exit):
     ]
 
 
-SPAWNER_RERUN = (
+HARDWARE_STEP = (
+    "ros2 control set_hardware_component_state RobotiqGripperHardwareInterface active"
+)
+CONTROLLER_STEP = (
     "ros2 run controller_manager spawner "
     "joint_state_broadcaster robotiq_gripper_controller robotiq_activation_controller"
 )
@@ -543,13 +548,25 @@ SPAWNER_RERUN = (
 @requires_launch
 @pytest.mark.parametrize("returncodes", [[1, 1, 1], [0, 1, 0], [1, 0, 0]])
 def test_launch_hints_once_after_the_last_spawner_exits(monkeypatch, returncodes):
-    # Verified on a 2F-85: bringing the hardware back leaves the controllers
-    # loaded but inactive, and re-running the spawners is what activates them.
-    emitted = hints(drive_spawner_exits(monkeypatch, returncodes))
-    assert emitted[:-1] == [[], []]
-    assert len(emitted[-1]) == 1
-    assert SPAWNER_RERUN in emitted[-1][0]
-    assert shutdowns(drive_spawner_exits(monkeypatch, returncodes)) == [[], [], []]
+    emitted = drive_spawner_exits(monkeypatch, returncodes)
+    assert hints(emitted)[:-1] == [[], []]
+    assert shutdowns(emitted) == [[], [], []]
+    (hint,) = hints(emitted)[-1]
+    # Verified on a 2F-85: the first step alone leaves the controllers loaded
+    # but inactive; the second is what configures and activates them again.
+    assert hint.index(HARDWARE_STEP) < hint.index(CONTROLLER_STEP)
+
+
+@requires_launch
+def test_launch_hints_the_spawners_exact_command_line(monkeypatch):
+    # Same arguments as the spawners themselves, so the two cannot drift; the
+    # param file is the one the first spawn used, and Lyrical needs it.
+    emitted = drive_spawner_exits(monkeypatch, [1, 1, 1])
+    (hint,) = hints(emitted)[-1]
+    rerun = hint[hint.index(CONTROLLER_STEP) :]
+    assert "--controller-manager /controller_manager" in rerun
+    assert f"--controller-manager-timeout {ACTIVATION_TIMEOUT_S}" in rerun
+    assert re.search(r"--param-file /\S+", rerun)
 
 
 @requires_launch
@@ -593,7 +610,18 @@ def test_launch_ends_on_humble_where_the_node_cannot_survive(monkeypatch):
     emitted = drive_spawner_exits(monkeypatch, [1, 1, 1], distro="humble")
     assert hints(emitted)[:-1] == [[], []]
     assert "relaunch" in hints(emitted)[-1][0]
-    assert SPAWNER_RERUN not in hints(emitted)[-1][0]
+    assert CONTROLLER_STEP not in hints(emitted)[-1][0]
+    assert [len(s) for s in shutdowns(emitted)] == [0, 0, 1]
+
+
+@requires_launch
+def test_launch_still_ends_on_humble_without_a_gripper(monkeypatch):
+    # No reconnect advice under the mock, but shutdown_on_failure is not about
+    # the gripper and must hold.
+    emitted = drive_spawner_exits(
+        monkeypatch, [1, 1, 1], distro="humble", use_fake_hardware="true"
+    )
+    assert hints(emitted) == [[], [], []]
     assert [len(s) for s in shutdowns(emitted)] == [0, 0, 1]
 
 
@@ -606,10 +634,10 @@ def test_launch_keeps_running_on_humble_when_asked(monkeypatch):
     assert shutdowns(emitted) == [[], [], []]
 
 
-def control_node_exit(monkeypatch, **launch_arguments):
+def control_node_exit(monkeypatch, distro="jazzy", **launch_arguments):
     from launch.events.process import ProcessExited
 
-    entities, context = launch_entities("jazzy", monkeypatch, **launch_arguments)
+    entities, context = launch_entities(distro, monkeypatch, **launch_arguments)
     (control_node,) = nodes_running(entities, context, "ros2_control_node")
     event = ProcessExited(action=control_node, returncode=-6, **PROCESS)
     return dispatch(entities, context, event)
@@ -622,6 +650,20 @@ def test_launch_ends_when_the_control_node_exits(monkeypatch):
     emitted = control_node_exit(monkeypatch)
     assert len(emitted) == 1
     assert isinstance(emitted[0], Shutdown)
+
+
+@requires_launch
+def test_launch_hints_when_the_node_aborts_on_humble(monkeypatch):
+    # The abort is the common Humble failure. Its Shutdown silences the spawner
+    # hint, so the one line the user needs has to come from this handler.
+    from launch.actions import LogInfo, Shutdown
+
+    emitted = control_node_exit(monkeypatch, distro="humble")
+    assert [type(e) for e in emitted] == [LogInfo, Shutdown]
+    assert "relaunch" in perform_text(emitted[0].msg)
+
+    kept = control_node_exit(monkeypatch, distro="humble", shutdown_on_failure="false")
+    assert [type(e) for e in kept] == [LogInfo]
 
 
 @requires_launch

--- a/grippers/robotiq_description/test/test_controller_config.py
+++ b/grippers/robotiq_description/test/test_controller_config.py
@@ -501,6 +501,111 @@ def dispatch(entities, context, event):
     return emitted
 
 
+def drive_spawner_exits(monkeypatch, returncodes, distro="jazzy", **launch_arguments):
+    """Exit each spawner that starts, in order, with the given returncodes.
+
+    Returns what the launch's handlers emitted after each exit.
+    """
+    from launch.events.process import ProcessExited
+
+    entities, context = launch_entities(distro, monkeypatch, **launch_arguments)
+    spawners = nodes_running(entities, context, "spawner")
+    assert len(spawners) == len(returncodes)
+    return [
+        dispatch(entities, context, ProcessExited(action=s, returncode=rc, **PROCESS))
+        for s, rc in zip(spawners, returncodes)
+    ]
+
+
+def hints(emitted_per_exit):
+    from launch.actions import LogInfo
+
+    return [
+        [perform_text(e.msg) for e in emitted if isinstance(e, LogInfo)]
+        for emitted in emitted_per_exit
+    ]
+
+
+def shutdowns(emitted_per_exit):
+    from launch.actions import Shutdown
+
+    return [
+        [e for e in emitted if isinstance(e, Shutdown)] for emitted in emitted_per_exit
+    ]
+
+
+SPAWNER_RERUN = (
+    "ros2 run controller_manager spawner "
+    "joint_state_broadcaster robotiq_gripper_controller robotiq_activation_controller"
+)
+
+
+@requires_launch
+@pytest.mark.parametrize("returncodes", [[1, 1, 1], [0, 1, 0], [1, 0, 0]])
+def test_launch_hints_once_after_the_last_spawner_exits(monkeypatch, returncodes):
+    # Verified on a 2F-85: bringing the hardware back leaves the controllers
+    # loaded but inactive, and re-running the spawners is what activates them.
+    emitted = hints(drive_spawner_exits(monkeypatch, returncodes))
+    assert emitted[:-1] == [[], []]
+    assert len(emitted[-1]) == 1
+    assert SPAWNER_RERUN in emitted[-1][0]
+    assert shutdowns(drive_spawner_exits(monkeypatch, returncodes)) == [[], [], []]
+
+
+@requires_launch
+def test_launch_stays_quiet_when_every_spawner_succeeds(monkeypatch):
+    assert drive_spawner_exits(monkeypatch, [0, 0, 0]) == [[], [], []]
+
+
+@requires_launch
+def test_launch_stays_quiet_when_the_spawners_are_killed(monkeypatch):
+    # SIGINT from a Ctrl-C or from the launch's own Shutdown is not a failure.
+    assert drive_spawner_exits(monkeypatch, [-2, -2, -2]) == [[], [], []]
+
+
+@requires_launch
+def test_launch_stays_quiet_once_shutting_down(monkeypatch):
+    from launch.events.process import ProcessExited
+
+    entities, context = launch_entities("jazzy", monkeypatch)
+    context._set_is_shutdown(True)
+    for spawner in nodes_running(entities, context, "spawner"):
+        event = ProcessExited(action=spawner, returncode=1, **PROCESS)
+        assert dispatch(entities, context, event) == []
+
+
+@requires_launch
+@pytest.mark.parametrize(
+    "launch_arguments,returncodes",
+    [({"sim_topic_based": "true"}, [1, 1]), ({"use_fake_hardware": "true"}, [1, 1, 1])],
+)
+def test_launch_gives_no_reconnect_advice_without_a_gripper(
+    monkeypatch, launch_arguments, returncodes
+):
+    emitted = drive_spawner_exits(monkeypatch, returncodes, **launch_arguments)
+    assert emitted == [[] for _ in returncodes]
+
+
+@requires_launch
+def test_launch_ends_on_humble_where_the_node_cannot_survive(monkeypatch):
+    # Humble's controller_manager aborts, or wedges, on a failed connect, so the
+    # spawners' failure is the only exit signal the launch can act on there.
+    emitted = drive_spawner_exits(monkeypatch, [1, 1, 1], distro="humble")
+    assert hints(emitted)[:-1] == [[], []]
+    assert "relaunch" in hints(emitted)[-1][0]
+    assert SPAWNER_RERUN not in hints(emitted)[-1][0]
+    assert [len(s) for s in shutdowns(emitted)] == [0, 0, 1]
+
+
+@requires_launch
+def test_launch_keeps_running_on_humble_when_asked(monkeypatch):
+    emitted = drive_spawner_exits(
+        monkeypatch, [1, 1, 1], distro="humble", shutdown_on_failure="false"
+    )
+    assert [len(h) for h in hints(emitted)] == [0, 0, 1]
+    assert shutdowns(emitted) == [[], [], []]
+
+
 def control_node_exit(monkeypatch, **launch_arguments):
     from launch.events.process import ProcessExited
 
@@ -524,3 +629,7 @@ def test_launch_can_outlive_the_control_node_for_includers(monkeypatch):
     # gripper_tactile_viz.launch.py includes this file next to the tactile
     # stack, which has no reason to stop streaming when the gripper is gone.
     assert control_node_exit(monkeypatch, shutdown_on_failure="false") == []
+
+
+def perform_text(msg):
+    return "".join(s.perform(LaunchContext()) for s in msg)

--- a/grippers/robotiq_description/test/test_controller_config.py
+++ b/grippers/robotiq_description/test/test_controller_config.py
@@ -305,33 +305,58 @@ requires_launch = pytest.mark.skipif(
 )
 
 
-def spawned_controllers(distro, monkeypatch, **launch_arguments):
-    from launch import LaunchContext
-    from launch.utilities import perform_substitutions
-    from launch_ros.actions import Node
+def launch_entities(distro, monkeypatch, **launch_arguments):
+    """The launch's entities, and a context with its arguments resolved.
 
+    `launch_arguments` override the declared defaults.
+    """
     if distro is None:
         monkeypatch.delenv("ROS_DISTRO", raising=False)
     else:
         monkeypatch.setenv("ROS_DISTRO", distro)
     context = LaunchContext()
-    context.launch_configurations.update(
-        {
-            "sim_topic_based": "false",
-            "gripper_joint": JOINT,
-            **launch_arguments,
-        }
-    )
+    context.launch_configurations.update(launch_arguments)
+    entities = load_launch_module().generate_launch_description().entities
+    for entity in entities:
+        if isinstance(entity, DeclareLaunchArgument):
+            entity.execute(context)
+    return entities, context
 
-    spawned = {}
-    for action in load_launch_module().generate_launch_description().entities:
-        if not isinstance(action, Node) or action.node_executable != "spawner":
-            continue
-        if action.condition is not None and not action.condition.evaluate(context):
-            continue
-        cmd = [perform_substitutions(context, part) for part in action.cmd]
-        spawned[cmd[1]] = Path(cmd[cmd.index("--param-file") + 1]).read_text()
-    return spawned
+
+def starts(action, context):
+    return action.condition is None or action.condition.evaluate(context)
+
+
+def nodes_running(entities, context, executable):
+    from launch_ros.actions import Node
+
+    return [
+        e
+        for e in entities
+        if isinstance(e, Node) and e.node_executable == executable
+        if starts(e, context)
+    ]
+
+
+def spawner_commands(distro, monkeypatch, **launch_arguments):
+    """Yield (controller, resolved command line) for every spawner that starts.
+
+    A generator so the entities, and with them the ParameterFile's temporary
+    file, outlive the caller's look at each command.
+    """
+    from launch.utilities import perform_substitutions
+
+    entities, context = launch_entities(distro, monkeypatch, **launch_arguments)
+    for spawner in nodes_running(entities, context, "spawner"):
+        cmd = [perform_substitutions(context, part) for part in spawner.cmd]
+        yield cmd[1], cmd
+
+
+def spawned_controllers(distro, monkeypatch, **launch_arguments):
+    return {
+        name: Path(cmd[cmd.index("--param-file") + 1]).read_text()
+        for name, cmd in spawner_commands(distro, monkeypatch, **launch_arguments)
+    }
 
 
 def resolved(config, joint=JOINT):
@@ -430,3 +455,53 @@ def test_controller_names_and_update_rate_are_identical_across_distros(config):
         controllers["joint_state_broadcaster"]["type"]
         == "joint_state_broadcaster/JointStateBroadcaster"
     )
+
+
+@requires_launch
+def test_launch_gives_a_slow_gripper_ten_seconds_to_reach_the_controller_manager(
+    monkeypatch,
+):
+    # Bounded so a controller_manager that never answers ends the bringup, wide
+    # enough that a gripper still recovering from a fault is not taken for missing.
+    for _, cmd in spawner_commands("jazzy", monkeypatch):
+        assert cmd[cmd.index("--controller-manager-timeout") + 1] == "10"
+
+
+PROCESS = {"name": "p", "cmd": ["p"], "cwd": None, "env": None, "pid": 1}
+
+
+def dispatch(entities, context, event):
+    from launch.actions import RegisterEventHandler
+
+    emitted = []
+    for entity in entities:
+        if not isinstance(entity, RegisterEventHandler) or not starts(entity, context):
+            continue
+        if entity.event_handler.matches(event):
+            emitted.extend(entity.event_handler.handle(event, context) or [])
+    return emitted
+
+
+def control_node_exit(monkeypatch, **launch_arguments):
+    from launch.events.process import ProcessExited
+
+    entities, context = launch_entities("jazzy", monkeypatch, **launch_arguments)
+    (control_node,) = nodes_running(entities, context, "ros2_control_node")
+    event = ProcessExited(action=control_node, returncode=-6, **PROCESS)
+    return dispatch(entities, context, event)
+
+
+@requires_launch
+def test_launch_ends_when_the_control_node_exits(monkeypatch):
+    from launch.actions import Shutdown
+
+    emitted = control_node_exit(monkeypatch)
+    assert len(emitted) == 1
+    assert isinstance(emitted[0], Shutdown)
+
+
+@requires_launch
+def test_launch_can_outlive_the_control_node_for_includers(monkeypatch):
+    # gripper_tactile_viz.launch.py includes this file next to the tactile
+    # stack, which has no reason to stop streaming when the gripper is gone.
+    assert control_node_exit(monkeypatch, shutdown_on_failure="false") == []

--- a/grippers/robotiq_description/test/test_controller_config.py
+++ b/grippers/robotiq_description/test/test_controller_config.py
@@ -73,6 +73,16 @@ JOINT = "robotiq_85_left_knuckle_joint"
 GRIPPER_JOINTS = (JOINT, "finger_joint")
 UPDATE_RATE_HZ = 500
 
+# Every key a controller_manager block may carry besides the controllers, per
+# config. A misspelled setting is silently ignored by the controller_manager, so
+# the blocks are compared exhaustively against these.
+CONTROLLER_MANAGER_SETTINGS = {
+    JAZZY_CONFIG: {"update_rate", "hardware_components_initial_state"},
+    HUMBLE_CONFIG: {"update_rate"},
+    JAZZY_TOPIC_BASED_CONFIG: {"update_rate"},
+    HUMBLE_TOPIC_BASED_CONFIG: {"update_rate"},
+}
+
 
 def exported_command_interfaces(joint):
     return {
@@ -403,8 +413,7 @@ def test_sim_configs_spawn_no_activation_controller(config):
     # No reactivate_gripper GPIO is declared under sim_topic_based (see
     # 2f_85.ros2_control.xacro), so the controller would have nothing to claim.
     controllers = load(config)["controller_manager"]["ros__parameters"]
-    assert set(controllers) == {
-        "update_rate",
+    assert set(controllers) == CONTROLLER_MANAGER_SETTINGS[config] | {
         "joint_state_broadcaster",
         "robotiq_gripper_controller",
     }
@@ -440,8 +449,7 @@ def test_controller_names_and_update_rate_are_identical_across_distros(config):
     # (/robotiq_gripper_controller/gripper_cmd), so they must not drift between
     # the two configs.
     controllers = load(config)["controller_manager"]["ros__parameters"]
-    assert set(controllers) == {
-        "update_rate",
+    assert set(controllers) == CONTROLLER_MANAGER_SETTINGS[config] | {
         "joint_state_broadcaster",
         "robotiq_gripper_controller",
         "robotiq_activation_controller",
@@ -455,6 +463,17 @@ def test_controller_names_and_update_rate_are_identical_across_distros(config):
         controllers["joint_state_broadcaster"]["type"]
         == "joint_state_broadcaster/JointStateBroadcaster"
     )
+
+
+def test_jazzy_config_keeps_the_node_alive_without_a_gripper():
+    controllers = load(JAZZY_CONFIG)["controller_manager"]["ros__parameters"]
+    initial_state = controllers["hardware_components_initial_state"]
+    assert initial_state["shutdown_on_initial_state_failure"] is False
+
+
+def test_humble_config_declares_no_initial_state_policy():
+    controllers = load(HUMBLE_CONFIG)["controller_manager"]["ros__parameters"]
+    assert "hardware_components_initial_state" not in controllers
 
 
 @requires_launch

--- a/grippers/robotiq_driver/src/hardware_interface.cpp
+++ b/grippers/robotiq_driver/src/hardware_interface.cpp
@@ -227,9 +227,11 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Roboti
    catch(const std::exception& e)
    {
       RCLCPP_ERROR(kLogger,
-                   "Cannot connect to the Robotiq gripper on %s: %s",
+                   "Cannot connect to the Robotiq gripper on %s: %s. Once it is connected, retry with: ros2 control "
+                   "set_hardware_component_state %s active",
                    describeLink(parameters_.connection).c_str(),
-                   e.what());
+                   e.what(),
+                   info_.name.c_str());
       return CallbackReturn::ERROR;
    }
 

--- a/grippers/robotiq_driver/src/hardware_interface.cpp
+++ b/grippers/robotiq_driver/src/hardware_interface.cpp
@@ -228,7 +228,7 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Roboti
    {
       RCLCPP_ERROR(kLogger,
                    "Cannot connect to the Robotiq gripper on %s: %s. Once it is connected, retry with: ros2 control "
-                   "set_hardware_component_state %s active",
+                   "set_hardware_component_state '%s' active",
                    describeLink(parameters_.connection).c_str(),
                    e.what(),
                    info_.name.c_str());

--- a/robotiq_tsf/launch/gripper_tactile_viz.launch.py
+++ b/robotiq_tsf/launch/gripper_tactile_viz.launch.py
@@ -150,6 +150,7 @@ def generate_launch_description():
             "baudrate": baudrate,
             "use_fake_hardware": use_fake_hardware,
             "launch_rviz": "false",
+            "shutdown_on_failure": "false",
         }.items(),
     )
 


### PR DESCRIPTION
## Survive a missing gripper at bringup

Closes #27. Closes #38 on Jazzy and newer; Humble is discussed below.

Launching `robotiq_control.launch.py` with no gripper attached used to fail
twice over. `ros2_control_node` asks for the hardware component to come up
`active`, so when `on_configure` cannot open the port the controller manager
rethrows and the process aborts (#38). Where the abort completes, the three
spawners then poll `/controller_manager/list_controllers` every 10 s forever
(#27); on some hosts the abort does not complete and the process wedges in its
backtrace handler, ignoring `SIGINT` and `SIGTERM`. Either way the only way
forward was Ctrl-C and a relaunch with the gripper plugged in.

Four commits, one per change:

**Bound the spawners' wait.** Each spawner gets `--controller-manager-timeout 15`,
so a controller manager that never answers makes them exit non-zero instead of
retrying indefinitely. The value is the driver's default `activation_timeout`:
the manager only answers once the hardware is active, so a gripper still
recovering from a fault must not read as missing. An unplugged gripper fails in
about a second regardless, so the bound only delays the verdict where the
manager never comes at all.
An `OnProcessExit` handler on `ros2_control_node` also ends the launch when the
node does exit. `shutdown_on_failure:=false` opts out of that for includers;
`gripper_tactile_viz.launch.py` passes it, so the tactile stack keeps streaming
without a gripper, as it did before.

**Keep the node alive.** `shutdown_on_initial_state_failure: false` in the
Jazzy controller config. A failed connect leaves the component `unconfigured`
and the node running, so the spawners fail fast and the user can recover
without relaunching.

**Say how to retry the connection.** The driver's connect error now ends with
the retry for the hardware component, since it is the one place that knows the
component's name:

```
Cannot connect to the Robotiq gripper on /dev/ttyUSB0 ...: <cause>. Once it is
connected, retry with: ros2 control set_hardware_component_state RobotiqGripperHardwareInterface active
```

**Say why the bringup failed, and the way back.** After the last spawner has
exited, and only if one failed, the launch prints both recovery steps in order.
Bringing the hardware back leaves the three controllers loaded but inactive
(nothing in the controller manager reactivates them), so the second step is a
spawner re-run, built from the spawners' own argument list so the two cannot
drift, which configures and activates what is already loaded:

```
ros2 control set_hardware_component_state RobotiqGripperHardwareInterface active
ros2 run controller_manager spawner joint_state_broadcaster robotiq_gripper_controller robotiq_activation_controller --controller-manager /controller_manager --controller-manager-timeout 15 --param-file /tmp/launch_params_...
```

The component names come from the description the launch loads, so a custom
`model:=` gets its own names.

The hint stays silent when the spawners were killed rather than failed (Ctrl-C,
or the launch's own shutdown) and under `use_fake_hardware` or `sim_topic_based`,
where no serial link can be the cause.

## Humble

Humble's `controller_manager` has no `shutdown_on_initial_state_failure`
parameter, so its config is unchanged and the node still aborts or wedges
there. When it aborts, the node-exit handler says to reconnect and relaunch and
ends the launch. When it wedges there is no exit to react to, so the spawners'
timeout is what ends the bringup: once they give up the launch prints the same
line and ends itself (unless `shutdown_on_failure:=false`), which is what gets
a wedged node killed.

## Retrying on its own

#38 also asked for the node to retry the connection by itself. This PR leaves
that to the user on purpose: reconnecting with backoff is a general grippers
need, so the retry loop belongs in the grippers SDK, which plans it. #71 tracks
the ROS side once that lands.

## Testing

Verified on Jazzy against a 2F-85, on the host, with the port held busy by
another process to stand in for an unplugged gripper:

| | gripper unplugged | plugged in after launch |
|---|---|---|
| before | node aborts (or wedges); spawners retry forever | relaunch only |
| after | node stays up; spawners exit in ~1 s; both hints printed | `set_hardware_component_state ... active` alone leaves all three controllers inactive; the spawner re-run brings them `active` and `/joint_states` flows |

Ctrl-C two seconds into a bringup prints no hint. The hint above is the one printed on the bench, param file path included. With the gripper attached
from the start the bringup is unchanged.

Tests drive the launch's exit handlers per spawner and check: the hint fires
once, after the last exit, for `[1,1,1]`, `[0,1,0]` and `[1,0,0]`; nothing
fires for success, for signal exits, once shutdown is under way, or under the
mock and simulated plugins; Humble gets the relaunch wording plus a `Shutdown`,
suppressed by `shutdown_on_failure:=false`; the control-node exit handler
emits `Shutdown` and is absent when opted out; the spawners carry the 10 s
timeout. The `controller_manager` blocks are compared exhaustively against the
settings each config may carry, so a misspelled setting cannot slip through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
