### PR TITLE
feat(mcp): ros tactile source on robotiq_tsf

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -49,9 +49,11 @@ hold. `gripper_verify_grasp` gives one of:
 | `closed_on_nothing` | Fingers fully closed |
 | `no_contact` | Fingers apart, pads quiet: the object slipped, or the stop was outside the pads |
 
-The ROS source on `robotiq_tsf`'s `TactileSensor/StaticData` topic is next;
-until it lands, `build_services` refuses a `tactile` entry by name. The tests
-drive the tools from a scripted pad model under `tests/fakes/`.
+The tactile source subscribes to `robotiq_tsf`'s `TactileSensor/StaticData`
+under the gripper's `namespace` (the tactile driver runs in the same namespace
+as the gripper's controller); it needs `robotiq_tsf` built
+and sourced alongside `rclpy`. The tests drive the tools from a scripted pad
+model under `tests/fakes/`.
 
 ## Quick start
 

--- a/mcp/gripper_mcp/config.py
+++ b/mcp/gripper_mcp/config.py
@@ -48,6 +48,7 @@ class GripperConfig(StrictModel):
     namespace: str
     description: str = ""
     tactile: Literal["ros"] | None = None
+    tactile_namespace: str | None = None
 
     @model_validator(mode="after")
     def _needs_a_namespace(self) -> "GripperConfig":

--- a/mcp/gripper_mcp/ros_tactile_backend.py
+++ b/mcp/gripper_mcp/ros_tactile_backend.py
@@ -1,0 +1,82 @@
+"""Tactile readings from a TSF-85 through this repo's robotiq_tsf driver.
+
+One node per gripper, in the namespace the wiring gives the pads (the gripper's
+own unless `tactile_namespace` says otherwise), so `TactileSensor/StaticData`
+and `TactileSensor/Dynamic` resolve to the pads on that gripper. It shares the
+executor thread with the gripper backends (RosGraph).
+
+The driver publishes with the sensor-data QoS (best effort), so the
+subscriptions must too: a reliable subscriber never matches a best-effort
+publisher and simply receives nothing, with no error anywhere.
+
+Reads return the latest message received and never block on the topic rate:
+the sensor publishes at about 2 kHz, and a contact loop reads far more often
+than it moves. Because of that, a read remembers when the last frame arrived
+and refuses to answer from a frame older than `STALE_FRAME_S`; otherwise a
+driver that stopped publishing would keep reporting its last frame forever,
+and a frozen "no contact" reads as "keep closing" to a tactile-guided close.
+"""
+
+import time
+
+from rclpy.node import Node
+from rclpy.qos import qos_profile_sensor_data
+from robotiq_tsf.msg import Dynamic, StaticData
+
+from gripper_mcp.ros_backend import RosGraph, poll_until
+from gripper_mcp.ros_tactile_messages import (
+    DYNAMIC_TOPIC,
+    STATIC_TOPIC,
+    reading_from_counts,
+    stale_frame_message,
+)
+from gripper_mcp.tactile_backend import TactileLayout, TactileReading
+
+STATIC_WAIT_S = 2.0
+STALE_FRAME_S = 2.0
+
+
+class RosTactileBackend:
+    name = "ros"
+
+    def __init__(
+        self, gripper_name: str, namespace: str, layout: TactileLayout
+    ) -> None:
+        self._layout = layout
+        executor = RosGraph.executor()
+        self._node = Node(
+            f"gripper_mcp_tactile_{gripper_name}", namespace=namespace or "/"
+        )
+        self._static: StaticData | None = None
+        self._dynamic: Dynamic | None = None
+        self._latest_at = 0.0
+        self._node.create_subscription(
+            StaticData, STATIC_TOPIC, self._on_static, qos_profile_sensor_data
+        )
+        self._node.create_subscription(
+            Dynamic, DYNAMIC_TOPIC, self._on_dynamic, qos_profile_sensor_data
+        )
+        executor.add_node(self._node)
+
+    def read_tactile(self) -> TactileReading:
+        static = poll_until(lambda: self._static, STATIC_WAIT_S)
+        dynamic = self._dynamic
+        if static is None:
+            raise RuntimeError(
+                f"No {STATIC_TOPIC} under '{self._node.get_namespace()}' within "
+                f"{STATIC_WAIT_S:.0f} s; is the robotiq_tsf driver running?"
+            )
+        age_s = time.monotonic() - self._latest_at
+        if age_s > STALE_FRAME_S:
+            raise RuntimeError(stale_frame_message(age_s, STALE_FRAME_S))
+        dynamics = [] if dynamic is None else [d.value for d in dynamic.data]
+        return reading_from_counts(
+            [list(pad.values) for pad in static.taxels], dynamics, self._layout
+        )
+
+    def _on_static(self, message: StaticData) -> None:
+        self._static = message
+        self._latest_at = time.monotonic()
+
+    def _on_dynamic(self, message: Dynamic) -> None:
+        self._dynamic = message

