### PR TITLE
feat(mcp): tactile datasheet, TactileService and read/tare/verify_grasp tools

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -15,6 +15,9 @@ hardware and against a simulator launched with `sim_topic_based:=true`.
 | `gripper_close` | Close fully; optional `max_effort_n` |
 | `gripper_move_to` | Move to a specific position, in mm of opening; optional `max_effort_n` |
 | `gripper_get_health` | Reachable, controller active |
+| `gripper_read_tactile` | TSF-85 pads: contact signal, per-pad split, hottest taxel |
+| `gripper_tare_tactile` | Re-zero the pads (fingers empty) |
+| `gripper_verify_grasp` | Confirm a hold from touch plus opening |
 
 Every tool takes an explicit `gripper_name`; nothing fans out to every gripper.
 Openings are in **millimetres**: `0.0` closed, the model's max opening (`85.0`
@@ -27,6 +30,28 @@ on a 2F-85, `140.0` on a 2F-140) fully open. Every motion result carries an
 | `stopped_on_object` | The fingers stopped on something before the commanded position, either direction; `object_detected: true`. Whether that is a grasp is the caller's call |
 | `incomplete` | Timed out or never finished |
 | `refused` | The backend rejected the goal |
+
+## Tactile
+
+A gripper fitted with TSF-85 fingers gets a `tactile` source in `grippers.yaml`
+next to its namespace; the three tactile tools fail for any other gripper.
+Readings are raw taxel counts, made meaningful by subtracting a baseline
+averaged over many samples with the fingers open (the first read takes it
+automatically if the gripper is open; `gripper_tare_tactile` retakes it).
+The tare also sets the contact threshold: the datasheet floor, or `noise_margin`
+times the peak rest signal its own frames showed, whichever is higher, so pads
+noisier than the twin the floor was tuned on do not read an empty gripper as a
+hold. `gripper_verify_grasp` gives one of:
+
+| Verdict | Meaning |
+|---|---|
+| `held` | Pads register contact and the fingers stopped before meeting |
+| `closed_on_nothing` | Fingers fully closed |
+| `no_contact` | Fingers apart, pads quiet: the object slipped, or the stop was outside the pads |
+
+The ROS source on `robotiq_tsf`'s `TactileSensor/StaticData` topic is next;
+until it lands, `build_services` refuses a `tactile` entry by name. The tests
+drive the tools from a scripted pad model under `tests/fakes/`.
 
 ## Quick start
 
@@ -85,8 +110,9 @@ Two layers, deliberately split:
 - `gripper_mcp/datasheets/<model>.yaml`: one datasheet per Robotiq model, the same
   on every host. The command joint's name and range come straight from
   `robotiq_description`'s URDF. Supporting another model is adding a file.
-- `grippers.yaml`: the cell's wiring, which grippers exist, their model and the
-  ROS namespace their driver runs under. Host-specific, so only
+- `grippers.yaml`: the cell's wiring, which grippers exist, their model, the
+  ROS namespace their driver runs under and an optional tactile source.
+  Host-specific, so only
   `grippers.yaml.example` ships.
 
 ## Not a ROS package