--- a/mcp/gripper_mcp/ros_tactile_backend.py
+++ b/mcp/gripper_mcp/ros_tactile_backend.py
@@ -2,11 +2,11 @@
 
 One node per gripper, in the namespace the wiring gives the pads (the gripper's
 own unless `tactile_namespace` says otherwise), so `TactileSensor/StaticData`
-and `TactileSensor/Dynamic` resolve to the pads on that gripper. It shares the
-executor thread with the gripper backends (RosGraph).
+resolves to the pads on that gripper. It shares the executor thread with the
+gripper backends (RosGraph).
 
 The driver publishes with the sensor-data QoS (best effort), so the
-subscriptions must too: a reliable subscriber never matches a best-effort
+subscription must too: a reliable subscriber never matches a best-effort
 publisher and simply receives nothing, with no error anywhere.
 
 Reads return the latest message received and never block on the topic rate:
@@ -15,20 +15,28 @@ than it moves. Because of that, a read remembers when the last frame arrived
 and refuses to answer from a frame older than `STALE_FRAME_S`; otherwise a
 driver that stopped publishing would keep reporting its last frame forever,
 and a frozen "no contact" reads as "keep closing" to a tactile-guided close.
+
+`sample` is the exception: it asks the subscription callback to keep the next
+`count` messages and sleeps until the callback signals the buffer is full, so
+each frame is a distinct sensor update and the two threads hand off once per
+sample rather than once per frame (a per-frame handoff under the GIL was
+measured at under 100 frames/s against a 2 kHz publisher). It gives up with a
+stalled-sample error if no frame arrives for `STALE_FRAME_S` mid-sample.
 """
 
+import threading
 import time
 
 from rclpy.node import Node
 from rclpy.qos import qos_profile_sensor_data
-from robotiq_tsf.msg import Dynamic, StaticData
+from robotiq_tsf.msg import StaticData
 
 from gripper_mcp.ros_backend import RosGraph, poll_until
 from gripper_mcp.ros_tactile_messages import (
-    DYNAMIC_TOPIC,
     STATIC_TOPIC,
     reading_from_counts,
     stale_frame_message,
+    stalled_sample_message,
 )
 from gripper_mcp.tactile_backend import TactileLayout, TactileReading
 
@@ -48,19 +56,17 @@ class RosTactileBackend:
             f"gripper_mcp_tactile_{gripper_name}", namespace=namespace or "/"
         )
         self._static: StaticData | None = None
-        self._dynamic: Dynamic | None = None
         self._latest_at = 0.0
+        self._wanted = 0
+        self._collected: list[StaticData] = []
+        self._sample_done = threading.Event()
         self._node.create_subscription(
             StaticData, STATIC_TOPIC, self._on_static, qos_profile_sensor_data
-        )
-        self._node.create_subscription(
-            Dynamic, DYNAMIC_TOPIC, self._on_dynamic, qos_profile_sensor_data
         )
         executor.add_node(self._node)
 
     def read_tactile(self) -> TactileReading:
         static = poll_until(lambda: self._static, STATIC_WAIT_S)
-        dynamic = self._dynamic
         if static is None:
             raise RuntimeError(
                 f"No {STATIC_TOPIC} under '{self._node.get_namespace()}' within "
@@ -69,14 +75,31 @@ class RosTactileBackend:
         age_s = time.monotonic() - self._latest_at
         if age_s > STALE_FRAME_S:
             raise RuntimeError(stale_frame_message(age_s, STALE_FRAME_S))
-        dynamics = [] if dynamic is None else [d.value for d in dynamic.data]
+        return self._reading(static)
+
+    def sample(self, count: int) -> list[TactileReading]:
+        self._wanted = 0
+        self._collected = []
+        self._sample_done.clear()
+        self._wanted = count
+        seen = 0
+        while not self._sample_done.wait(STALE_FRAME_S):
+            if len(self._collected) == seen:
+                self._wanted = 0
+                raise RuntimeError(stalled_sample_message(seen, count, STALE_FRAME_S))
+            seen = len(self._collected)
+        self._wanted = 0
+        return [self._reading(message) for message in self._collected]
+
+    def _reading(self, static: StaticData) -> TactileReading:
         return reading_from_counts(
-            [list(pad.values) for pad in static.taxels], dynamics, self._layout
+            [list(pad.values) for pad in static.taxels], self._layout
         )
 
     def _on_static(self, message: StaticData) -> None:
         self._static = message
         self._latest_at = time.monotonic()
-
-    def _on_dynamic(self, message: Dynamic) -> None:
-        self._dynamic = message
+        if len(self._collected) < self._wanted:
+            self._collected.append(message)
+            if len(self._collected) == self._wanted:
+                self._sample_done.set()

--- a/mcp/gripper_mcp/ros_tactile_messages.py
+++ b/mcp/gripper_mcp/ros_tactile_messages.py
@@ -44,3 +44,10 @@ def stale_frame_message(age_s: float, limit_s: float) -> str:
         f"The last {STATIC_TOPIC} frame is {age_s:.1f} s old (limit {limit_s:.0f} s); "
         "the robotiq_tsf driver has stopped publishing."
     )
+
+
+def stalled_sample_message(collected: int, wanted: int, limit_s: float) -> str:
+    return (
+        f"No new {STATIC_TOPIC} frame for {limit_s:.0f} s after {collected} of "
+        f"{wanted} samples; the robotiq_tsf driver has stopped publishing."
+    )

--- a/mcp/gripper_mcp/ros_tactile_messages.py
+++ b/mcp/gripper_mcp/ros_tactile_messages.py
@@ -1,0 +1,46 @@
+"""Shaping robotiq_tsf messages into a TactileReading, with no ROS imports.
+
+`TactileSensor/StaticData` carries `Taxels[2] taxels`, each `uint16[28] values`:
+the two 7x4 pads as raw counts. Counts stay raw, exactly as the driver reports
+them; the baseline arithmetic lives in tactile.py and nowhere else.
+"""
+
+from gripper_mcp.tactile_backend import TactileLayout, TactilePad, TactileReading
+
+STATIC_TOPIC = "TactileSensor/StaticData"
+
+
+class TactileMessageMismatch(Exception):
+    pass
+
+
+def reading_from_counts(
+    pads_counts: list[list[int]], layout: TactileLayout
+) -> TactileReading:
+    if len(pads_counts) != len(layout.pad_names):
+        raise TactileMessageMismatch(
+            f"{STATIC_TOPIC} carried {len(pads_counts)} pad(s), expected "
+            f"{len(layout.pad_names)}. Wrong topic, or a message type mismatch."
+        )
+    for index, counts in enumerate(pads_counts):
+        if len(counts) != layout.taxels_per_pad:
+            raise TactileMessageMismatch(
+                f"{STATIC_TOPIC} pad {index} carried {len(counts)} taxel(s), expected "
+                f"{layout.taxels_per_pad} ({layout.rows}x{layout.cols}). The driver "
+                "and the datasheet disagree on the sensor grid."
+            )
+
+    return TactileReading(
+        pads=tuple(
+            TactilePad(name=name, taxels=tuple(int(c) for c in counts))
+            for name, counts in zip(layout.pad_names, pads_counts)
+        ),
+        layout=layout,
+    )
+
+
+def stale_frame_message(age_s: float, limit_s: float) -> str:
+    return (
+        f"The last {STATIC_TOPIC} frame is {age_s:.1f} s old (limit {limit_s:.0f} s); "
+        "the robotiq_tsf driver has stopped publishing."
+    )

--- a/mcp/gripper_mcp/server.py
+++ b/mcp/gripper_mcp/server.py
@@ -97,13 +97,11 @@ def build_backend(config: GripperConfig, spec: GripperModelSpec) -> GripperBacke
     return RosGripperBackend(config.name, config.namespace)
 
 
-TactileFactory = Callable[
-    [GripperConfig, GripperModelSpec, GripperBackend], TactileBackend | None
-]
+TactileFactory = Callable[[GripperConfig, GripperModelSpec], TactileBackend | None]
 
 
 def build_tactile(
-    config: GripperConfig, spec: GripperModelSpec, gripper: GripperBackend
+    config: GripperConfig, spec: GripperModelSpec
 ) -> TactileBackend | None:
     if config.tactile is None:
         return None
@@ -112,9 +110,21 @@ def build_tactile(
             f"Gripper '{config.name}' asks for tactile pads, but model "
             f"'{config.model}' names no tactile_model in its datasheet."
         )
-    raise NotImplementedError(
-        f"Gripper '{config.name}' asks for the ROS tactile source, which is not in "
-        "this build."
+    return build_ros_tactile(config, spec)
+
+
+def build_ros_tactile(config: GripperConfig, spec: GripperModelSpec) -> TactileBackend:
+    try:
+        from gripper_mcp.ros_tactile_backend import RosTactileBackend
+    except ImportError as error:
+        raise RuntimeError(
+            f"Gripper '{config.name}' uses the ros tactile source, which needs a "
+            f"sourced ROS 2 install with rclpy and robotiq_tsf: {error}"
+        ) from error
+    return RosTactileBackend(
+        config.name,
+        config.tactile_namespace or config.namespace,
+        spec.tactile.layout,
     )
 
 
@@ -131,7 +141,7 @@ def build_services(
     }
     tactile_backends = {}
     for name, cfg in configs.items():
-        tactile = make_tactile(cfg, specs[cfg.model], backends[name])
+        tactile = make_tactile(cfg, specs[cfg.model])
         if tactile is not None:
             tactile_backends[name] = tactile
 

--- a/mcp/grippers.yaml.example
+++ b/mcp/grippers.yaml.example
@@ -2,16 +2,19 @@
 # lives. Copy to grippers.yaml and edit. Every entry needs a name (what agents
 # pass as gripper_name), a model (a file in datasheets/) and the namespace its
 # robotiq_gripper_controller runs under. Without hardware, launch the driver on
-# ros2_control's fake hardware (use_fake_hardware) and point an entry at it the
-# same way.
+# ros2_control's fake hardware (use_fake_hardware:=true) and point an entry at
+# it the same way.
 #
-# tactile: ros   optional; TSF-85 pads read from robotiq_tsf under the same
-#                namespace. Only for models whose datasheet names a tactile_model.
+# tactile: ros   optional; TSF-85 pads read from robotiq_tsf's TactileSensor/*
+#                topics. Only for models whose datasheet names a tactile_model.
+# tactile_namespace: /left_tsf   optional; where the robotiq_tsf driver runs
+#                when it is not under the gripper's own namespace.
 
 - name: left
   model: robotiq_2f_85
+  tactile: ros
   namespace: /left
-  description: Robotiq 2F-85 on the left arm
+  description: Robotiq 2F-85 with TSF-85 pads on the left arm
 
 - name: right
   model: robotiq_2f_140

--- a/mcp/tests/test_config.py
+++ b/mcp/tests/test_config.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 
 import gripper_mcp
 from gripper_mcp.config import (
+    GripperConfig,
     SPEC_DIR,
     load_gripper_configs,
     load_model_spec,
@@ -141,6 +142,7 @@ def test_the_example_wiring_loads_and_names_a_namespace_per_gripper():
 
     assert {config.model for config in configs} <= set(MODELS)
     assert all(config.namespace.startswith("/") for config in configs)
+    assert {config.tactile for config in configs} == {None, "ros"}
 
 
 def test_a_mock_tactile_source_is_not_a_wiring_option(tmp_path):
@@ -244,3 +246,17 @@ def test_a_tactile_datasheet_whose_margin_would_lower_the_noise_is_rejected(tmp_
 
     with pytest.raises(ValidationError, match="noise_margin"):
         load_tactile_spec(sheet)
+
+
+def test_the_pads_default_to_the_gripper_namespace_unless_told_otherwise():
+    same = GripperConfig(name="left", model="robotiq_2f_85", namespace="/left")
+    apart = GripperConfig(
+        name="left",
+        model="robotiq_2f_85",
+        namespace="/left",
+        tactile="ros",
+        tactile_namespace="/left_tsf",
+    )
+
+    assert same.tactile_namespace is None
+    assert apart.tactile_namespace == "/left_tsf"

--- a/mcp/tests/test_ros_tactile_messages.py
+++ b/mcp/tests/test_ros_tactile_messages.py
@@ -1,0 +1,38 @@
+import pytest
+
+from gripper_mcp.ros_tactile_messages import (
+    stale_frame_message,
+    TactileMessageMismatch,
+    reading_from_counts,
+)
+from gripper_mcp.tactile_backend import TactileLayout
+
+LAYOUT = TactileLayout(rows=7, cols=4, pad_names=("left", "right"))
+LEFT_COUNTS = [100] * LAYOUT.taxels_per_pad
+RIGHT_COUNTS = [200] * LAYOUT.taxels_per_pad
+
+
+def test_two_full_pads_become_two_named_pads():
+    reading = reading_from_counts([LEFT_COUNTS, RIGHT_COUNTS], LAYOUT)
+
+    assert [pad.name for pad in reading.pads] == ["left", "right"]
+    assert reading.pads[0].taxels == tuple(LEFT_COUNTS)
+    assert reading.pads[1].taxels == tuple(RIGHT_COUNTS)
+    assert reading.layout == LAYOUT
+
+
+def test_one_pad_is_a_pad_mismatch():
+    with pytest.raises(TactileMessageMismatch, match="1 pad"):
+        reading_from_counts([LEFT_COUNTS], LAYOUT)
+
+
+def test_a_short_taxel_array_names_the_grid():
+    with pytest.raises(TactileMessageMismatch, match="7x4"):
+        reading_from_counts([LEFT_COUNTS[:-1], RIGHT_COUNTS], LAYOUT)
+
+
+def test_a_stale_frame_message_names_the_age_and_the_driver():
+    message = stale_frame_message(3.24, 2.0)
+
+    assert "3.2 s old" in message
+    assert "stopped publishing" in message

--- a/mcp/tests/test_ros_tactile_messages.py
+++ b/mcp/tests/test_ros_tactile_messages.py
@@ -1,7 +1,9 @@
 import pytest
 
 from gripper_mcp.ros_tactile_messages import (
+    STATIC_TOPIC,
     stale_frame_message,
+    stalled_sample_message,
     TactileMessageMismatch,
     reading_from_counts,
 )
@@ -36,3 +38,10 @@ def test_a_stale_frame_message_names_the_age_and_the_driver():
 
     assert "3.2 s old" in message
     assert "stopped publishing" in message
+
+
+def test_a_stalled_sample_says_how_far_it_got():
+    message = stalled_sample_message(42, 1000, 2.0)
+
+    assert "42 of 1000" in message
+    assert STATIC_TOPIC in message

--- a/mcp/tests/test_server.py
+++ b/mcp/tests/test_server.py
@@ -50,7 +50,7 @@ def gripper_holding_a_cube(config, spec):
     )
 
 
-def pads_on_the_cube(config, spec, gripper):
+def pads_on_the_cube(gripper, spec):
     return MockTactileBackend(
         read_opening_mm=lambda: gripper.opening_mm_for(
             gripper.read_state().position_rad
@@ -62,11 +62,18 @@ def pads_on_the_cube(config, spec, gripper):
 
 @pytest.fixture
 def mcp(tmp_path):
+    grippers = {}
+
+    def make_backend(config, spec):
+        grippers[config.name] = gripper_holding_a_cube(config, spec)
+        return grippers[config.name]
+
+    def make_tactile(config, spec):
+        return pads_on_the_cube(grippers[config.name], spec)
+
     wiring = write_wiring(tmp_path)
     return build_mcp(
-        *build_services(
-            wiring, make_backend=gripper_holding_a_cube, make_tactile=pads_on_the_cube
-        )
+        *build_services(wiring, make_backend=make_backend, make_tactile=make_tactile)
     )
 
 
@@ -126,6 +133,13 @@ def test_a_close_then_verify_through_the_wire_confirms_the_hold(mcp):
 
     assert verification.verdict == "held"
     assert verification.tactile_backend == "mock"
+
+
+def test_a_ros_tactile_entry_names_the_missing_ros_install(tmp_path, monkeypatch):
+    monkeypatch.setitem(sys.modules, "rclpy", None)
+
+    with pytest.raises(RuntimeError, match="robotiq_tsf"):
+        build_services(write_wiring(tmp_path), make_backend=gripper_holding_a_cube)
 
 
 def test_tactile_on_a_model_without_pads_fails_at_startup(tmp_path):


### PR DESCRIPTION
## Change

Tenth PR of the `mcp/` series (stacked on #65). Tactile reaches the driver:

1. **`ros_tactile_backend.py`** — `RosTactileBackend` subscribes to `TactileSensor/StaticData` with the sensor-data QoS (the driver publishes best effort; a reliable subscriber never matches it and simply hears nothing), under the gripper's namespace or the wiring's `tactile_namespace` when the `robotiq_tsf` driver runs elsewhere, on the executor thread the gripper backends already share. A read returns the latest frame and never blocks on the topic rate (about 2 kHz on the bench), because a contact loop reads far more often than it moves; it refuses a frame older than `STALE_FRAME_S` so a driver that stopped publishing cannot keep answering. `sample(count)` is the exception: the callback buffers `count` consecutive frames and hands them over once, so a tare averages distinct frames and reports a true count (see the live block for what that costs). The `Dynamic` channel is not read: nothing in the series consumes it.
2. **`ros_tactile_messages.py`** — shapes `StaticData` into a `TactileReading` with no ROS imports, so the pad-count and grid mismatches it reports, and the stale-frame and stalled-sample messages, are unit-tested in CI. Counts stay raw; `tactile.py` remains the only place baseline arithmetic happens.
3. **`tactile: ros`** in `grippers.yaml` is now built by the default factory; the import is lazy so the unit tests run without ROS. The example wiring puts TSF-85 pads on the left 2F-85.

The tactile-guided closing loop (`gripper_grasp_until_contact`) is split out to its own PR, stacked on this one, until it has run on a real gripper with pads.

## Verification

- `uv run pytest`: 189 passed (7 new): message shaping (two named pads, one-pad / short-grid mismatches, stale-frame and stalled-sample messages); `tactile: ros` without rclpy names `robotiq_tsf`; `tactile_namespace` defaults to the gripper's namespace; the example wiring loads with one tactile entry.
- **Live, in `robotiq_ros2:jazzy`** (rerun after this round): driver on fake hardware + a dummy `robotiq_tsf` publisher (real `robotiq_tsf/msg/StaticData`, sensor-data QoS, ~1.7 kHz, rest 12540 ± 2 counts per taxel so the tare has real noise to average, pressure following the fake gripper's `joint_states` with a 46 mm virtual object), `RosGripperBackend` + `RosTactileBackend` through the real services. "Close on the object" is `move_to_opening(45.0)` because fake hardware cannot stall on the virtual object; a full `close_fully` reaches 0.0 and reads `closed_on_nothing` with the pads touching at ~0.999.

  ```
  list:         [{'gripper_name': 'left', 'model': 'robotiq_2f_85', 'backend': 'ros', 'max_opening_mm': 85.0, 'tactile': 'ros'}]
  open:         reached
  tare:         {'samples': 1000, 'rest_counts_mean': 12540.0, 'noise_floor': 0.00866, 'threshold': 0.02, 'tactile_backend': 'ros'} wall=8.81s
  read open:    {'contact': False, 'contact_signal': 0.00407, 'threshold': 0.02, 'pad_signals': {'left': 0.00363, 'right': 0.00452}, 'peak_taxel_counts': 2.1}
  close 45mm:   reached
  verify:       {'verdict': 'held', 'object_held': True, 'opening_mm': 45.0, 'contact_signal': 0.26449, 'threshold': 0.02}
  open:         reached
  verify open:  no_contact
  --- ros2 topic info -v /TactileSensor/StaticData
  Publisher    dummy_tsf                 Reliability: BEST_EFFORT
  Subscription gripper_mcp_tactile_left  Reliability: BEST_EFFORT
  --- stale check: dummy publisher stopped, 3 s later
  read:         RuntimeError: The last TactileSensor/StaticData frame is 3.0 s old (limit 2 s); the robotiq_tsf driver has stopped publishing.
  ```

  The tare's 1000 distinct frames took 8.8 s, not the 0.5 s the publish rate allows: rclpy's executor delivers about 110 `StaticData` callbacks per second here whatever the publisher does (measured the same with a per-frame wake-up and with the callback buffering the whole sample). Reported truthfully in `samples`; whether 1000 is the right count for a tool call is open.
- `pre-commit run --all-files`: green.

## Stack
Stacked on #65: this PR shows only its own 2 commits.