--- a/mcp/gripper_mcp/config.py
+++ b/mcp/gripper_mcp/config.py
@@ -1,12 +1,17 @@
 """Configuration loading: gripper model datasheets and per-cell wiring.
 
-Two kinds of files, deliberately split:
+Three kinds of files, deliberately split:
 
-- `gripper_mcp/datasheets/<model>.yaml`: one datasheet per Robotiq
+- `gripper_mcp/datasheets/<model>.yaml`: one datasheet per Robotiq gripper
   model, shipped inside the package so an installed wheel finds it. It carries
   only what no robot description can tell us: the stroke in mm, the grip force
-  the product is rated for, and timing defaults. The command joint's name and
-  range come from the robot at runtime. Adding a model is adding a file.
+  the product is rated for, timing defaults, and which tactile pads fit it. The
+  command joint's name and range come from the robot at runtime. Adding a model
+  is adding a file.
+- `gripper_mcp/datasheets/tactile/<model>.yaml`: one datasheet per tactile
+  product. The TSF pads are a separate product fitted onto a 2F gripper, with
+  their own driver, so they get their own sheet; a gripper sheet points at it
+  by `tactile_model`.
 - `grippers.yaml`: the cell's wiring, which grippers exist, their model and
   the ROS namespace their driver runs under. Host-specific, so it ships as an
   example to copy.
@@ -21,13 +26,16 @@ typo that silently dropped a field would point the server at the wrong robot.
 
 from importlib.resources import files
 from pathlib import Path
+from typing import Any, Literal
 
 import yaml
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from gripper_mcp.tactile_backend import TactileLayout
 from gripper_mcp.units import Stroke
 
 SPEC_DIR = Path(str(files("gripper_mcp").joinpath("datasheets")))
+TACTILE_SUBDIR = "tactile"
 
 
 class StrictModel(BaseModel):
@@ -39,6 +47,7 @@ class GripperConfig(StrictModel):
     model: str
     namespace: str
     description: str = ""
+    tactile: Literal["ros"] | None = None
 
     @model_validator(mode="after")
     def _needs_a_namespace(self) -> "GripperConfig":
@@ -66,11 +75,37 @@ class Defaults(StrictModel):
     motion_timeout_s: float
 
 
+class TactileSpec(StrictModel):
+    model: str
+    rows: int = Field(gt=0)
+    cols: int = Field(gt=0)
+    pads: list[str]
+    full_scale_counts: float = Field(gt=0.0)
+    contact_threshold: float
+    baseline_samples: int = Field(gt=0)
+
+    @property
+    def layout(self) -> TactileLayout:
+        return TactileLayout(rows=self.rows, cols=self.cols, pad_names=tuple(self.pads))
+
+
 class GripperModelSpec(StrictModel):
     model: str
     stroke: Stroke
     grip_force: GripForce
     defaults: Defaults
+    tactile_model: str | None = None
+    tactile: TactileSpec | None = Field(default=None, exclude=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _tactile_comes_from_its_own_datasheet(cls, data: Any) -> Any:
+        if isinstance(data, dict) and "tactile" in data:
+            raise ValueError(
+                "a gripper datasheet names its pads with tactile_model; the tactile "
+                f"block belongs in datasheets/{TACTILE_SUBDIR}/<tactile_model>.yaml"
+            )
+        return data
 
     @model_validator(mode="after")
     def _default_effort_within_the_rated_range(self) -> "GripperModelSpec":
@@ -84,7 +119,24 @@ class GripperModelSpec(StrictModel):
 
 
 def load_model_spec(path: Path) -> GripperModelSpec:
-    return GripperModelSpec.model_validate(yaml.safe_load(path.read_text()))
+    spec = GripperModelSpec.model_validate(yaml.safe_load(path.read_text()))
+    if spec.tactile_model is None:
+        return spec
+    tactile = load_tactile_spec(
+        path.parent / TACTILE_SUBDIR / f"{spec.tactile_model}.yaml"
+    )
+    if tactile.model != spec.tactile_model:
+        raise ValueError(
+            f"{path.name} names tactile_model '{spec.tactile_model}' but the tactile "
+            f"datasheet calls itself '{tactile.model}'"
+        )
+    return spec.model_copy(update={"tactile": tactile})
+
+
+def load_tactile_spec(path: Path) -> TactileSpec:
+    if not path.exists():
+        raise FileNotFoundError(f"No tactile datasheet at {path}.")
+    return TactileSpec.model_validate(yaml.safe_load(path.read_text()))
 
 
 def load_model_specs(spec_dir: Path, models: set[str]) -> dict[str, GripperModelSpec]:

--- a/mcp/gripper_mcp/config.py
+++ b/mcp/gripper_mcp/config.py
@@ -82,6 +82,7 @@ class TactileSpec(StrictModel):
     pads: list[str]
     full_scale_counts: float = Field(gt=0.0)
     contact_threshold: float
+    noise_margin: float = Field(ge=1.0)
     baseline_samples: int = Field(gt=0)
 
     @property

--- a/mcp/gripper_mcp/datasheets/robotiq_2f_85.yaml
+++ b/mcp/gripper_mcp/datasheets/robotiq_2f_85.yaml
@@ -31,3 +31,8 @@ defaults:
   # Requested grip force when a call does not name one; must sit in grip_force.
   max_effort_n: 50.0
   motion_timeout_s: 10.0
+
+# Tactile pads that fit this gripper: datasheets/tactile/<tactile_model>.yaml.
+# Omit for a model with no tactile option. Whether a given gripper wears them
+# is the wiring's business (`tactile: ros` in grippers.yaml).
+tactile_model: robotiq_tsf_85

--- a/mcp/gripper_mcp/datasheets/tactile/robotiq_tsf_85.yaml
+++ b/mcp/gripper_mcp/datasheets/tactile/robotiq_tsf_85.yaml
@@ -17,9 +17,16 @@ pads: [left, right]
 # Unverified against a physical TSF-85; re-measure before trusting it there.
 full_scale_counts: 6160.0
 
-# Contact is declared at or above this signal. Deliberately just above the
-# noise floor: the point is to notice FIRST touch, not a firm grip.
+# Floor for the contact threshold. Deliberately just above the twin's noise
+# floor: the point is to notice FIRST touch, not a firm grip.
 contact_threshold: 0.02
+
+# The threshold used at runtime is max(contact_threshold, noise_margin x the
+# peak rest signal seen during the tare), so real pads whose noise sits above
+# the twin-tuned floor still get a threshold above their own noise. Measured
+# on a physical TSF-85: rest noise peaks near 0.035 of full scale, an external
+# hold reads about 0.8, so 2x the noise separates the two with room.
+noise_margin: 2.0
 
 # Matches the tactile SDK's findBaseline(), which averages 1000 samples.
 baseline_samples: 1000

--- a/mcp/gripper_mcp/datasheets/tactile/robotiq_tsf_85.yaml
+++ b/mcp/gripper_mcp/datasheets/tactile/robotiq_tsf_85.yaml
@@ -1,0 +1,25 @@
+# Robotiq TSF-85 tactile fingers datasheet. The pads are a separate product
+# fitted onto a 2F-85 and read by their own driver (robotiq_tsf), so they get
+# their own sheet; the gripper's datasheet points here with `tactile_model`.
+# Whether a given gripper has them or not is the wiring's business
+# (`tactile: ros` in grippers.yaml).
+
+model: robotiq_tsf_85
+
+# The 7x4 grid per pad is what robotiq_tsf publishes (Taxels: uint16[28]).
+rows: 7
+cols: 4
+pads: [left, right]
+
+# Signal 1.0 means every taxel on both pads is at the working ceiling:
+# 56 taxels x 110 counts. Tuned against the Isaac Sim twin's tactile
+# extension (hottest taxel ~106, no-contact floor ~0.0003 of full scale).
+# Unverified against a physical TSF-85; re-measure before trusting it there.
+full_scale_counts: 6160.0
+
+# Contact is declared at or above this signal. Deliberately just above the
+# noise floor: the point is to notice FIRST touch, not a firm grip.
+contact_threshold: 0.02
+
+# Matches the tactile SDK's findBaseline(), which averages 1000 samples.
+baseline_samples: 1000

--- a/mcp/gripper_mcp/models.py
+++ b/mcp/gripper_mcp/models.py
@@ -12,6 +12,9 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 Backend = Literal["ros", "mock"]
+TactileSource = Literal["mock"]
+
+GraspVerdict = Literal["held", "no_contact", "closed_on_nothing"]
 
 Outcome = Literal[
     "reached",
@@ -27,6 +30,9 @@ class GripperInfo(BaseModel):
     model: str
     backend: Backend
     max_opening_mm: float = Field(description="Fully open, in millimetres")
+    tactile: TactileSource | None = Field(
+        default=None, description="Tactile source when the gripper has pads"
+    )
     description: str
 
 
@@ -72,3 +78,37 @@ class GripperHealth(BaseModel):
     )
     detail: str
     backend: Backend
+
+
+class TactileTareResult(BaseModel):
+    robot_name: str
+    samples: int = Field(description="Readings averaged into the new baseline")
+    rest_counts_mean: float = Field(description="Mean raw count across every taxel")
+    tactile_backend: TactileSource
+    measured_at: datetime = Field(description="UTC, timezone-aware")
+
+
+class TactileReadingResult(BaseModel):
+    robot_name: str
+    contact: bool = Field(description="contact_signal is at or above threshold")
+    contact_signal: float = Field(
+        description="Baseline-subtracted pressure over both pads: 0.0 rest, 1.0 full scale"
+    )
+    threshold: float = Field(description="Signal at or above which contact is declared")
+    pad_signals: dict[str, float] = Field(description="Same scale, per pad")
+    peak_taxel_counts: float = Field(
+        description="Largest single-taxel rise, raw counts"
+    )
+    tactile_backend: TactileSource
+    measured_at: datetime = Field(description="UTC, timezone-aware")
+
+
+class GraspVerification(BaseModel):
+    robot_name: str
+    verdict: GraspVerdict
+    object_held: bool = Field(description="True only for verdict held")
+    opening_mm: float
+    contact_signal: float
+    threshold: float
+    detail: str
+    tactile_backend: TactileSource

--- a/mcp/gripper_mcp/models.py
+++ b/mcp/gripper_mcp/models.py
@@ -12,7 +12,7 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 Backend = Literal["ros", "mock"]
-TactileSource = Literal["mock"]
+TactileSource = Literal["ros", "mock"]
 
 GraspVerdict = Literal["held", "no_contact", "closed_on_nothing"]
 
@@ -81,21 +81,33 @@ class GripperHealth(BaseModel):
 
 
 class TactileTareResult(BaseModel):
-    robot_name: str
-    samples: int = Field(description="Readings averaged into the new baseline")
+    gripper_name: str
+    samples: int = Field(description="Distinct frames averaged into the new baseline")
     rest_counts_mean: float = Field(description="Mean raw count across every taxel")
+    noise_floor: float = Field(
+        description="Peak contact_signal the rest frames showed against the baseline"
+    )
+    threshold: float = Field(
+        description="Contact threshold from now on: the datasheet floor or "
+        "noise_margin x noise_floor, whichever is higher"
+    )
     tactile_backend: TactileSource
     measured_at: datetime = Field(description="UTC, timezone-aware")
 
 
 class TactileReadingResult(BaseModel):
-    robot_name: str
+    gripper_name: str
     contact: bool = Field(description="contact_signal is at or above threshold")
     contact_signal: float = Field(
         description="Baseline-subtracted pressure over both pads: 0.0 rest, 1.0 full scale"
     )
-    threshold: float = Field(description="Signal at or above which contact is declared")
-    pad_signals: dict[str, float] = Field(description="Same scale, per pad")
+    threshold: float = Field(
+        description="Signal at or above which contact is declared; set at tare as the "
+        "datasheet floor or noise_margin x the measured rest noise, whichever is higher"
+    )
+    pad_signals: dict[str, float] = Field(
+        description="Per pad, as a fraction of that pad's own ceiling (1.0 = saturated)"
+    )
     peak_taxel_counts: float = Field(
         description="Largest single-taxel rise, raw counts"
     )
@@ -104,7 +116,7 @@ class TactileReadingResult(BaseModel):
 
 
 class GraspVerification(BaseModel):
-    robot_name: str
+    gripper_name: str
     verdict: GraspVerdict
     object_held: bool = Field(description="True only for verdict held")
     opening_mm: float

--- a/mcp/gripper_mcp/server.py
+++ b/mcp/gripper_mcp/server.py
@@ -22,12 +22,17 @@ from gripper_mcp.config import (
     load_model_specs,
 )
 from gripper_mcp.models import (
+    GraspVerification,
     GripperHealth,
     GripperInfo,
     GripperMotionResult,
     GripperState,
+    TactileReadingResult,
+    TactileTareResult,
 )
 from gripper_mcp.service import GripperService
+from gripper_mcp.tactile_backend import TactileBackend
+from gripper_mcp.tactile_service import TactileService
 
 DEFAULT_WIRING = Path("grippers.yaml")
 DEFAULT_PORT = 8300
@@ -39,7 +44,10 @@ INSTRUCTIONS = (
     "opening, reported by gripper_list_grippers. Every motion returns an outcome "
     "field that says how it ended; read that rather than inferring from the flags. "
     "stopped_on_object means the fingers met something; whether that is a grasp "
-    "is for the caller to judge."
+    "is for the caller to judge. "
+    "Grippers listed with a tactile source have TSF-85 pads: gripper_verify_grasp "
+    "confirms a hold from touch, gripper_read_tactile reads the pads, "
+    "gripper_tare_tactile re-zeroes them."
 )
 
 READ_ONLY = {
@@ -57,6 +65,12 @@ OPENS = {
 CLOSES = {
     "read_only_hint": False,
     "destructive_hint": True,
+    "idempotent_hint": True,
+    "open_world_hint": True,
+}
+REZEROES = {
+    "read_only_hint": False,
+    "destructive_hint": False,
     "idempotent_hint": True,
     "open_world_hint": True,
 }
@@ -83,22 +97,68 @@ def build_backend(config: GripperConfig, spec: GripperModelSpec) -> GripperBacke
     return RosGripperBackend(config.name, config.namespace)
 
 
-def build_service(
+TactileFactory = Callable[
+    [GripperConfig, GripperModelSpec, GripperBackend], TactileBackend | None
+]
+
+
+def build_tactile(
+    config: GripperConfig, spec: GripperModelSpec, gripper: GripperBackend
+) -> TactileBackend | None:
+    if config.tactile is None:
+        return None
+    if spec.tactile is None:
+        raise RuntimeError(
+            f"Gripper '{config.name}' asks for tactile pads, but model "
+            f"'{config.model}' names no tactile_model in its datasheet."
+        )
+    raise NotImplementedError(
+        f"Gripper '{config.name}' asks for the ROS tactile source, which is not in "
+        "this build."
+    )
+
+
+def build_services(
     wiring: Path,
     spec_dir: Path = SPEC_DIR,
     make_backend: BackendFactory = build_backend,
-) -> GripperService:
+    make_tactile: TactileFactory = build_tactile,
+) -> tuple[GripperService, TactileService]:
     configs = {cfg.name: cfg for cfg in load_gripper_configs(wiring)}
     specs = load_model_specs(spec_dir, {cfg.model for cfg in configs.values()})
     backends = {
         name: make_backend(cfg, specs[cfg.model]) for name, cfg in configs.items()
     }
-    return GripperService(specs=specs, configs=configs, backends=backends)
+    tactile_backends = {}
+    for name, cfg in configs.items():
+        tactile = make_tactile(cfg, specs[cfg.model], backends[name])
+        if tactile is not None:
+            tactile_backends[name] = tactile
+
+    grippers = GripperService(
+        specs=specs,
+        configs=configs,
+        backends=backends,
+        tactile_sources={name: t.name for name, t in tactile_backends.items()},
+    )
+    tactile = TactileService(
+        grippers,
+        {
+            name: (backend, specs[configs[name].model].tactile)
+            for name, backend in tactile_backends.items()
+        },
+    )
+    return grippers, tactile
 
 
-def build_mcp(service: GripperService) -> FastMCP:
+def build_mcp(grippers: GripperService, tactile: TactileService) -> FastMCP:
     mcp = FastMCP("robotiq_gripper_mcp", instructions=INSTRUCTIONS)
+    register_gripper_tools(mcp, grippers)
+    register_tactile_tools(mcp, tactile)
+    return mcp
 
+
+def register_gripper_tools(mcp: FastMCP, service: GripperService) -> None:
     @mcp.tool(
         name="gripper_list_grippers",
         annotations={**READ_ONLY, "open_world_hint": False},
@@ -224,7 +284,73 @@ def build_mcp(service: GripperService) -> FastMCP:
     def gripper_get_health(gripper_name: str) -> GripperHealth:
         return service.get_health(gripper_name)
 
-    return mcp
+
+def register_tactile_tools(mcp: FastMCP, service: TactileService) -> None:
+    @mcp.tool(
+        name="gripper_read_tactile",
+        annotations=READ_ONLY,
+        description=describe(
+            """
+        Read the tactile pads of one gripper fitted with TSF-85 fingers.
+
+        Returns a contact signal from 0.0 (nothing touching) to 1.0 (both pads
+        at full scale), the per-pad split, the hottest single taxel, and whether
+        the signal is at or above the contact threshold. The signal is relative
+        to a baseline captured with the fingers fully open; the first read takes
+        it automatically if the gripper is open, otherwise call
+        gripper_tare_tactile first. Fails for grippers without a tactile source.
+
+        Args:
+            gripper_name: Name of the gripper (see gripper_list_grippers).
+            """
+        ),
+    )
+    def gripper_read_tactile(gripper_name: str) -> TactileReadingResult:
+        return service.read(gripper_name)
+
+    @mcp.tool(
+        name="gripper_tare_tactile",
+        annotations=REZEROES,
+        description=describe(
+            """
+        Re-zero the tactile pads of one gripper.
+
+        Averages many distinct frames into a new rest baseline and sets the
+        contact threshold from the noise those frames show (never below the
+        datasheet floor). Only call it with NOTHING between the fingers: taring
+        on a held object makes that object invisible to every later reading.
+
+        Args:
+            gripper_name: Name of the gripper (see gripper_list_grippers).
+            """
+        ),
+    )
+    def gripper_tare_tactile(gripper_name: str) -> TactileTareResult:
+        return service.tare(gripper_name)
+
+    @mcp.tool(
+        name="gripper_verify_grasp",
+        annotations=READ_ONLY,
+        description=describe(
+            """
+        Confirm from touch whether one gripper is holding something.
+
+        Combines the pads and the opening. verdict="held" means the pads
+        register contact and the fingers stopped before meeting.
+        "closed_on_nothing" means the fingers are fully closed. "no_contact"
+        means the fingers are apart but nothing presses on the pads: either the
+        object slipped, or the gripper stopped on something outside the pads.
+        Call it after gripper_close, before lifting. A hold made by opening
+        into a bore is recognised only weakly, since the pads face away from
+        the part; treat "held" after gripper_open as a hint, not a verdict.
+
+        Args:
+            gripper_name: Name of the gripper (see gripper_list_grippers).
+            """
+        ),
+    )
+    def gripper_verify_grasp(gripper_name: str) -> GraspVerification:
+        return service.verify_grasp(gripper_name)
 
 
 def main() -> None:
@@ -235,7 +361,7 @@ def main() -> None:
     parser.add_argument("--port", type=int, default=DEFAULT_PORT)
     args = parser.parse_args()
 
-    mcp = build_mcp(build_service(args.config, args.spec_dir))
+    mcp = build_mcp(*build_services(args.config, args.spec_dir))
     try:
         mcp.run(transport="http", host=args.host, port=args.port)
     finally:

--- a/mcp/gripper_mcp/service.py
+++ b/mcp/gripper_mcp/service.py
@@ -56,10 +56,12 @@ class GripperService:
         specs: dict[str, GripperModelSpec],
         configs: dict[str, GripperConfig],
         backends: dict[str, GripperBackend],
+        tactile_sources: dict[str, str] | None = None,
     ) -> None:
         self._specs = specs
         self._configs = configs
         self._backends = backends
+        self._tactile_sources = tactile_sources or {}
 
     def list_grippers(self) -> list[GripperInfo]:
         return [
@@ -68,10 +70,14 @@ class GripperService:
                 model=config.model,
                 backend=self._backends[name].name,
                 max_opening_mm=self._specs[config.model].stroke.max_opening_mm,
+                tactile=self._tactile_sources.get(name),
                 description=config.description,
             )
             for name, config in self._configs.items()
         ]
+
+    def stroke_of(self, gripper_name: str) -> Stroke:
+        return self._spec(gripper_name).stroke
 
     def get_state(self, gripper_name: str) -> GripperState:
         backend = self._backend(gripper_name)
@@ -88,7 +94,7 @@ class GripperService:
             knuckle_rad=round(state.position_rad, RAD_DECIMALS),
             force_n=state.force_n,
             backend=backend.name,
-            measured_at=datetime.now(timezone.utc),
+            measured_at=timestamp(),
         )
 
     def open_fully(
@@ -167,6 +173,10 @@ class GripperService:
 
 def geometry_of(spec: GripperModelSpec, backend: GripperBackend) -> GripperGeometry:
     return GripperGeometry.of(spec.stroke, backend.joint_geometry())
+
+
+def timestamp() -> datetime:
+    return datetime.now(timezone.utc)
 
 
 def clamp_note(requested_mm: float, target_mm: float) -> str:

--- a/mcp/gripper_mcp/tactile.py
+++ b/mcp/gripper_mcp/tactile.py
@@ -16,6 +16,10 @@ pad, and a firm one-sided grasp could report no contact at all.
 pads sits at the working ceiling, so a firm one-sided contact reads about half
 of what the same force spread over both pads reads. Thresholds against it are
 in those units.
+
+`rest_noise` is the largest `contact_signal` any tare sample shows against the
+baseline they average to: the noise floor, measured for free at tare time, that
+a runtime threshold has to sit above.
 """
 
 from dataclasses import dataclass
@@ -71,6 +75,14 @@ def contact_signal(
         )
 
     return sum(pad_sums(reading, baseline)) / full_scale_counts
+
+
+def rest_noise(
+    readings: list[TactileReading], baseline: TactileBaseline, full_scale_counts: float
+) -> float:
+    return max(
+        contact_signal(reading, baseline, full_scale_counts) for reading in readings
+    )
 
 
 def _average_pad(readings: list[TactileReading], pad_name: str) -> tuple[float, ...]:

--- a/mcp/gripper_mcp/tactile_backend.py
+++ b/mcp/gripper_mcp/tactile_backend.py
@@ -9,6 +9,11 @@ backend has to refuse.
 Taxel counts are raw and uncalibrated, exactly as the sensor reports them. They
 only mean something once a baseline is subtracted; that arithmetic lives in
 `tactile.py`, in one place, so no source does it differently.
+
+`read_tactile` answers with the latest frame and never waits. `sample(count)`
+delivers `count` distinct frames, one per sensor update, never the same frame
+twice: a baseline averaged from repeated reads of one cached frame would
+report an averaging that never happened.
 """
 
 from dataclasses import dataclass
@@ -43,3 +48,5 @@ class TactileBackend(Protocol):
     name: str
 
     def read_tactile(self) -> TactileReading: ...
+
+    def sample(self, count: int) -> list[TactileReading]: ...

--- a/mcp/gripper_mcp/tactile_service.py
+++ b/mcp/gripper_mcp/tactile_service.py
@@ -1,0 +1,201 @@
+"""Tactile tools over a gripper's TSF-85 pads.
+
+Kept apart from `GripperService` because tactile is optional per gripper and
+has its own state, the rest baseline. The one piece of domain judgement here is
+`judge_grasp`: contact on the pads with the fingers apart is a hold; fingers
+that met hold nothing whatever the pads say (on a TSF-85 the pads touch each
+other when fully closed, and read well above the contact threshold, so position
+has to make that call, never the pads).
+
+An internal hold, the fingers pressing outward on the inside of a bore, is
+recognised only weakly: the pads face away from the part, and what they read
+comes from finger deflection or the bore edge, a few times the noise floor
+against an order of magnitude for an external hold. Do not tune the threshold
+against it. The gripper's own object detection names that case outright and
+will replace the inference once the backend reads it.
+
+Per-pad signals are each pad's fraction of its own ceiling
+(`full_scale_counts / pads`), so one saturated pad reads 1.0 on its own line
+while `contact_signal` stays normalised across both.
+
+The contact threshold is set at tare time, not copied from the datasheet: the
+rest frames the tare averages also show how noisy the pads are, and the
+threshold is the datasheet floor or `noise_margin` times that measured noise,
+whichever is higher. Real pads are far noisier than the twin the floor was
+tuned on, and a threshold under the noise makes an empty open gripper read as
+a hold.
+"""
+
+import threading
+from dataclasses import dataclass
+
+from gripper_mcp.config import TactileSpec
+from gripper_mcp.models import (
+    GraspVerdict,
+    GraspVerification,
+    TactileReadingResult,
+    TactileTareResult,
+)
+from gripper_mcp.service import GripperService, timestamp
+from gripper_mcp.tactile import (
+    TactileBaseline,
+    average_readings,
+    contact_signal,
+    pad_sums,
+    peak_rise,
+    rest_noise,
+)
+from gripper_mcp.tactile_backend import TactileBackend, TactileReading
+
+VERDICT_DETAIL: dict[GraspVerdict, str] = {
+    "held": "The pads register contact and the fingers stopped before meeting.",
+    "closed_on_nothing": "The fingers are fully closed; nothing is between them.",
+    "no_contact": "The fingers are apart but the pads register no contact.",
+}
+
+
+class TactileUnavailableError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class Tare:
+    baseline: TactileBaseline
+    noise_floor: float
+    threshold: float
+
+
+class TactileService:
+    def __init__(
+        self,
+        grippers: GripperService,
+        pads: dict[str, tuple[TactileBackend, TactileSpec]],
+    ) -> None:
+        self._grippers = grippers
+        self._pads = pads
+        self._tares: dict[str, Tare] = {}
+        self._tare_lock = threading.Lock()
+
+    def tare(self, gripper_name: str) -> TactileTareResult:
+        tactile, spec = self._pads_for(gripper_name)
+        tare = self._capture_tare(gripper_name, tactile, spec)
+
+        return TactileTareResult(
+            gripper_name=gripper_name,
+            samples=spec.baseline_samples,
+            rest_counts_mean=round(mean_counts(tare.baseline), 2),
+            noise_floor=round(tare.noise_floor, 5),
+            threshold=round(tare.threshold, 5),
+            tactile_backend=tactile.name,
+            measured_at=timestamp(),
+        )
+
+    def read(self, gripper_name: str) -> TactileReadingResult:
+        opening_mm = self._grippers.get_state(gripper_name).opening_mm
+
+        return self._read_at(gripper_name, opening_mm)
+
+    def verify_grasp(self, gripper_name: str) -> GraspVerification:
+        opening_mm = self._grippers.get_state(gripper_name).opening_mm
+        reading = self._read_at(gripper_name, opening_mm)
+        stroke = self._grippers.stroke_of(gripper_name)
+        verdict = judge_grasp(reading.contact, stroke.fingers_met(opening_mm))
+
+        return GraspVerification(
+            gripper_name=gripper_name,
+            verdict=verdict,
+            object_held=verdict == "held",
+            opening_mm=opening_mm,
+            contact_signal=reading.contact_signal,
+            threshold=reading.threshold,
+            detail=VERDICT_DETAIL[verdict],
+            tactile_backend=reading.tactile_backend,
+        )
+
+    def _read_at(self, gripper_name: str, opening_mm: float) -> TactileReadingResult:
+        tactile, spec = self._pads_for(gripper_name)
+        tare = self._tare(gripper_name, tactile, spec, opening_mm)
+
+        return self._reading(gripper_name, tactile, tare, spec)
+
+    def _pads_for(self, gripper_name: str) -> tuple[TactileBackend, TactileSpec]:
+        self._grippers.assert_known(gripper_name)
+        if gripper_name not in self._pads:
+            raise TactileUnavailableError(
+                f"Gripper '{gripper_name}' has no tactile pads configured."
+            )
+        return self._pads[gripper_name]
+
+    def _tare(
+        self,
+        gripper_name: str,
+        tactile: TactileBackend,
+        spec: TactileSpec,
+        opening_mm: float,
+    ) -> Tare:
+        if gripper_name in self._tares:
+            return self._tares[gripper_name]
+        if not self._grippers.stroke_of(gripper_name).fingers_open(opening_mm):
+            raise TactileUnavailableError(
+                "No tactile baseline yet, and the fingers are not fully open to "
+                "capture one. Open the gripper, or call gripper_tare_tactile."
+            )
+        return self._capture_tare(gripper_name, tactile, spec)
+
+    def _capture_tare(
+        self, gripper_name: str, tactile: TactileBackend, spec: TactileSpec
+    ) -> Tare:
+        with self._tare_lock:
+            tare = measure_tare(tactile.sample(spec.baseline_samples), spec)
+            self._tares[gripper_name] = tare
+        return tare
+
+    def _reading(
+        self,
+        gripper_name: str,
+        tactile: TactileBackend,
+        tare: Tare,
+        spec: TactileSpec,
+    ) -> TactileReadingResult:
+        reading = tactile.read_tactile()
+        signal = contact_signal(reading, tare.baseline, spec.full_scale_counts)
+        per_pad = zip(reading.pads, pad_sums(reading, tare.baseline))
+        pad_full_scale = spec.full_scale_counts / len(reading.pads)
+
+        return TactileReadingResult(
+            gripper_name=gripper_name,
+            contact=signal >= tare.threshold,
+            contact_signal=round(signal, 5),
+            threshold=round(tare.threshold, 5),
+            pad_signals={
+                pad.name: round(total / pad_full_scale, 5) for pad, total in per_pad
+            },
+            peak_taxel_counts=round(peak_rise(reading, tare.baseline), 1),
+            tactile_backend=tactile.name,
+            measured_at=timestamp(),
+        )
+
+
+def measure_tare(readings: list[TactileReading], spec: TactileSpec) -> Tare:
+    baseline = average_readings(readings)
+    noise_floor = rest_noise(readings, baseline, spec.full_scale_counts)
+
+    return Tare(
+        baseline=baseline,
+        noise_floor=noise_floor,
+        threshold=max(spec.contact_threshold, spec.noise_margin * noise_floor),
+    )
+
+
+def mean_counts(baseline: TactileBaseline) -> float:
+    total = sum(sum(pad) for pad in baseline.pads)
+    count = sum(len(pad) for pad in baseline.pads)
+    return total / count
+
+
+def judge_grasp(contact: bool, fingers_met: bool) -> GraspVerdict:
+    if fingers_met:
+        return "closed_on_nothing"
+    if contact:
+        return "held"
+    return "no_contact"

--- a/mcp/gripper_mcp/units.py
+++ b/mcp/gripper_mcp/units.py
@@ -49,6 +49,9 @@ class Stroke:
     def fingers_met(self, opening_mm: float) -> bool:
         return opening_mm <= self.min_opening_mm + self.closed_tolerance_mm
 
+    def fingers_open(self, opening_mm: float) -> bool:
+        return opening_mm >= self.max_opening_mm - self.closed_tolerance_mm
+
 
 @dataclass(frozen=True)
 class JointGeometry:

--- a/mcp/grippers.yaml.example
+++ b/mcp/grippers.yaml.example
@@ -4,6 +4,9 @@
 # robotiq_gripper_controller runs under. Without hardware, launch the driver on
 # ros2_control's fake hardware (use_fake_hardware) and point an entry at it the
 # same way.
+#
+# tactile: ros   optional; TSF-85 pads read from robotiq_tsf under the same
+#                namespace. Only for models whose datasheet has a tactile block.
 
 - name: left
   model: robotiq_2f_85

--- a/mcp/grippers.yaml.example
+++ b/mcp/grippers.yaml.example
@@ -6,7 +6,7 @@
 # same way.
 #
 # tactile: ros   optional; TSF-85 pads read from robotiq_tsf under the same
-#                namespace. Only for models whose datasheet has a tactile block.
+#                namespace. Only for models whose datasheet names a tactile_model.
 
 - name: left
   model: robotiq_2f_85

--- a/mcp/tests/fakes/tactile.py
+++ b/mcp/tests/fakes/tactile.py
@@ -60,6 +60,9 @@ class MockTactileBackend:
             layout=self._layout,
         )
 
+    def sample(self, count: int) -> list[TactileReading]:
+        return [self.read_tactile() for _ in range(count)]
+
     def _taxel_counts(self) -> int:
         penetration_mm = self._penetration_mm()
         if penetration_mm is None:

--- a/mcp/tests/test_config.py
+++ b/mcp/tests/test_config.py
@@ -232,3 +232,15 @@ def test_a_tactile_datasheet_with_no_samples_to_average_is_rejected(tmp_path):
 
     with pytest.raises(ValidationError, match="baseline_samples"):
         load_tactile_spec(sheet)
+
+
+def test_a_tactile_datasheet_whose_margin_would_lower_the_noise_is_rejected(tmp_path):
+    sheet = tmp_path / "robotiq_tsf_85.yaml"
+    sheet.write_text(
+        (TACTILE_SPEC_DIR / "robotiq_tsf_85.yaml")
+        .read_text()
+        .replace("noise_margin: 2.0", "noise_margin: 0.5")
+    )
+
+    with pytest.raises(ValidationError, match="noise_margin"):
+        load_tactile_spec(sheet)

--- a/mcp/tests/test_config.py
+++ b/mcp/tests/test_config.py
@@ -10,6 +10,7 @@ from gripper_mcp.config import (
     load_gripper_configs,
     load_model_spec,
     load_model_specs,
+    load_tactile_spec,
 )
 
 MCP_DIR = Path(__file__).resolve().parent.parent
@@ -19,6 +20,8 @@ MODELS = {
     "robotiq_2f_85": (85.0, 20.0, 235.0),
     "robotiq_2f_140": (140.0, 10.0, 125.0),
 }
+TSF_85_TAXELS_PER_PAD = 28
+TACTILE_SPEC_DIR = SPEC_DIR / "tactile"
 
 
 def wiring_file(tmp_path, entries):
@@ -93,11 +96,68 @@ def test_a_default_effort_outside_the_rated_grip_force_is_rejected(tmp_path):
         load_model_spec(write_datasheet(tmp_path, too_strong))
 
 
+def test_the_2f_85_datasheet_names_the_tsf_85_pads():
+    spec = load_model_spec(SPEC_DIR / "robotiq_2f_85.yaml")
+
+    assert spec.tactile_model == "robotiq_tsf_85"
+    assert spec.tactile.layout.taxels_per_pad == TSF_85_TAXELS_PER_PAD
+    assert spec.tactile.layout.pad_names == ("left", "right")
+    assert 0.0 < spec.tactile.contact_threshold < 1.0
+
+
+def test_the_2f_140_datasheet_has_no_tactile_option():
+    spec = load_model_spec(SPEC_DIR / "robotiq_2f_140.yaml")
+
+    assert spec.tactile_model is None
+    assert spec.tactile is None
+
+
+def test_every_shipped_tactile_datasheet_is_named_by_a_gripper():
+    named = {load_model_spec(path).tactile_model for path in SPEC_DIR.glob("*.yaml")}
+
+    assert {path.stem for path in TACTILE_SPEC_DIR.glob("*.yaml")} <= named
+
+
+def test_a_tactile_block_inside_a_gripper_datasheet_is_rejected(tmp_path):
+    inlined = datasheet_2f_85()
+    inlined["tactile"] = yaml.safe_load(
+        (TACTILE_SPEC_DIR / "robotiq_tsf_85.yaml").read_text()
+    )
+
+    with pytest.raises(ValidationError, match="tactile_model"):
+        load_model_spec(write_datasheet(tmp_path, inlined))
+
+
+def test_a_missing_tactile_datasheet_is_named(tmp_path):
+    orphan = datasheet_2f_85()
+    orphan["tactile_model"] = "robotiq_tsf_140"
+
+    with pytest.raises(FileNotFoundError, match="robotiq_tsf_140"):
+        load_model_spec(write_datasheet(tmp_path, orphan))
+
+
 def test_the_example_wiring_loads_and_names_a_namespace_per_gripper():
     configs = load_gripper_configs(EXAMPLE_WIRING)
 
     assert {config.model for config in configs} <= set(MODELS)
     assert all(config.namespace.startswith("/") for config in configs)
+
+
+def test_a_mock_tactile_source_is_not_a_wiring_option(tmp_path):
+    path = wiring_file(
+        tmp_path,
+        [
+            {
+                "name": "left",
+                "model": "robotiq_2f_85",
+                "namespace": "/left",
+                "tactile": "mock",
+            }
+        ],
+    )
+
+    with pytest.raises(ValidationError, match="tactile"):
+        load_gripper_configs(path)
 
 
 def test_a_gripper_without_a_namespace_is_rejected(tmp_path):
@@ -160,3 +220,15 @@ def test_a_missing_wiring_file_names_the_path(tmp_path):
 
     with pytest.raises(FileNotFoundError, match=str(missing.resolve())):
         load_gripper_configs(missing)
+
+
+def test_a_tactile_datasheet_with_no_samples_to_average_is_rejected(tmp_path):
+    sheet = tmp_path / "robotiq_tsf_85.yaml"
+    sheet.write_text(
+        (TACTILE_SPEC_DIR / "robotiq_tsf_85.yaml")
+        .read_text()
+        .replace("baseline_samples: 1000", "baseline_samples: 0")
+    )
+
+    with pytest.raises(ValidationError, match="baseline_samples"):
+        load_tactile_spec(sheet)

--- a/mcp/tests/test_mock_tactile_backend.py
+++ b/mcp/tests/test_mock_tactile_backend.py
@@ -13,6 +13,7 @@ JUST_TOUCHING_MM = 40.0
 LIGHTLY_PRESSED_MM = 38.0
 FIRMLY_PRESSED_MM = 30.0
 CRUSHED_MM = 0.0
+SAMPLE_COUNT = 3
 
 
 def backend(opening_mm: float, object_width_mm: float | None) -> MockTactileBackend:
@@ -91,3 +92,18 @@ def test_the_reading_follows_the_live_opening():
     after = live.read_tactile()
 
     assert all_resting(before) and not all_resting(after)
+
+
+def test_a_sample_is_one_fresh_reading_per_frame_asked():
+    opening = {"mm": FULLY_OPEN_MM}
+    live = MockTactileBackend(
+        read_opening_mm=lambda: opening["mm"], object_width_mm=OBJECT_WIDTH_MM
+    )
+
+    resting = live.sample(SAMPLE_COUNT)
+    opening["mm"] = FIRMLY_PRESSED_MM
+    pressed = live.sample(SAMPLE_COUNT)
+
+    assert len(resting) == len(pressed) == SAMPLE_COUNT
+    assert all(all_resting(frame) for frame in resting)
+    assert not any(all_resting(frame) for frame in pressed)

--- a/mcp/tests/test_server.py
+++ b/mcp/tests/test_server.py
@@ -4,9 +4,10 @@ import sys
 import pytest
 import yaml
 from fakes.gripper import MockGripperBackend
+from fakes.tactile import MockTactileBackend
 from fastmcp import Client
 
-from gripper_mcp.server import build_mcp, build_service
+from gripper_mcp.server import build_mcp, build_services
 
 EXPECTED_TOOLS = {
     "gripper_list_grippers",
@@ -15,8 +16,12 @@ EXPECTED_TOOLS = {
     "gripper_close",
     "gripper_move_to",
     "gripper_get_health",
+    "gripper_read_tactile",
+    "gripper_tare_tactile",
+    "gripper_verify_grasp",
 }
 CLOSING_TOOLS = {"gripper_close", "gripper_move_to"}
+TACTILE_READS = {"gripper_read_tactile", "gripper_verify_grasp"}
 CUBE_WIDTH_MM = 40.0
 
 
@@ -24,7 +29,14 @@ def write_wiring(directory):
     wiring = directory / "grippers.yaml"
     wiring.write_text(
         yaml.safe_dump(
-            [{"name": "left", "model": "robotiq_2f_85", "namespace": "/left"}]
+            [
+                {
+                    "name": "left",
+                    "model": "robotiq_2f_85",
+                    "namespace": "/left",
+                    "tactile": "ros",
+                }
+            ]
         )
     )
     return wiring
@@ -38,10 +50,24 @@ def gripper_holding_a_cube(config, spec):
     )
 
 
+def pads_on_the_cube(config, spec, gripper):
+    return MockTactileBackend(
+        read_opening_mm=lambda: gripper.opening_mm_for(
+            gripper.read_state().position_rad
+        ),
+        object_width_mm=CUBE_WIDTH_MM,
+        layout=spec.tactile.layout,
+    )
+
+
 @pytest.fixture
 def mcp(tmp_path):
     wiring = write_wiring(tmp_path)
-    return build_mcp(build_service(wiring, make_backend=gripper_holding_a_cube))
+    return build_mcp(
+        *build_services(
+            wiring, make_backend=gripper_holding_a_cube, make_tactile=pads_on_the_cube
+        )
+    )
 
 
 @pytest.fixture
@@ -85,6 +111,40 @@ def test_opening_is_not_destructive_and_reads_are_read_only(tools):
     assert tools["gripper_open"].annotations.destructive_hint is False
     assert tools["gripper_get_state"].annotations.read_only_hint is True
     assert tools["gripper_get_health"].annotations.read_only_hint is True
+    for name in TACTILE_READS:
+        assert tools[name].annotations.read_only_hint is True, name
+    assert tools["gripper_tare_tactile"].annotations.read_only_hint is False
+    assert tools["gripper_tare_tactile"].annotations.destructive_hint is False
+
+
+def test_a_close_then_verify_through_the_wire_confirms_the_hold(mcp):
+    call(mcp, "gripper_open", gripper_name="left")
+    call(mcp, "gripper_tare_tactile", gripper_name="left")
+
+    call(mcp, "gripper_close", gripper_name="left")
+    verification = call(mcp, "gripper_verify_grasp", gripper_name="left")
+
+    assert verification.verdict == "held"
+    assert verification.tactile_backend == "mock"
+
+
+def test_tactile_on_a_model_without_pads_fails_at_startup(tmp_path):
+    wiring = tmp_path / "grippers.yaml"
+    wiring.write_text(
+        yaml.safe_dump(
+            [
+                {
+                    "name": "right",
+                    "model": "robotiq_2f_140",
+                    "namespace": "/right",
+                    "tactile": "ros",
+                }
+            ]
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="tactile_model"):
+        build_services(wiring, make_backend=gripper_holding_a_cube)
 
 
 def test_every_motion_is_safe_to_repeat(tools):
@@ -112,4 +172,4 @@ def test_a_wiring_entry_names_the_missing_ros_install(tmp_path, monkeypatch):
     monkeypatch.setitem(sys.modules, "rclpy", None)
 
     with pytest.raises(RuntimeError, match="rclpy"):
-        build_service(write_wiring(tmp_path))
+        build_services(write_wiring(tmp_path))

--- a/mcp/tests/test_tactile.py
+++ b/mcp/tests/test_tactile.py
@@ -6,6 +6,7 @@ from gripper_mcp.tactile import (
     contact_signal,
     pad_sums,
     peak_rise,
+    rest_noise,
 )
 from gripper_mcp.tactile_backend import TactileLayout, TactilePad, TactileReading
 
@@ -18,6 +19,7 @@ RISE_COUNTS = PRESSED_COUNTS - REST_COUNTS
 FULL_SCALE_COUNTS = float(RISE_COUNTS * TAXELS_PER_PAD * 2)
 HOT_TAXEL_COUNTS = 900
 DRIFTED_LOW_COUNTS = 40
+NOISY_REST_COUNTS = REST_COUNTS + 2
 
 
 def reading(left_counts: int, right_counts: int) -> TactileReading:
@@ -184,3 +186,22 @@ def test_a_pad_the_baseline_never_saw_is_an_error():
 
     with pytest.raises(TactileShapeMismatch, match="thumb"):
         pad_sums(renamed, resting_baseline())
+
+
+def test_identical_rest_frames_have_no_noise():
+    frames = [reading(REST_COUNTS, REST_COUNTS)] * 3
+
+    assert rest_noise(frames, average_readings(frames), FULL_SCALE_COUNTS) == 0.0
+
+
+def test_the_noise_floor_is_the_loudest_rest_frame_against_the_mean():
+    frames = [
+        reading(REST_COUNTS, REST_COUNTS),
+        reading(NOISY_REST_COUNTS, REST_COUNTS),
+    ]
+    baseline = average_readings(frames)
+
+    expected = contact_signal(frames[1], baseline, FULL_SCALE_COUNTS)
+
+    assert rest_noise(frames, baseline, FULL_SCALE_COUNTS) == pytest.approx(expected)
+    assert rest_noise(frames, baseline, FULL_SCALE_COUNTS) > 0.0

--- a/mcp/tests/test_tactile_service.py
+++ b/mcp/tests/test_tactile_service.py
@@ -1,0 +1,296 @@
+import pytest
+from fakes.gripper import MockGripperBackend
+from fakes.tactile import REST_COUNTS, MockTactileBackend
+
+from gripper_mcp.config import SPEC_DIR, GripperConfig, load_model_specs
+from gripper_mcp.service import GripperService, UnknownGripperError
+from gripper_mcp.tactile_backend import TactilePad, TactileReading
+from gripper_mcp.tactile_service import (
+    TactileService,
+    TactileUnavailableError,
+    judge_grasp,
+)
+
+MODEL = "robotiq_2f_85"
+ARM = "left"
+CUBE_WIDTH_MM = 40.0
+FULLY_CLOSED_MM = 0.0
+SPEC = load_model_specs(SPEC_DIR, {MODEL})[MODEL]
+
+BENCH_REST_COUNTS = 12540
+BENCH_REST_NOISE_SIGNAL = 0.035
+BENCH_EXTERNAL_HOLD_SIGNAL = 0.8
+
+
+class ScriptedPads:
+    name = "mock"
+
+    def __init__(self, rest_frames: list[TactileReading]) -> None:
+        self._rest_frames = rest_frames
+        self.live: TactileReading = rest_frames[0]
+
+    def read_tactile(self) -> TactileReading:
+        return self.live
+
+    def sample(self, count: int) -> list[TactileReading]:
+        return [self._rest_frames[i % len(self._rest_frames)] for i in range(count)]
+
+
+def uniform_frame(counts: int) -> TactileReading:
+    layout = SPEC.tactile.layout
+    return TactileReading(
+        pads=tuple(
+            TactilePad(name=name, taxels=(counts,) * layout.taxels_per_pad)
+            for name in layout.pad_names
+        ),
+        layout=layout,
+    )
+
+
+def frame_at_signal(signal: float, above: TactileReading) -> TactileReading:
+    taxel_count = sum(len(pad.taxels) for pad in above.pads)
+    rise = round(signal * SPEC.tactile.full_scale_counts / taxel_count)
+    return uniform_frame(above.pads[0].taxels[0] + rise)
+
+
+def bench_services() -> tuple[GripperService, TactileService, ScriptedPads]:
+    quiet = uniform_frame(BENCH_REST_COUNTS)
+    loud = frame_at_signal(2 * BENCH_REST_NOISE_SIGNAL, quiet)
+    pads = ScriptedPads([quiet, loud])
+    gripper = MockGripperBackend(
+        object_width_mm=CUBE_WIDTH_MM, sleep_fn=lambda _seconds: None
+    )
+    grippers = GripperService(
+        specs={MODEL: SPEC},
+        configs={
+            ARM: GripperConfig(name=ARM, model=MODEL, namespace="/left", tactile="ros")
+        },
+        backends={ARM: gripper},
+        tactile_sources={ARM: pads.name},
+    )
+    return grippers, TactileService(grippers, {ARM: (pads, SPEC.tactile)}), pads
+
+
+def services_with(
+    gripper_object_mm: float | None, pad_object_mm: float | None
+) -> tuple[GripperService, TactileService]:
+    gripper = MockGripperBackend(
+        object_width_mm=gripper_object_mm, sleep_fn=lambda _seconds: None
+    )
+    pads = MockTactileBackend(
+        read_opening_mm=lambda: gripper.opening_mm_for(
+            gripper.read_state().position_rad
+        ),
+        object_width_mm=pad_object_mm,
+        layout=SPEC.tactile.layout,
+    )
+    grippers = GripperService(
+        specs={MODEL: SPEC},
+        configs={
+            ARM: GripperConfig(name=ARM, model=MODEL, namespace="/left", tactile="ros")
+        },
+        backends={ARM: gripper},
+        tactile_sources={ARM: pads.name},
+    )
+    return grippers, TactileService(grippers, {ARM: (pads, SPEC.tactile)})
+
+
+def services_without_pads() -> tuple[GripperService, TactileService]:
+    grippers = GripperService(
+        specs={MODEL: SPEC},
+        configs={ARM: GripperConfig(name=ARM, model=MODEL, namespace="/left")},
+        backends={ARM: MockGripperBackend(sleep_fn=lambda _seconds: None)},
+    )
+    return grippers, TactileService(grippers, {})
+
+
+def test_taring_averages_the_datasheet_sample_count_at_rest():
+    _, tactile = services_with(CUBE_WIDTH_MM, CUBE_WIDTH_MM)
+
+    result = tactile.tare(ARM)
+
+    assert result.samples == SPEC.tactile.baseline_samples
+    assert result.rest_counts_mean == pytest.approx(REST_COUNTS)
+    assert result.tactile_backend == "mock"
+
+
+def test_quiet_pads_keep_the_datasheet_threshold():
+    _, tactile = services_with(CUBE_WIDTH_MM, CUBE_WIDTH_MM)
+
+    result = tactile.tare(ARM)
+
+    assert result.noise_floor == pytest.approx(0.0)
+    assert result.threshold == SPEC.tactile.contact_threshold
+
+
+def test_noisy_pads_raise_the_threshold_above_their_own_noise():
+    _, tactile, _ = bench_services()
+
+    result = tactile.tare(ARM)
+
+    assert result.noise_floor == pytest.approx(BENCH_REST_NOISE_SIGNAL, abs=0.002)
+    assert result.threshold == pytest.approx(
+        SPEC.tactile.noise_margin * BENCH_REST_NOISE_SIGNAL, abs=0.004
+    )
+    assert result.threshold > SPEC.tactile.contact_threshold
+
+
+def test_an_empty_open_gripper_at_bench_noise_is_not_a_hold():
+    _, tactile, pads = bench_services()
+    tactile.tare(ARM)
+    pads.live = frame_at_signal(
+        BENCH_REST_NOISE_SIGNAL, uniform_frame(BENCH_REST_COUNTS)
+    )
+
+    reading = tactile.read(ARM)
+    verification = tactile.verify_grasp(ARM)
+
+    assert reading.contact is False
+    assert verification.verdict == "no_contact"
+
+
+def test_a_bench_external_hold_is_still_held():
+    grippers, tactile, pads = bench_services()
+    tactile.tare(ARM)
+    grippers.close_fully(ARM)
+    pads.live = frame_at_signal(
+        BENCH_EXTERNAL_HOLD_SIGNAL, uniform_frame(BENCH_REST_COUNTS)
+    )
+
+    verification = tactile.verify_grasp(ARM)
+
+    assert verification.verdict == "held"
+    assert verification.contact_signal > verification.threshold
+
+
+def test_an_open_gripper_reads_no_contact():
+    _, tactile = services_with(CUBE_WIDTH_MM, CUBE_WIDTH_MM)
+
+    reading = tactile.read(ARM)
+
+    assert reading.contact is False
+    assert reading.contact_signal == pytest.approx(0.0)
+    assert reading.threshold == SPEC.tactile.contact_threshold
+
+
+def test_a_grasp_on_the_cube_presses_both_pads():
+    grippers, tactile = services_with(CUBE_WIDTH_MM, CUBE_WIDTH_MM)
+    tactile.tare(ARM)
+
+    grippers.close_fully(ARM)
+    reading = tactile.read(ARM)
+
+    assert reading.contact is True
+    assert set(reading.pad_signals) == set(SPEC.tactile.pads)
+    assert all(signal > 0.0 for signal in reading.pad_signals.values())
+    assert sum(reading.pad_signals.values()) == pytest.approx(
+        reading.contact_signal * len(SPEC.tactile.pads), abs=1e-4
+    )
+    assert reading.peak_taxel_counts > 0.0
+
+
+def test_verifying_after_a_grasp_on_the_cube_says_held():
+    grippers, tactile = services_with(CUBE_WIDTH_MM, CUBE_WIDTH_MM)
+    tactile.tare(ARM)
+
+    grippers.close_fully(ARM)
+    verification = tactile.verify_grasp(ARM)
+
+    assert verification.verdict == "held"
+    assert verification.object_held is True
+    assert verification.opening_mm == pytest.approx(CUBE_WIDTH_MM)
+
+
+def test_a_verification_reads_the_gripper_state_once():
+    grippers, tactile = services_with(CUBE_WIDTH_MM, CUBE_WIDTH_MM)
+    reads = []
+    get_state = grippers.get_state
+    grippers.get_state = lambda name: reads.append(name) or get_state(name)
+
+    verification = tactile.verify_grasp(ARM)
+
+    assert verification.verdict == "no_contact"
+    assert reads == [ARM]
+
+
+def test_verifying_an_open_gripper_says_no_contact():
+    _, tactile = services_with(CUBE_WIDTH_MM, CUBE_WIDTH_MM)
+
+    verification = tactile.verify_grasp(ARM)
+
+    assert verification.verdict == "no_contact"
+    assert verification.object_held is False
+
+
+def test_verifying_after_closing_on_nothing_says_so():
+    grippers, tactile = services_with(None, None)
+    tactile.tare(ARM)
+
+    grippers.close_fully(ARM)
+    verification = tactile.verify_grasp(ARM)
+
+    assert verification.verdict == "closed_on_nothing"
+    assert verification.opening_mm == pytest.approx(FULLY_CLOSED_MM)
+
+
+def test_a_stall_outside_the_pads_is_not_a_hold():
+    grippers, tactile = services_with(CUBE_WIDTH_MM, None)
+    tactile.tare(ARM)
+
+    close = grippers.close_fully(ARM)
+    verification = tactile.verify_grasp(ARM)
+
+    assert close.outcome == "stopped_on_object"
+    assert verification.verdict == "no_contact"
+
+
+def test_the_first_read_takes_its_baseline_from_an_open_gripper():
+    grippers, tactile = services_with(CUBE_WIDTH_MM, CUBE_WIDTH_MM)
+
+    tactile.read(ARM)
+    grippers.close_fully(ARM)
+
+    assert tactile.read(ARM).contact is True
+
+
+def test_reading_with_the_fingers_closed_and_no_baseline_asks_for_a_tare():
+    grippers, tactile = services_with(None, None)
+    grippers.close_fully(ARM)
+
+    with pytest.raises(TactileUnavailableError, match="gripper_tare_tactile"):
+        tactile.read(ARM)
+
+
+def test_a_gripper_without_pads_refuses_tactile_tools():
+    _, tactile = services_without_pads()
+
+    with pytest.raises(TactileUnavailableError, match=ARM):
+        tactile.read(ARM)
+
+
+def test_an_unknown_gripper_is_still_reported_as_unknown():
+    _, tactile = services_with(None, None)
+
+    with pytest.raises(UnknownGripperError):
+        tactile.verify_grasp("nonexistent")
+
+
+def test_the_listing_shows_which_grippers_have_pads():
+    (with_pads,) = services_with(None, None)[0].list_grippers()
+    (without_pads,) = services_without_pads()[0].list_grippers()
+
+    assert with_pads.tactile == "mock"
+    assert without_pads.tactile is None
+
+
+@pytest.mark.parametrize(
+    ("contact", "fingers_met", "verdict"),
+    [
+        (True, False, "held"),
+        (False, False, "no_contact"),
+        (True, True, "closed_on_nothing"),
+        (False, True, "closed_on_nothing"),
+    ],
+)
+def test_judge_grasp_covers_every_combination(contact, fingers_met, verdict):
+    assert judge_grasp(contact, fingers_met) == verdict

--- a/mcp/tests/test_units.py
+++ b/mcp/tests/test_units.py
@@ -100,3 +100,8 @@ def test_a_closed_tolerance_outside_the_stroke_is_rejected(tolerance_mm):
 def test_the_fingers_have_met_within_the_closed_tolerance():
     assert STROKE_2F_85.fingers_met(1.4)
     assert not STROKE_2F_85.fingers_met(1.6)
+
+
+def test_the_fingers_are_open_within_the_closed_tolerance_of_the_stop():
+    assert STROKE_2F_85.fingers_open(83.6)
+    assert not STROKE_2F_85.fingers_open(83.4)


### PR DESCRIPTION
## Change

Ninth PR of the `mcp/` series (stacked on #62, now merged). Tactile reaches the tool surface; the ROS source and `grasp_until_contact` are the next PRs.

1. **Datasheets + wiring** — the TSF-85 pads are a separate product fitted onto a 2F gripper, so they get their own sheet, `datasheets/tactile/robotiq_tsf_85.yaml` (the 7x4 two-pad layout `robotiq_tsf` publishes, `full_scale_counts`, `contact_threshold` as a floor, `noise_margin`, `baseline_samples`); `robotiq_2f_85.yaml` names it with `tactile_model` and the loader stitches the two so consumers keep reading `spec.tactile`. The 2F-140 names no pads. A `grippers.yaml` entry opts in with `tactile: ros`, and startup fails clearly if the model names no tactile pads. `gripper_list_grippers` now reports each gripper's tactile source (or `null`).
2. **`tactile_service.py`** — a `TactileService` next to `GripperService` rather than inside it: tactile is optional per gripper and owns its own state, the rest baseline. The baseline is taken on demand from an open gripper, retaken by `gripper_tare_tactile`, and refused with a pointer to the tare when the fingers are not open. A tare averages `baseline_samples` *distinct* frames: the tactile protocol gained `sample(count)` (first commit), so a source that caches its latest message cannot hand back the same frame a thousand times. The tare also measures its own noise: the threshold in force is `max(contact_threshold, noise_margin x the peak rest signal the tare saw)`, reported by the tare and echoed on every reading, so real pads whose noise sits above the twin-tuned floor (Eric measured 0.035 against a 0.02 floor) still get a threshold above their own noise. `verify_grasp` reads the gripper state once and derives both the opening it reports and the fingers-met test from that single reading, so the verdict and the opening describe the same instant. `judge_grasp`: contact with the fingers apart is `held`; fingers that met are `closed_on_nothing` whatever the pads say (TSF-85 pads touch each other when fully closed); fingers apart with quiet pads is `no_contact`, the slipped-or-stopped-outside-the-pads case.
3. **Three tools** — `gripper_read_tactile` (signal, per-pad split as each pad's fraction of its own ceiling, hottest taxel, contact flag), `gripper_tare_tactile` (samples, rest mean, `noise_floor`, `threshold`), `gripper_verify_grasp`. Tool registration is now two helpers (`register_gripper_tools` / `register_tactile_tools`) and `build_service` became `build_services(wiring, make_backend=..., make_tactile=...)`, returning both. The tactile factory is a parameter like the backend's: the default refuses a `tactile` entry by name until the ROS source lands, the tests hand in the fake pads.
The split into two services is also what keeps `GripperService` inside the coupling budget of the maintainability gate this repo's `mcp/` code is held to; the first cut, with tactile folded in, tripped it.

## Verification

- `uv run pytest`: 182 passed (34 new): `sample(count)` on the mock; `rest_noise`; `noise_margin` validation; quiet pads keep the datasheet floor; pads scripted at Eric's bench numbers raise the threshold to ~0.07, an empty open gripper at 0.035 is `no_contact`, an external hold at 0.8 is `held`; a verification reads the gripper state once; the 2F-85 names the TSF-85 sheet / 2F-140 names none / every shipped tactile sheet is named by a gripper / a tactile block inlined in a gripper sheet is rejected / a missing tactile sheet is named / `tactile: mock` is not a wiring option; tare, read at rest, grasp-on-cube presses both pads, verify → `held` / `no_contact` / `closed_on_nothing`, stall-outside-the-pads is not a hold, first read self-baselines from an open gripper, closed-with-no-baseline asks for a tare, gripper without pads refuses, unknown gripper still `UnknownGripperError`, `judge_grasp` table; wire-level grasp→verify says `held`, tactile on a 2F-140 fails at startup, the default factory names the missing ROS tactile source, annotations.
- `pre-commit run --all-files`: green.

## Follow-up
#77: measure the constants on real TSF pads (assigned to me; none on hand today).

## Stack
#62 is merged; this PR shows its own 3 commits.




