### PR TITLE
refactor(robotiq_description): name the topic-based sim path after the plugin, plus build note

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,16 +257,16 @@ ros2 launch robotiq_description robotiq_control.launch.py                    # r
 ros2 launch robotiq_description robotiq_control.launch.py use_fake_hardware:=true   # ros2_control mock
 ros2 launch robotiq_description robotiq_control.launch.py launch_rviz:=true         # + RViz visualization
 ros2 launch robotiq_description robotiq_control.launch.py baudrate:=<rate>
-ros2 launch robotiq_description robotiq_control.launch.py sim_isaac:=true \
-  isaac_joint_commands:=/isaac_joint_commands isaac_joint_states:=/isaac_joint_states  # topic_based_ros2_control
+ros2 launch robotiq_description robotiq_control.launch.py sim_topic_based:=true \
+  joint_commands_topic:=/sim/joint_commands joint_states_topic:=/sim/joint_states  # topic_based_ros2_control
 ```
 
 This activates `joint_state_broadcaster`, `robotiq_gripper_controller`, and `robotiq_activation_controller`.
 
-`sim_isaac` swaps the hardware plugin for `topic_based_ros2_control/TopicBasedSystem` (any
-simulator that exchanges `sensor_msgs/JointState` on two topics — Isaac Sim is the usual one, hence
-the argument names). That plugin exports only the standard joint interfaces, so the launch loads
-`config/robotiq_controllers.sim.yaml` for it (per-goal `effort`/`velocity` are accepted and ignored;
+`sim_topic_based` swaps the hardware plugin for `topic_based_ros2_control/TopicBasedSystem`: any
+simulator that exchanges `sensor_msgs/JointState` on two topics (Isaac Sim, or a bridge of your
+own), named by `joint_commands_topic` / `joint_states_topic`. That plugin exports only the standard joint interfaces, so the launch loads
+`config/robotiq_controllers.topic_based.yaml` for it (per-goal `effort`/`velocity` are accepted and ignored;
 a stall aborts the goal rather than succeeding, since a simulator that publishes no joint velocities
 would otherwise report every failed grasp as success) and skips `robotiq_activation_controller`,
 whose `reactivate_gripper` GPIO only the driver and the mock declare. `TopicBasedSystem` matches

--- a/README.md
+++ b/README.md
@@ -278,8 +278,18 @@ six joint names for the model you launch, each with your `prefix`, or nothing mo
 | `2f_85` | `robotiq_85_left_knuckle_joint` | `robotiq_85_right_knuckle_joint`, `robotiq_85_left_inner_knuckle_joint`, `robotiq_85_right_inner_knuckle_joint`, `robotiq_85_left_finger_tip_joint`, `robotiq_85_right_finger_tip_joint` |
 | `2f_140` | `finger_joint` | `right_outer_knuckle_joint`, `left_inner_knuckle_joint`, `right_inner_knuckle_joint`, `left_inner_finger_joint`, `right_inner_finger_joint` |
 
-The plugin is not a dependency of this package — build
-[topic_based_ros2_control](https://github.com/PickNikRobotics/topic_based_ros2_control) yourself.
+The plugin is not a dependency of this package. On Humble install
+`ros-humble-topic-based-ros2-control`; on Jazzy and Lyrical it has no binary release, so build
+[topic_based_ros2_control](https://github.com/PickNikRobotics/topic_based_ros2_control) in an
+overlay once:
+
+```bash
+git clone https://github.com/PickNikRobotics/topic_based_ros2_control <ws>/src/topic_based_ros2_control
+colcon build --cmake-args -DBUILD_TESTING=OFF
+```
+
+(`-DBUILD_TESTING=OFF` skips its `ros_testing` test dependency, which a runtime install does not
+have.)
 The `ros2_control` xacros also carry a `sim_gazebo` parameter (`gz_ros2_control/GazeboSimSystem`)
 for cells that embed the gripper macro in their own Gazebo description; this launch does not wire
 it, since Gazebo hosts its own `controller_manager`.

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ All four read `NaN` until the component is activated; activation seeds them from
 
 `motor_current` is motor current, **not** grip force, and it is not convertible to one.
 
-`motor_current` and `object_status` are not `ros2_control` standard interface names (there are `HW_IF_` constants for position, velocity and effort, and nothing for either of these), so consumers spell them out. The descriptions declare them on the real-hardware branch only — `mock_components/GenericSystem`, Gazebo and Isaac never write them — so under `use_fake_hardware:=true` both are absent rather than wrong.
+`motor_current` and `object_status` are not `ros2_control` standard interface names (there are `HW_IF_` constants for position, velocity and effort, and nothing for either of these), so consumers spell them out. The descriptions declare them on the real-hardware branch only — `mock_components/GenericSystem`, Gazebo and the topic-based plugin never write them — so under `use_fake_hardware:=true` both are absent rather than wrong.
 
 ### Hardware parameters
 
@@ -383,7 +383,7 @@ Drag the `robotiq_85_left_knuckle_joint` slider; the five finger joints follow i
 
 Goal-based commanding also works without hardware: `robotiq_control.launch.py use_fake_hardware:=true launch_rviz:=true` brings up all three controllers against `mock_components/GenericSystem`, and `gripper_cmd` goals drive the model — the five finger joints follow the knuckle via URDF `mimic`, exactly as on hardware. Use the slider above when you want to pose the model by hand instead.
 
-Mock and hardware publish the same `/joint_states` contract on every distro: the knuckle joint alone, with `robot_state_publisher` deriving the mimicked finger joints from the URDF. Only the Gazebo and Isaac paths declare the mimicked joints to `ros2_control`, since those simulators supply their own joint state.
+Mock and hardware publish the same `/joint_states` contract on every distro: the knuckle joint alone, with `robot_state_publisher` deriving the mimicked finger joints from the URDF. Only the Gazebo and topic-based paths (`sim_gazebo`, `sim_topic_based`) declare the mimicked joints to `ros2_control`, since those simulators supply their own joint state.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -273,7 +273,14 @@ whose `reactivate_gripper` GPIO only the driver and the mock declare. Renamed in
 `sim_isaac`, `isaac_joint_commands` and `isaac_joint_states` (launch arguments and macro parameters,
 shipped in 1.1.0) still work and log a deprecation warning, `sim_isaac:=true` keeping its old
 `/isaac_joint_commands` / `/isaac_joint_states` topic defaults; they are removed in the next major
-release. `TopicBasedSystem` matches
+release. To stay on those topic names without the deprecated arguments:
+
+```bash
+ros2 launch robotiq_description robotiq_control.launch.py sim_topic_based:=true \
+  sim_joint_commands_topic:=/isaac_joint_commands sim_joint_states_topic:=/isaac_joint_states
+```
+
+`TopicBasedSystem` matches
 joints to the simulator's `JointState` **by name**, so the simulator must publish this description's
 six joint names for the model you launch, each with your `prefix`, or nothing moves:
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,8 @@ overlay once:
 
 ```bash
 git clone https://github.com/PickNikRobotics/topic_based_ros2_control <ws>/src/topic_based_ros2_control
-colcon build --cmake-args -DBUILD_TESTING=OFF
+cd <ws>
+colcon build --packages-select topic_based_ros2_control --cmake-args -DBUILD_TESTING=OFF
 ```
 
 (`-DBUILD_TESTING=OFF` skips its `ros_testing` test dependency, which a runtime install does not

--- a/README.md
+++ b/README.md
@@ -258,14 +258,14 @@ ros2 launch robotiq_description robotiq_control.launch.py use_fake_hardware:=tru
 ros2 launch robotiq_description robotiq_control.launch.py launch_rviz:=true         # + RViz visualization
 ros2 launch robotiq_description robotiq_control.launch.py baudrate:=<rate>
 ros2 launch robotiq_description robotiq_control.launch.py sim_topic_based:=true \
-  joint_commands_topic:=/sim/joint_commands joint_states_topic:=/sim/joint_states  # topic_based_ros2_control
+  sim_joint_commands_topic:=/sim/joint_commands sim_joint_states_topic:=/sim/joint_states  # topic_based_ros2_control
 ```
 
 This activates `joint_state_broadcaster`, `robotiq_gripper_controller`, and `robotiq_activation_controller`.
 
 `sim_topic_based` swaps the hardware plugin for `topic_based_ros2_control/TopicBasedSystem`: any
 simulator that exchanges `sensor_msgs/JointState` on two topics (Isaac Sim, or a bridge of your
-own), named by `joint_commands_topic` / `joint_states_topic`. That plugin exports only the standard joint interfaces, so the launch loads
+own), named by `sim_joint_commands_topic` / `sim_joint_states_topic`. That plugin exports only the standard joint interfaces, so the launch loads
 `config/robotiq_controllers.topic_based.yaml` for it (per-goal `effort`/`velocity` are accepted and ignored;
 a stall aborts the goal rather than succeeding, since a simulator that publishes no joint velocities
 would otherwise report every failed grasp as success) and skips `robotiq_activation_controller`,

--- a/README.md
+++ b/README.md
@@ -269,7 +269,11 @@ own), named by `sim_joint_commands_topic` / `sim_joint_states_topic`. That plugi
 `config/robotiq_controllers.topic_based.yaml` for it (per-goal `effort`/`velocity` are accepted and ignored;
 a stall aborts the goal rather than succeeding, since a simulator that publishes no joint velocities
 would otherwise report every failed grasp as success) and skips `robotiq_activation_controller`,
-whose `reactivate_gripper` GPIO only the driver and the mock declare. `TopicBasedSystem` matches
+whose `reactivate_gripper` GPIO only the driver and the mock declare. Renamed in 1.2.0: PickNik's
+`sim_isaac`, `isaac_joint_commands` and `isaac_joint_states` (launch arguments and macro parameters,
+shipped in 1.1.0) still work and log a deprecation warning, `sim_isaac:=true` keeping its old
+`/isaac_joint_commands` / `/isaac_joint_states` topic defaults; they are removed in the next major
+release. `TopicBasedSystem` matches
 joints to the simulator's `JointState` **by name**, so the simulator must publish this description's
 six joint names for the model you launch, each with your `prefix`, or nothing moves:
 

--- a/grippers/robotiq_description/config/robotiq_controllers.topic_based.humble.yaml
+++ b/grippers/robotiq_description/config/robotiq_controllers.topic_based.humble.yaml
@@ -1,8 +1,9 @@
-# Humble controller configuration for the simulated hardware plugin
-# (`sim_isaac:=true`). Same controller as
+# Humble controller configuration for the topic_based_ros2_control plugin
+# (`sim_topic_based:=true`; not the `use_fake_hardware` mock, which keeps
+# robotiq_controllers.humble.yaml). Same controller as
 # robotiq_controllers.humble.yaml — Humble's stock
 # position_controllers/GripperActionController, since parallel_gripper_controller
-# only arrived in Jazzy — with the two departures robotiq_controllers.sim.yaml
+# only arrived in Jazzy — with the two departures robotiq_controllers.topic_based.yaml
 # explains: no activation controller (no reactivate GPIO to claim) and a stall
 # that aborts rather than succeeds (a simulator without joint velocities would
 # otherwise pass every failed grasp).

--- a/grippers/robotiq_description/config/robotiq_controllers.topic_based.humble.yaml
+++ b/grippers/robotiq_description/config/robotiq_controllers.topic_based.humble.yaml
@@ -1,7 +1,8 @@
 # Humble controller configuration for the topic_based_ros2_control plugin
-# (`sim_topic_based:=true`; not the `use_fake_hardware` mock, which keeps
-# robotiq_controllers.humble.yaml). Same controller as
-# robotiq_controllers.humble.yaml — Humble's stock
+# (`sim_topic_based:=true`).
+# Not for the `use_fake_hardware` mock, which teleports to the commanded
+# position and keeps robotiq_controllers.humble.yaml. Same controller as
+# that file — Humble's stock
 # position_controllers/GripperActionController, since parallel_gripper_controller
 # only arrived in Jazzy — with the two departures robotiq_controllers.topic_based.yaml
 # explains: no activation controller (no reactivate GPIO to claim) and a stall

--- a/grippers/robotiq_description/config/robotiq_controllers.topic_based.yaml
+++ b/grippers/robotiq_description/config/robotiq_controllers.topic_based.yaml
@@ -1,15 +1,23 @@
-# Controller configuration for the simulated hardware plugin the description
-# can select: `sim_isaac:=true` (topic_based_ros2_control/TopicBasedSystem).
-# Selected by launch/robotiq_control.launch.py whenever that argument is set; see
-# config/robotiq_controllers.yaml for the hardware and mock config it replaces,
-# and robotiq_controllers.sim.humble.yaml for the Humble variant.
+# Controller configuration for the topic_based_ros2_control/TopicBasedSystem
+# hardware plugin the description selects with `sim_topic_based:=true`: any
+# simulator that exchanges JointState messages on two topics. Selected by
+# launch/robotiq_control.launch.py whenever that argument is set; see
+# config/robotiq_controllers.yaml for the config it replaces, and
+# robotiq_controllers.topic_based.humble.yaml for the Humble variant.
 #
-# It differs from robotiq_controllers.yaml only where the simulated plugin
+# This is NOT the config for `use_fake_hardware:=true`. The ros2_control mock
+# (GenericSystem) declares the driver's interfaces and teleports: the position
+# command is copied into the state each cycle, so a goal succeeds on the next
+# update and stall detection never runs. It keeps robotiq_controllers.yaml.
+# Under sim_topic_based the simulator integrates the joint with its own drives, the
+# finger moves over time, and the stall parameters below read a real velocity.
+#
+# It differs from robotiq_controllers.yaml only where the topic_based plugin
 # exports something different from the driver, so the controller can activate:
 #
 # - No `robotiq_activation_controller`. The `reactivate_gripper` GPIO it claims is
-#   declared for the driver and the mock only (2f_85.ros2_control.xacro); under a
-#   simulated plugin there is nothing to reactivate.
+#   declared for the driver and the mock only (2f_85.ros2_control.xacro); under
+#   the topic_based plugin there is nothing to reactivate.
 # - No `max_effort_interface` / `max_velocity_interface`. The plugin exposes the
 #   standard position/velocity/effort interfaces only, never the driver's
 #   `set_gripper_max_*`, and a claimed interface that does not exist stops the
@@ -18,9 +26,7 @@
 #   joint velocities leaves the velocity state at 0, which reads as "stalled"
 #   from the first cycle, so allow_stalling would report every out-of-tolerance
 #   goal as succeeded. The client decides whether an aborted, stalled goal means
-#   an object was gripped. The stall window itself is wider than the driver's:
-#   a goal needs longer than 0.05 s to show up as motion over a topic, and
-#   simulated joint velocities carry more noise than the driver's.
+#   an object was gripped. See robotiq/ros#63 for the stall window itself.
 controller_manager:
   ros__parameters:
     update_rate: 500  # Hz

--- a/grippers/robotiq_description/config/robotiq_controllers.topic_based.yaml
+++ b/grippers/robotiq_description/config/robotiq_controllers.topic_based.yaml
@@ -10,7 +10,8 @@
 # command is copied into the state each cycle, so a goal succeeds on the next
 # update and stall detection never runs. It keeps robotiq_controllers.yaml.
 # Under sim_topic_based, position and velocity are published by the simulator, so
-# a realistic movement is possible, with finger moving over time and a real velocity.
+# a realistic movement is possible, with finger moving over time and a real velocity,
+# provided the simulator populates JointState.velocity (see the stall bullet below).
 #
 # It differs from robotiq_controllers.yaml only where the topic_based plugin
 # exports something different from the driver, so the controller can activate:

--- a/grippers/robotiq_description/config/robotiq_controllers.topic_based.yaml
+++ b/grippers/robotiq_description/config/robotiq_controllers.topic_based.yaml
@@ -9,8 +9,8 @@
 # (GenericSystem) declares the driver's interfaces and teleports: the position
 # command is copied into the state each cycle, so a goal succeeds on the next
 # update and stall detection never runs. It keeps robotiq_controllers.yaml.
-# Under sim_topic_based the simulator integrates the joint with its own drives, the
-# finger moves over time, and the stall parameters below read a real velocity.
+# Under sim_topic_based, position and velocity are published by the simulator, so
+# a realistic movement is possible, with finger moving over time and a real velocity.
 #
 # It differs from robotiq_controllers.yaml only where the topic_based plugin
 # exports something different from the driver, so the controller can activate:

--- a/grippers/robotiq_description/launch/robotiq_control.launch.py
+++ b/grippers/robotiq_description/launch/robotiq_control.launch.py
@@ -45,39 +45,43 @@ from launch_ros.parameter_descriptions import ParameterFile
 import os
 
 # Humble has no parallel_gripper_controller package, so it needs its own
-# controller config, and the simulated plugin (sim_isaac) exports a different
+# controller config, and the topic_based plugin exports a different
 # interface set from the driver and the mock, so it needs its own too.
 # See config/robotiq_controllers*.yaml.
 JAZZY_CONTROLLERS_FILE = "robotiq_controllers.yaml"
 HUMBLE_CONTROLLERS_FILE = "robotiq_controllers.humble.yaml"
-JAZZY_SIM_CONTROLLERS_FILE = "robotiq_controllers.sim.yaml"
-HUMBLE_SIM_CONTROLLERS_FILE = "robotiq_controllers.sim.humble.yaml"
+JAZZY_TOPIC_BASED_CONTROLLERS_FILE = "robotiq_controllers.topic_based.yaml"
+HUMBLE_TOPIC_BASED_CONTROLLERS_FILE = "robotiq_controllers.topic_based.humble.yaml"
 
 
-def controllers_file_for_distro(distro, simulated=False):
+def controllers_file_for_distro(distro, topic_based=False):
     """Return the controller config file name for ROS distro `distro`.
 
-    `simulated` selects the config for the sim_isaac hardware plugin.
+    `topic_based` selects the config for the sim_topic_based hardware plugin.
     """
     if distro == "humble":
-        return HUMBLE_SIM_CONTROLLERS_FILE if simulated else HUMBLE_CONTROLLERS_FILE
-    return JAZZY_SIM_CONTROLLERS_FILE if simulated else JAZZY_CONTROLLERS_FILE
+        return (
+            HUMBLE_TOPIC_BASED_CONTROLLERS_FILE
+            if topic_based
+            else HUMBLE_CONTROLLERS_FILE
+        )
+    return JAZZY_TOPIC_BASED_CONTROLLERS_FILE if topic_based else JAZZY_CONTROLLERS_FILE
 
 
 class ControllersFile(Substitution):
-    def __init__(self, distro, simulated):
+    def __init__(self, distro, topic_based):
         super().__init__()
         self.distro = distro
-        self.simulated = simulated
+        self.topic_based = topic_based
 
     def perform(self, context):
-        simulated = evaluate_condition_expression(context, [self.simulated])
-        return controllers_file_for_distro(self.distro, simulated)
+        topic_based = evaluate_condition_expression(context, [self.topic_based])
+        return controllers_file_for_distro(self.distro, topic_based)
 
 
 # The xacro emits one <plugin> per flag that is set, and ros2_control_node
 # accepts only one, so two flags would fail late and obscurely.
-HARDWARE_FLAGS = ("use_fake_hardware", "sim_isaac")
+HARDWARE_FLAGS = ("use_fake_hardware", "sim_topic_based")
 
 
 def reject_conflicting_hardware_flags(context):
@@ -138,14 +142,14 @@ def xacro_command():
             "baudrate:=",
             LaunchConfiguration("baudrate"),
             " ",
-            "sim_isaac:=",
-            LaunchConfiguration("sim_isaac"),
+            "sim_topic_based:=",
+            LaunchConfiguration("sim_topic_based"),
             " ",
-            "isaac_joint_commands:=",
-            LaunchConfiguration("isaac_joint_commands"),
+            "joint_commands_topic:=",
+            LaunchConfiguration("joint_commands_topic"),
             " ",
-            "isaac_joint_states:=",
-            LaunchConfiguration("isaac_joint_states"),
+            "joint_states_topic:=",
+            LaunchConfiguration("joint_states_topic"),
         ]
     )
 
@@ -219,27 +223,27 @@ def generate_launch_description():
     )
     args.append(
         launch.actions.DeclareLaunchArgument(
-            name="sim_isaac",
+            name="sim_topic_based",
             default_value="false",
             description="Drive a simulator over topic_based_ros2_control instead of a real gripper",
         )
     )
     args.append(
         launch.actions.DeclareLaunchArgument(
-            name="isaac_joint_commands",
-            default_value="/isaac_joint_commands",
-            description="sim_isaac only: JointState topic the simulator takes commands on",
+            name="joint_commands_topic",
+            default_value="/sim/joint_commands",
+            description="sim_topic_based only: JointState topic the simulator takes commands on",
         )
     )
     args.append(
         launch.actions.DeclareLaunchArgument(
-            name="isaac_joint_states",
-            default_value="/isaac_joint_states",
-            description="sim_isaac only: JointState topic the simulator publishes",
+            name="joint_states_topic",
+            default_value="/sim/joint_states",
+            description="sim_topic_based only: JointState topic the simulator publishes",
         )
     )
 
-    simulated = LaunchConfiguration("sim_isaac")
+    topic_based = LaunchConfiguration("sim_topic_based")
 
     robot_description_param = {
         "robot_description": launch_ros.parameter_descriptions.ParameterValue(
@@ -247,7 +251,7 @@ def generate_launch_description():
         )
     }
 
-    controllers_file = ControllersFile(os.environ.get("ROS_DISTRO"), simulated)
+    controllers_file = ControllersFile(os.environ.get("ROS_DISTRO"), topic_based)
     initial_joint_controllers = ParameterFile(
         PathJoinSubstitution([description_pkg_share, "config", controllers_file]),
         allow_substs=True,
@@ -301,9 +305,9 @@ def generate_launch_description():
     joint_state_broadcaster_spawner = spawner("joint_state_broadcaster")
     robotiq_gripper_controller_spawner = spawner("robotiq_gripper_controller")
     # The reactivate_gripper GPIO this controller claims is declared for the
-    # driver and the mock only; the simulated plugin has nothing to reactivate.
+    # driver and the mock only; the topic_based plugin has nothing to reactivate.
     robotiq_activation_controller_spawner = spawner(
-        "robotiq_activation_controller", condition=UnlessCondition(simulated)
+        "robotiq_activation_controller", condition=UnlessCondition(topic_based)
     )
 
     nodes = [

--- a/grippers/robotiq_description/launch/robotiq_control.launch.py
+++ b/grippers/robotiq_description/launch/robotiq_control.launch.py
@@ -27,6 +27,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import launch
+import launch.logging
 from launch.actions import OpaqueFunction
 from launch.substitution import Substitution
 from launch.substitutions import (
@@ -82,6 +83,39 @@ class ControllersFile(Substitution):
 # The xacro emits one <plugin> per flag that is set, and ros2_control_node
 # accepts only one, so two flags would fail late and obscurely.
 HARDWARE_FLAGS = ("use_fake_hardware", "sim_topic_based")
+
+# PickNik's names for the topic-based path, released in 1.1.0. Each maps to its
+# replacement and, for the topics, to the default it had then, which sim_isaac
+# restores so a 1.1.0 command line keeps driving the same simulator.
+DEPRECATED_ISAAC_ARGUMENTS = {
+    "sim_isaac": ("sim_topic_based", None),
+    "isaac_joint_commands": ("sim_joint_commands_topic", "/isaac_joint_commands"),
+    "isaac_joint_states": ("sim_joint_states_topic", "/isaac_joint_states"),
+}
+DEPRECATION_NOTICE = (
+    "{} deprecated since 1.2.0 and removed in the next major release; "
+    "use sim_topic_based, sim_joint_commands_topic and sim_joint_states_topic"
+)
+
+
+def alias_deprecated_isaac_arguments(context):
+    # Runs before the DeclareLaunchArguments, so the context holds only what the
+    # caller actually passed and an explicit new-style argument always wins.
+    given = context.launch_configurations
+    used = [old for old in DEPRECATED_ISAAC_ARGUMENTS if old in given]
+    if not used:
+        return
+    launch.logging.get_logger("robotiq_control.launch").warning(
+        DEPRECATION_NOTICE.format(
+            f"{', '.join(used)} {'is' if len(used) == 1 else 'are'}"
+        )
+    )
+    restore_isaac_defaults = "sim_isaac" in used
+    for old, (new, isaac_default) in DEPRECATED_ISAAC_ARGUMENTS.items():
+        if old in used:
+            given.setdefault(new, given[old])
+        elif restore_isaac_defaults and isaac_default is not None:
+            given.setdefault(new, isaac_default)
 
 
 def reject_conflicting_hardware_flags(context):
@@ -242,6 +276,14 @@ def generate_launch_description():
             description="sim_topic_based only: JointState topic the simulator publishes",
         )
     )
+    for old, (new, _) in DEPRECATED_ISAAC_ARGUMENTS.items():
+        args.append(
+            launch.actions.DeclareLaunchArgument(
+                name=old,
+                default_value="",
+                description=f"Deprecated since 1.2.0: use {new}",
+            )
+        )
 
     topic_based = LaunchConfiguration("sim_topic_based")
 
@@ -320,4 +362,6 @@ def generate_launch_description():
         rviz_node,
     ]
 
-    return launch.LaunchDescription(args + nodes)
+    return launch.LaunchDescription(
+        [OpaqueFunction(function=alias_deprecated_isaac_arguments)] + args + nodes
+    )

--- a/grippers/robotiq_description/launch/robotiq_control.launch.py
+++ b/grippers/robotiq_description/launch/robotiq_control.launch.py
@@ -145,11 +145,11 @@ def xacro_command():
             "sim_topic_based:=",
             LaunchConfiguration("sim_topic_based"),
             " ",
-            "joint_commands_topic:=",
-            LaunchConfiguration("joint_commands_topic"),
+            "sim_joint_commands_topic:=",
+            LaunchConfiguration("sim_joint_commands_topic"),
             " ",
-            "joint_states_topic:=",
-            LaunchConfiguration("joint_states_topic"),
+            "sim_joint_states_topic:=",
+            LaunchConfiguration("sim_joint_states_topic"),
         ]
     )
 
@@ -230,14 +230,14 @@ def generate_launch_description():
     )
     args.append(
         launch.actions.DeclareLaunchArgument(
-            name="joint_commands_topic",
+            name="sim_joint_commands_topic",
             default_value="/sim/joint_commands",
             description="sim_topic_based only: JointState topic the simulator takes commands on",
         )
     )
     args.append(
         launch.actions.DeclareLaunchArgument(
-            name="joint_states_topic",
+            name="sim_joint_states_topic",
             default_value="/sim/joint_states",
             description="sim_topic_based only: JointState topic the simulator publishes",
         )

--- a/grippers/robotiq_description/test/test_controller_config.py
+++ b/grippers/robotiq_description/test/test_controller_config.py
@@ -54,13 +54,16 @@ ALL_CONFIGS = (JAZZY_CONFIG, HUMBLE_CONFIG)
 # both models; robotiq_control.launch.py resolves it via ParameterFile.
 JOINT_PLACEHOLDER = "$(var gripper_joint)"
 
-# The simulated plugin (sim_isaac) exports neither the set_gripper_max_* command
+# The topic_based plugin exports neither the set_gripper_max_* command
 # interfaces nor the reactivate_gripper GPIO, so it gets a config of its own per
 # distro, selected by the same launch file.
-JAZZY_SIM_CONFIG = CONFIG_DIR / "robotiq_controllers.sim.yaml"
-HUMBLE_SIM_CONFIG = CONFIG_DIR / "robotiq_controllers.sim.humble.yaml"
-SIM_CONFIGS = (JAZZY_SIM_CONFIG, HUMBLE_SIM_CONFIG)
-SIM_OF = {JAZZY_CONFIG: JAZZY_SIM_CONFIG, HUMBLE_CONFIG: HUMBLE_SIM_CONFIG}
+JAZZY_TOPIC_BASED_CONFIG = CONFIG_DIR / "robotiq_controllers.topic_based.yaml"
+HUMBLE_TOPIC_BASED_CONFIG = CONFIG_DIR / "robotiq_controllers.topic_based.humble.yaml"
+TOPIC_BASED_CONFIGS = (JAZZY_TOPIC_BASED_CONFIG, HUMBLE_TOPIC_BASED_CONFIG)
+TOPIC_BASED_OF = {
+    JAZZY_CONFIG: JAZZY_TOPIC_BASED_CONFIG,
+    HUMBLE_CONFIG: HUMBLE_TOPIC_BASED_CONFIG,
+}
 
 # Names exported by robotiq_driver's hardware interface for the joint it is
 # given. Kept in sync by robotiq_driver's test_robotiq_gripper_hardware_interface,
@@ -86,7 +89,10 @@ EXPECTED_CONTROLLER_TYPES = {
     HUMBLE_CONFIG: "position_controllers/GripperActionController",
 }
 EXPECTED_CONTROLLER_TYPES.update(
-    {SIM_OF[config]: plugin for config, plugin in EXPECTED_CONTROLLER_TYPES.items()}
+    {
+        TOPIC_BASED_OF[config]: plugin
+        for config, plugin in EXPECTED_CONTROLLER_TYPES.items()
+    }
 )
 
 
@@ -135,7 +141,7 @@ def test_humble_config_claims_no_unsupported_interfaces():
     assert "max_velocity_interface" not in params
 
 
-@pytest.mark.parametrize("config", ALL_CONFIGS + SIM_CONFIGS)
+@pytest.mark.parametrize("config", ALL_CONFIGS + TOPIC_BASED_CONFIGS)
 def test_joint_is_left_to_the_launch(config):
     # Hardcoding the 2F-85 joint here is why a 2F-140 launch used to fail to
     # activate robotiq_gripper_controller.
@@ -171,25 +177,27 @@ def test_launch_restricts_gripper_model_to_the_known_joints():
 
 
 @pytest.mark.parametrize(
-    "use_fake_hardware,sim_isaac",
+    "use_fake_hardware,sim_topic_based",
     [("false", "false"), ("true", "false"), ("false", "true")],
 )
-def test_launch_accepts_at_most_one_hardware_flag(use_fake_hardware, sim_isaac):
+def test_launch_accepts_at_most_one_hardware_flag(use_fake_hardware, sim_topic_based):
     launch_module = load_launch_module()
     context = LaunchContext()
     context.launch_configurations.update(
-        use_fake_hardware=use_fake_hardware, sim_isaac=sim_isaac
+        use_fake_hardware=use_fake_hardware, sim_topic_based=sim_topic_based
     )
     launch_module.reject_conflicting_hardware_flags(context)
 
 
-def test_launch_rejects_fake_hardware_together_with_sim_isaac():
+def test_launch_rejects_fake_hardware_together_with_sim_topic_based():
     # Both flags set makes the xacro emit two <plugin> elements while the launch
-    # picks the sim config; neither half can work, so fail before anything starts.
+    # picks the topic_based config; neither half can work, so fail before anything starts.
     launch_module = load_launch_module()
     context = LaunchContext()
-    context.launch_configurations.update(use_fake_hardware="true", sim_isaac="true")
-    with pytest.raises(RuntimeError, match="use_fake_hardware and sim_isaac"):
+    context.launch_configurations.update(
+        use_fake_hardware="true", sim_topic_based="true"
+    )
+    with pytest.raises(RuntimeError, match="use_fake_hardware and sim_topic_based"):
         launch_module.reject_conflicting_hardware_flags(context)
 
 
@@ -205,15 +213,15 @@ def test_launch_forwards_the_gripper_model_to_xacro():
         use_fake_hardware="true",
         com_port="/dev/null",
         baudrate="115200",
-        sim_isaac="false",
-        isaac_joint_commands="/isaac_joint_commands",
-        isaac_joint_states="/isaac_joint_states",
+        sim_topic_based="false",
+        joint_commands_topic="/sim/joint_commands",
+        joint_states_topic="/sim/joint_states",
     )
     rendered = "".join(s.perform(context) for s in command.command)
     assert "gripper_model:=2f_140" in rendered
 
 
-@pytest.mark.parametrize("config", ALL_CONFIGS + SIM_CONFIGS)
+@pytest.mark.parametrize("config", ALL_CONFIGS + TOPIC_BASED_CONFIGS)
 def test_controller_type_matches_distro(config):
     controllers = load(config)["controller_manager"]["ros__parameters"]
     assert (
@@ -237,9 +245,9 @@ def test_launch_selects_the_config_for_the_distro(distro, expected):
     assert selected == expected.name
     assert (CONFIG_DIR / selected).is_file()
 
-    simulated = launch_module.controllers_file_for_distro(distro, simulated=True)
-    assert simulated == SIM_OF[expected].name
-    assert (CONFIG_DIR / simulated).is_file()
+    topic_based = launch_module.controllers_file_for_distro(distro, topic_based=True)
+    assert topic_based == TOPIC_BASED_OF[expected].name
+    assert (CONFIG_DIR / topic_based).is_file()
 
 
 requires_launch = pytest.mark.skipif(
@@ -259,7 +267,7 @@ def spawned_controllers(distro, monkeypatch, **launch_arguments):
     context = LaunchContext()
     context.launch_configurations.update(
         {
-            "sim_isaac": "false",
+            "sim_topic_based": "false",
             "gripper_joint": JOINT,
             **launch_arguments,
         }
@@ -284,9 +292,9 @@ def resolved(config, joint=JOINT):
 @pytest.mark.parametrize(
     "distro,hardware_config,sim_config",
     [
-        ("humble", HUMBLE_CONFIG, HUMBLE_SIM_CONFIG),
-        ("jazzy", JAZZY_CONFIG, JAZZY_SIM_CONFIG),
-        (None, JAZZY_CONFIG, JAZZY_SIM_CONFIG),
+        ("humble", HUMBLE_CONFIG, HUMBLE_TOPIC_BASED_CONFIG),
+        ("jazzy", JAZZY_CONFIG, JAZZY_TOPIC_BASED_CONFIG),
+        (None, JAZZY_CONFIG, JAZZY_TOPIC_BASED_CONFIG),
     ],
 )
 def test_launch_spawns_per_plugin(distro, hardware_config, sim_config, monkeypatch):
@@ -299,25 +307,25 @@ def test_launch_spawns_per_plugin(distro, hardware_config, sim_config, monkeypat
         "robotiq_activation_controller": resolved(hardware_config),
     }
 
-    simulated = spawned_controllers(distro, monkeypatch, sim_isaac="true")
-    assert simulated == {
+    topic_based = spawned_controllers(distro, monkeypatch, sim_topic_based="true")
+    assert topic_based == {
         "joint_state_broadcaster": resolved(sim_config),
         "robotiq_gripper_controller": resolved(sim_config),
     }
 
 
-@pytest.mark.parametrize("config", SIM_CONFIGS)
+@pytest.mark.parametrize("config", TOPIC_BASED_CONFIGS)
 def test_sim_configs_claim_no_driver_only_command_interfaces(config):
     # TopicBasedSystem exports the standard joint interfaces only; claiming
-    # set_gripper_max_* here is why the sim path never activated.
+    # set_gripper_max_* here is why the sim_topic_based path never activated.
     params = gripper_controller_params(config)
     assert "max_effort_interface" not in params
     assert "max_velocity_interface" not in params
 
 
-@pytest.mark.parametrize("config", SIM_CONFIGS)
+@pytest.mark.parametrize("config", TOPIC_BASED_CONFIGS)
 def test_sim_configs_spawn_no_activation_controller(config):
-    # No reactivate_gripper GPIO is declared under sim_isaac (see
+    # No reactivate_gripper GPIO is declared under sim_topic_based (see
     # 2f_85.ros2_control.xacro), so the controller would have nothing to claim.
     controllers = load(config)["controller_manager"]["ros__parameters"]
     assert set(controllers) == {
@@ -336,13 +344,13 @@ def test_sim_config_keeps_the_action_surface_of_its_distro(config):
     # Stall handling is the one deliberate difference: a simulator that publishes
     # no velocities would otherwise pass every failed grasp as a successful stall.
     hardware = gripper_controller_params(config)
-    sim = gripper_controller_params(SIM_OF[config])
+    sim = gripper_controller_params(TOPIC_BASED_OF[config])
     assert sim["joint"] == hardware["joint"]
     assert sim["goal_tolerance"] == hardware["goal_tolerance"]
     assert hardware["allow_stalling"] is True
     assert sim["allow_stalling"] is False
     assert (
-        load(SIM_OF[config])["controller_manager"]["ros__parameters"][
+        load(TOPIC_BASED_OF[config])["controller_manager"]["ros__parameters"][
             "robotiq_gripper_controller"
         ]
         == load(config)["controller_manager"]["ros__parameters"][

--- a/grippers/robotiq_description/test/test_controller_config.py
+++ b/grippers/robotiq_description/test/test_controller_config.py
@@ -37,6 +37,7 @@
 # regardless of the distro the tests run on, so neither can rot unnoticed.
 
 import importlib.util
+import logging
 from pathlib import Path
 
 import pytest
@@ -199,6 +200,55 @@ def test_launch_rejects_fake_hardware_together_with_sim_topic_based():
     )
     with pytest.raises(RuntimeError, match="use_fake_hardware and sim_topic_based"):
         launch_module.reject_conflicting_hardware_flags(context)
+
+
+@pytest.fixture
+def launch_log(caplog):
+    # launch's loggers never propagate and their screen handler binds sys.stdout
+    # once per process, so neither caplog nor capsys sees them unaided.
+    logger = logging.getLogger("robotiq_control.launch")
+    logger.addHandler(caplog.handler)
+    yield caplog
+    logger.removeHandler(caplog.handler)
+
+
+def test_launch_aliases_the_deprecated_isaac_arguments(launch_log):
+    # PickNik's 1.1.0 names must keep driving the same simulator, and say so.
+    launch_module = load_launch_module()
+    context = LaunchContext()
+    context.launch_configurations.update(sim_isaac="true")
+    launch_module.alias_deprecated_isaac_arguments(context)
+    assert context.launch_configurations["sim_topic_based"] == "true"
+    assert (
+        context.launch_configurations["sim_joint_commands_topic"]
+        == "/isaac_joint_commands"
+    )
+    assert (
+        context.launch_configurations["sim_joint_states_topic"] == "/isaac_joint_states"
+    )
+    assert "sim_isaac is deprecated" in launch_log.text
+
+
+def test_launch_lets_an_explicit_new_argument_win_over_a_deprecated_one():
+    launch_module = load_launch_module()
+    context = LaunchContext()
+    context.launch_configurations.update(
+        sim_isaac="true", isaac_joint_commands="/old", sim_joint_commands_topic="/new"
+    )
+    launch_module.alias_deprecated_isaac_arguments(context)
+    assert context.launch_configurations["sim_joint_commands_topic"] == "/new"
+    assert (
+        context.launch_configurations["sim_joint_states_topic"] == "/isaac_joint_states"
+    )
+
+
+def test_launch_is_quiet_without_deprecated_arguments(launch_log):
+    launch_module = load_launch_module()
+    context = LaunchContext()
+    context.launch_configurations.update(sim_topic_based="true")
+    launch_module.alias_deprecated_isaac_arguments(context)
+    assert context.launch_configurations == {"sim_topic_based": "true"}
+    assert "deprecated" not in launch_log.text
 
 
 def test_launch_forwards_the_gripper_model_to_xacro():

--- a/grippers/robotiq_description/test/test_controller_config.py
+++ b/grippers/robotiq_description/test/test_controller_config.py
@@ -214,8 +214,8 @@ def test_launch_forwards_the_gripper_model_to_xacro():
         com_port="/dev/null",
         baudrate="115200",
         sim_topic_based="false",
-        joint_commands_topic="/sim/joint_commands",
-        joint_states_topic="/sim/joint_states",
+        sim_joint_commands_topic="/sim/joint_commands",
+        sim_joint_states_topic="/sim/joint_states",
     )
     rendered = "".join(s.perform(context) for s in command.command)
     assert "gripper_model:=2f_140" in rendered

--- a/grippers/robotiq_description/test/test_ros2_control_urdf.py
+++ b/grippers/robotiq_description/test/test_ros2_control_urdf.py
@@ -52,7 +52,7 @@ import yaml
 PKG_DIR = Path(__file__).parents[1]
 URDF_DIR = PKG_DIR / "urdf"
 CONFIG = PKG_DIR / "config" / "robotiq_controllers.yaml"
-SIM_CONFIG = PKG_DIR / "config" / "robotiq_controllers.sim.yaml"
+TOPIC_BASED_CONFIG = PKG_DIR / "config" / "robotiq_controllers.topic_based.yaml"
 
 # Top-level xacro -> the joint carrying the gripper's position command.
 MODELS = {
@@ -62,8 +62,8 @@ MODELS = {
 
 MOCK_PLUGIN = "mock_components/GenericSystem"
 REAL_PLUGIN = "robotiq_driver/RobotiqGripperHardwareInterface"
-ISAAC_PLUGIN = "topic_based_ros2_control/TopicBasedSystem"
-SIM_ARG = "sim_isaac:=true"
+TOPIC_BASED_PLUGIN = "topic_based_ros2_control/TopicBasedSystem"
+TOPIC_BASED_ARG = "sim_topic_based:=true"
 
 # Every 2F finger joint except the driven knuckle follows it through <mimic>.
 MIMIC_JOINT_COUNT = 5
@@ -205,31 +205,31 @@ def test_baudrate_reaches_the_driver(model):
 @requires_xacro
 @pytest.mark.parametrize("model,joint", MODELS.items())
 def test_sim_plugin_declares_only_the_position_command(model, joint):
-    # The simulated plugin does not know the driver's set_gripper_max_* interfaces;
-    # config/robotiq_controllers.sim.yaml therefore claims none, and the URDF must
+    # The topic_based plugin does not know the driver's set_gripper_max_* interfaces;
+    # config/robotiq_controllers.topic_based.yaml therefore claims none, and the URDF must
     # not declare them either or the plugin rejects the joint.
-    ros2_control = expand(model, False, SIM_ARG)
-    assert plugin_of(ros2_control) == ISAAC_PLUGIN
+    ros2_control = expand(model, False, TOPIC_BASED_ARG)
+    assert plugin_of(ros2_control) == TOPIC_BASED_PLUGIN
     assert command_interfaces_of(ros2_control, joint) == {"position"}
 
 
 @requires_xacro
 @pytest.mark.parametrize("model,joint", MODELS.items())
 def test_sim_plugin_declares_no_reactivate_gpio(model, joint):
-    # robotiq_control.launch.py skips robotiq_activation_controller under sim_isaac;
+    # robotiq_control.launch.py skips robotiq_activation_controller under sim_topic_based;
     # this is the URDF side of that agreement.
-    assert expand(model, False, SIM_ARG).find("gpio") is None
+    assert expand(model, False, TOPIC_BASED_ARG).find("gpio") is None
     assert expand(model, False).find("gpio[@name='reactivate_gripper']") is not None
     assert expand(model, True).find("gpio[@name='reactivate_gripper']") is not None
 
 
 @requires_xacro
 @pytest.mark.parametrize("model,joint", MODELS.items())
-def test_sim_isaac_declares_the_mimic_joints_as_state_only(model, joint):
+def test_sim_topic_based_declares_the_mimic_joints_as_state_only(model, joint):
     # TopicBasedSystem reports only the joints declared here, and the simulator
     # owns the mimic joints, so they must be declared for /joint_states to carry
     # them, but with no command interface: only the knuckle is driven.
-    ros2_control = expand(model, False, "sim_isaac:=true")
+    ros2_control = expand(model, False, "sim_topic_based:=true")
     mimic = joints_of(ros2_control) - {joint}
     assert len(mimic) == MIMIC_JOINT_COUNT
     for name in mimic:
@@ -239,32 +239,32 @@ def test_sim_isaac_declares_the_mimic_joints_as_state_only(model, joint):
 
 @requires_xacro
 @pytest.mark.parametrize("model", MODELS)
-def test_isaac_topics_reach_the_plugin(model):
+def test_sim_topics_reach_the_plugin(model):
     # Same three-file chain as baudrate: a half-forwarded argument only shows up
     # as a simulator that never hears a command.
     ros2_control = expand(
         model,
         False,
-        "sim_isaac:=true",
-        "isaac_joint_commands:=/sim/cmd",
-        "isaac_joint_states:=/sim/state",
+        "sim_topic_based:=true",
+        "joint_commands_topic:=/sim/cmd",
+        "joint_states_topic:=/sim/state",
     )
     assert hardware_param(ros2_control, "joint_commands_topic") == "/sim/cmd"
     assert hardware_param(ros2_control, "joint_states_topic") == "/sim/state"
 
-    default = expand(model, False, "sim_isaac:=true")
-    assert hardware_param(default, "joint_commands_topic") == "/isaac_joint_commands"
-    assert hardware_param(default, "joint_states_topic") == "/isaac_joint_states"
+    default = expand(model, False, "sim_topic_based:=true")
+    assert hardware_param(default, "joint_commands_topic") == "/sim/joint_commands"
+    assert hardware_param(default, "joint_states_topic") == "/sim/joint_states"
 
 
 @requires_xacro
 @pytest.mark.parametrize("model,joint", MODELS.items())
 def test_sim_controller_config_claims_only_what_the_sim_urdf_declares(model, joint):
-    # The sim counterpart of test_gripper_controller_config_interfaces_exist_under_mock.
-    params = yaml.safe_load(SIM_CONFIG.read_text())["robotiq_gripper_controller"][
-        "ros__parameters"
-    ]
-    ros2_control = expand(model, False, SIM_ARG)
+    # The sim_topic_based counterpart of test_gripper_controller_config_interfaces_exist_under_mock.
+    params = yaml.safe_load(TOPIC_BASED_CONFIG.read_text())[
+        "robotiq_gripper_controller"
+    ]["ros__parameters"]
+    ros2_control = expand(model, False, TOPIC_BASED_ARG)
 
     assert params["joint"] == "$(var gripper_joint)"
     assert "max_effort_interface" not in params

--- a/grippers/robotiq_description/test/test_ros2_control_urdf.py
+++ b/grippers/robotiq_description/test/test_ros2_control_urdf.py
@@ -246,8 +246,8 @@ def test_sim_topics_reach_the_plugin(model):
         model,
         False,
         "sim_topic_based:=true",
-        "joint_commands_topic:=/sim/cmd",
-        "joint_states_topic:=/sim/state",
+        "sim_joint_commands_topic:=/sim/cmd",
+        "sim_joint_states_topic:=/sim/state",
     )
     assert hardware_param(ros2_control, "joint_commands_topic") == "/sim/cmd"
     assert hardware_param(ros2_control, "joint_states_topic") == "/sim/state"

--- a/grippers/robotiq_description/test/test_ros2_control_urdf.py
+++ b/grippers/robotiq_description/test/test_ros2_control_urdf.py
@@ -257,6 +257,35 @@ def test_sim_topics_reach_the_plugin(model):
     assert hardware_param(default, "joint_states_topic") == "/sim/joint_states"
 
 
+def xacro_stderr(model, *extra_args):
+    return subprocess.run(
+        ["xacro", str(URDF_DIR / model), *extra_args],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stderr
+
+
+@requires_xacro
+@pytest.mark.parametrize("model", MODELS)
+def test_deprecated_isaac_arguments_still_select_the_plugin_and_warn(model):
+    # PickNik's 1.1.0 names: same plugin, the /isaac_* topic defaults they had,
+    # an explicit isaac_* topic still wins, and xacro says so on stderr.
+    ros2_control = expand(model, False, "sim_isaac:=true")
+    assert plugin_of(ros2_control) == TOPIC_BASED_PLUGIN
+    assert (
+        hardware_param(ros2_control, "joint_commands_topic") == "/isaac_joint_commands"
+    )
+    assert hardware_param(ros2_control, "joint_states_topic") == "/isaac_joint_states"
+
+    overridden = expand(model, False, "sim_isaac:=true", "isaac_joint_commands:=/x")
+    assert hardware_param(overridden, "joint_commands_topic") == "/x"
+
+    assert "sim_isaac" in xacro_stderr(model, "sim_isaac:=true")
+    assert "deprecated" in xacro_stderr(model, "sim_isaac:=true")
+    assert "deprecated" not in xacro_stderr(model, TOPIC_BASED_ARG)
+
+
 @requires_xacro
 @pytest.mark.parametrize("model,joint", MODELS.items())
 def test_sim_controller_config_claims_only_what_the_sim_urdf_declares(model, joint):

--- a/grippers/robotiq_description/urdf/2f_140.ros2_control.xacro
+++ b/grippers/robotiq_description/urdf/2f_140.ros2_control.xacro
@@ -7,9 +7,9 @@
         name
         prefix
         sim_gazebo:=false
-        sim_isaac:=false
-        isaac_joint_commands:=/isaac_joint_commands
-        isaac_joint_states:=/isaac_joint_states
+        sim_topic_based:=false
+        joint_commands_topic:=/sim/joint_commands
+        joint_states_topic:=/sim/joint_states
         use_fake_hardware:=false
         mock_sensor_commands:=false
         com_port:=/dev/ttyUSB0
@@ -24,9 +24,9 @@
             <!-- Plugins -->
             <xacro:robotiq_2f_hardware
                 sim_gazebo="${sim_gazebo}"
-                sim_isaac="${sim_isaac}"
-                isaac_joint_commands="${isaac_joint_commands}"
-                isaac_joint_states="${isaac_joint_states}"
+                sim_topic_based="${sim_topic_based}"
+                joint_commands_topic="${joint_commands_topic}"
+                joint_states_topic="${joint_states_topic}"
                 use_fake_hardware="${use_fake_hardware}"
                 mock_sensor_commands="${mock_sensor_commands}"
                 com_port="${com_port}"
@@ -50,13 +50,13 @@
                     <param name="initial_value">${gripper_closed_position}</param>
                 </state_interface>
                 <state_interface name="velocity"/>
-                <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_isaac}">
+                <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_topic_based}">
                     <state_interface name="motor_current"/>
                     <state_interface name="object_status"/>
                 </xacro:unless>
             </joint>
             <!-- When simulating we need to include the rest of the gripper joints -->
-            <xacro:if value="${sim_isaac or sim_gazebo}">
+            <xacro:if value="${sim_topic_based or sim_gazebo}">
                 <xacro:robotiq_2f_sim_mimic_joint name="${prefix}left_inner_knuckle_joint" sim_gazebo="${sim_gazebo}"/>
                 <xacro:robotiq_2f_sim_mimic_joint name="${prefix}left_inner_finger_joint" sim_gazebo="${sim_gazebo}"/>
                 <xacro:robotiq_2f_sim_mimic_joint name="${prefix}right_outer_knuckle_joint" sim_gazebo="${sim_gazebo}"/>
@@ -65,7 +65,7 @@
             </xacro:if>
 
             <!-- Only add this with fake hardware mode -->
-            <xacro:unless value="${sim_gazebo or sim_isaac}">
+            <xacro:unless value="${sim_gazebo or sim_topic_based}">
                 <gpio name="reactivate_gripper">
                     <command_interface name="reactivate_gripper_cmd" />
                     <command_interface name="reactivate_gripper_response" />

--- a/grippers/robotiq_description/urdf/2f_140.ros2_control.xacro
+++ b/grippers/robotiq_description/urdf/2f_140.ros2_control.xacro
@@ -8,8 +8,8 @@
         prefix
         sim_gazebo:=false
         sim_topic_based:=false
-        joint_commands_topic:=/sim/joint_commands
-        joint_states_topic:=/sim/joint_states
+        sim_joint_commands_topic:=/sim/joint_commands
+        sim_joint_states_topic:=/sim/joint_states
         use_fake_hardware:=false
         mock_sensor_commands:=false
         com_port:=/dev/ttyUSB0
@@ -25,8 +25,8 @@
             <xacro:robotiq_2f_hardware
                 sim_gazebo="${sim_gazebo}"
                 sim_topic_based="${sim_topic_based}"
-                joint_commands_topic="${joint_commands_topic}"
-                joint_states_topic="${joint_states_topic}"
+                sim_joint_commands_topic="${sim_joint_commands_topic}"
+                sim_joint_states_topic="${sim_joint_states_topic}"
                 use_fake_hardware="${use_fake_hardware}"
                 mock_sensor_commands="${mock_sensor_commands}"
                 com_port="${com_port}"

--- a/grippers/robotiq_description/urdf/2f_85.ros2_control.xacro
+++ b/grippers/robotiq_description/urdf/2f_85.ros2_control.xacro
@@ -7,9 +7,9 @@
         name
         prefix
         sim_gazebo:=false
-        sim_isaac:=false
-        isaac_joint_commands:=/isaac_joint_commands
-        isaac_joint_states:=/isaac_joint_states
+        sim_topic_based:=false
+        joint_commands_topic:=/sim/joint_commands
+        joint_states_topic:=/sim/joint_states
         use_fake_hardware:=false
         mock_sensor_commands:=false
         com_port:=/dev/ttyUSB0
@@ -24,9 +24,9 @@
             <!-- Plugins -->
             <xacro:robotiq_2f_hardware
                 sim_gazebo="${sim_gazebo}"
-                sim_isaac="${sim_isaac}"
-                isaac_joint_commands="${isaac_joint_commands}"
-                isaac_joint_states="${isaac_joint_states}"
+                sim_topic_based="${sim_topic_based}"
+                joint_commands_topic="${joint_commands_topic}"
+                joint_states_topic="${joint_states_topic}"
                 use_fake_hardware="${use_fake_hardware}"
                 mock_sensor_commands="${mock_sensor_commands}"
                 com_port="${com_port}"
@@ -57,13 +57,13 @@
                     <param name="initial_value">${gripper_closed_position}</param>
                 </state_interface>
                 <state_interface name="velocity"/>
-                <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_isaac}">
+                <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_topic_based}">
                     <state_interface name="motor_current"/>
                     <state_interface name="object_status"/>
                 </xacro:unless>
             </joint>
             <!-- When simulating we need to include the rest of the gripper joints -->
-            <xacro:if value="${sim_isaac or sim_gazebo}">
+            <xacro:if value="${sim_topic_based or sim_gazebo}">
                 <xacro:robotiq_2f_sim_mimic_joint name="${prefix}robotiq_85_right_knuckle_joint" sim_gazebo="${sim_gazebo}"/>
                 <xacro:robotiq_2f_sim_mimic_joint name="${prefix}robotiq_85_left_inner_knuckle_joint" sim_gazebo="${sim_gazebo}"/>
                 <xacro:robotiq_2f_sim_mimic_joint name="${prefix}robotiq_85_right_inner_knuckle_joint" sim_gazebo="${sim_gazebo}"/>
@@ -72,7 +72,7 @@
             </xacro:if>
 
             <!-- Only add this with fake hardware mode -->
-            <xacro:unless value="${sim_gazebo or sim_isaac}">
+            <xacro:unless value="${sim_gazebo or sim_topic_based}">
                 <gpio name="reactivate_gripper">
                     <command_interface name="reactivate_gripper_cmd" />
                     <command_interface name="reactivate_gripper_response" />

--- a/grippers/robotiq_description/urdf/2f_85.ros2_control.xacro
+++ b/grippers/robotiq_description/urdf/2f_85.ros2_control.xacro
@@ -8,8 +8,8 @@
         prefix
         sim_gazebo:=false
         sim_topic_based:=false
-        joint_commands_topic:=/sim/joint_commands
-        joint_states_topic:=/sim/joint_states
+        sim_joint_commands_topic:=/sim/joint_commands
+        sim_joint_states_topic:=/sim/joint_states
         use_fake_hardware:=false
         mock_sensor_commands:=false
         com_port:=/dev/ttyUSB0
@@ -25,8 +25,8 @@
             <xacro:robotiq_2f_hardware
                 sim_gazebo="${sim_gazebo}"
                 sim_topic_based="${sim_topic_based}"
-                joint_commands_topic="${joint_commands_topic}"
-                joint_states_topic="${joint_states_topic}"
+                sim_joint_commands_topic="${sim_joint_commands_topic}"
+                sim_joint_states_topic="${sim_joint_states_topic}"
                 use_fake_hardware="${use_fake_hardware}"
                 mock_sensor_commands="${mock_sensor_commands}"
                 com_port="${com_port}"

--- a/grippers/robotiq_description/urdf/2f_common.ros2_control.xacro
+++ b/grippers/robotiq_description/urdf/2f_common.ros2_control.xacro
@@ -6,9 +6,9 @@
          2f_140.ros2_control.xacro. -->
     <xacro:macro name="robotiq_2f_hardware" params="
         sim_gazebo
-        sim_isaac
-        isaac_joint_commands
-        isaac_joint_states
+        sim_topic_based
+        joint_commands_topic
+        joint_states_topic
         use_fake_hardware
         mock_sensor_commands
         com_port
@@ -24,10 +24,10 @@
             <!-- Set use_dummy to true to connect to a dummy driver for testing purposes. -->
             <param name="use_dummy">false</param>
 
-            <xacro:if value="${sim_isaac}">
+            <xacro:if value="${sim_topic_based}">
                 <plugin>topic_based_ros2_control/TopicBasedSystem</plugin>
-                <param name="joint_commands_topic">${isaac_joint_commands}</param>
-                <param name="joint_states_topic">${isaac_joint_states}</param>
+                <param name="joint_commands_topic">${joint_commands_topic}</param>
+                <param name="joint_states_topic">${joint_states_topic}</param>
                 <param name="trigger_joint_command_threshold">0.02</param>
             </xacro:if>
             <xacro:if value="${sim_gazebo}">
@@ -38,7 +38,7 @@
                 <param name="mock_sensor_commands">${mock_sensor_commands}</param>
                 <param name="state_following_offset">0.0</param>
             </xacro:if>
-            <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_isaac}">
+            <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_topic_based}">
                 <plugin>robotiq_driver/RobotiqGripperHardwareInterface</plugin>
                 <param name="gripper_closed_position">${gripper_closed_position}</param>
                 <param name="COM_port">${com_port}</param>

--- a/grippers/robotiq_description/urdf/2f_common.ros2_control.xacro
+++ b/grippers/robotiq_description/urdf/2f_common.ros2_control.xacro
@@ -7,8 +7,8 @@
     <xacro:macro name="robotiq_2f_hardware" params="
         sim_gazebo
         sim_topic_based
-        joint_commands_topic
-        joint_states_topic
+        sim_joint_commands_topic
+        sim_joint_states_topic
         use_fake_hardware
         mock_sensor_commands
         com_port
@@ -26,8 +26,8 @@
 
             <xacro:if value="${sim_topic_based}">
                 <plugin>topic_based_ros2_control/TopicBasedSystem</plugin>
-                <param name="joint_commands_topic">${joint_commands_topic}</param>
-                <param name="joint_states_topic">${joint_states_topic}</param>
+                <param name="joint_commands_topic">${sim_joint_commands_topic}</param>
+                <param name="joint_states_topic">${sim_joint_states_topic}</param>
                 <param name="trigger_joint_command_threshold">0.02</param>
             </xacro:if>
             <xacro:if value="${sim_gazebo}">

--- a/grippers/robotiq_description/urdf/robotiq_2f_140_macro.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_140_macro.urdf.xacro
@@ -6,9 +6,9 @@
         parent
         *origin
         sim_gazebo:=false
-        sim_isaac:=false
-        isaac_joint_commands:=/isaac_joint_commands
-        isaac_joint_states:=/isaac_joint_states
+        sim_topic_based:=false
+        joint_commands_topic:=/sim/joint_commands
+        joint_states_topic:=/sim/joint_states
         use_fake_hardware:=false
         mock_sensor_commands:=false
         include_ros2_control:=true
@@ -27,9 +27,9 @@
             <xacro:robotiq_gripper_ros2_control
                 name="${name}" prefix="${prefix}"
                 sim_gazebo="${sim_gazebo}"
-                sim_isaac="${sim_isaac}"
-                isaac_joint_commands="${isaac_joint_commands}"
-                isaac_joint_states="${isaac_joint_states}"
+                sim_topic_based="${sim_topic_based}"
+                joint_commands_topic="${joint_commands_topic}"
+                joint_states_topic="${joint_states_topic}"
                 use_fake_hardware="${use_fake_hardware}"
                 mock_sensor_commands="${mock_sensor_commands}"
                 com_port="${com_port}"

--- a/grippers/robotiq_description/urdf/robotiq_2f_140_macro.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_140_macro.urdf.xacro
@@ -7,8 +7,8 @@
         *origin
         sim_gazebo:=false
         sim_topic_based:=false
-        joint_commands_topic:=/sim/joint_commands
-        joint_states_topic:=/sim/joint_states
+        sim_joint_commands_topic:=/sim/joint_commands
+        sim_joint_states_topic:=/sim/joint_states
         use_fake_hardware:=false
         mock_sensor_commands:=false
         include_ros2_control:=true
@@ -28,8 +28,8 @@
                 name="${name}" prefix="${prefix}"
                 sim_gazebo="${sim_gazebo}"
                 sim_topic_based="${sim_topic_based}"
-                joint_commands_topic="${joint_commands_topic}"
-                joint_states_topic="${joint_states_topic}"
+                sim_joint_commands_topic="${sim_joint_commands_topic}"
+                sim_joint_states_topic="${sim_joint_states_topic}"
                 use_fake_hardware="${use_fake_hardware}"
                 mock_sensor_commands="${mock_sensor_commands}"
                 com_port="${com_port}"

--- a/grippers/robotiq_description/urdf/robotiq_2f_140_macro.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_140_macro.urdf.xacro
@@ -9,6 +9,9 @@
         sim_topic_based:=false
         sim_joint_commands_topic:=/sim/joint_commands
         sim_joint_states_topic:=/sim/joint_states
+        sim_isaac:=false
+        isaac_joint_commands:=''
+        isaac_joint_states:=''
         use_fake_hardware:=false
         mock_sensor_commands:=false
         include_ros2_control:=true
@@ -20,6 +23,16 @@
         gripper_max_force:=125.0
         gripper_closed_position:=0.695">
 
+        <!-- PickNik's names for the topic-based path, released in 1.1.0 and
+             deprecated since 1.2.0. sim_isaac keeps its old /isaac_joint_* topic
+             defaults; an explicit new-style argument wins over both. -->
+        <xacro:if value="${sim_isaac or isaac_joint_commands != '' or isaac_joint_states != ''}">
+            ${xacro.warning('sim_isaac, isaac_joint_commands and isaac_joint_states are deprecated since 1.2.0 and removed in the next major release; use sim_topic_based, sim_joint_commands_topic and sim_joint_states_topic')}
+        </xacro:if>
+        <xacro:property name="topic_based" value="${sim_topic_based or sim_isaac}"/>
+        <xacro:property name="commands_topic" value="${isaac_joint_commands or ('/isaac_joint_commands' if sim_isaac else sim_joint_commands_topic)}"/>
+        <xacro:property name="states_topic" value="${isaac_joint_states or ('/isaac_joint_states' if sim_isaac else sim_joint_states_topic)}"/>
+
         <!-- ros2 control include -->
         <xacro:include filename="$(find robotiq_description)/urdf/2f_140.ros2_control.xacro" />
         <!-- if we are simulating or directly communicating with the gripper we need a ros2 control instance -->
@@ -27,9 +40,9 @@
             <xacro:robotiq_gripper_ros2_control
                 name="${name}" prefix="${prefix}"
                 sim_gazebo="${sim_gazebo}"
-                sim_topic_based="${sim_topic_based}"
-                sim_joint_commands_topic="${sim_joint_commands_topic}"
-                sim_joint_states_topic="${sim_joint_states_topic}"
+                sim_topic_based="${topic_based}"
+                sim_joint_commands_topic="${commands_topic}"
+                sim_joint_states_topic="${states_topic}"
                 use_fake_hardware="${use_fake_hardware}"
                 mock_sensor_commands="${mock_sensor_commands}"
                 com_port="${com_port}"

--- a/grippers/robotiq_description/urdf/robotiq_2f_85_macro.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_85_macro.urdf.xacro
@@ -6,9 +6,9 @@
         parent
         *origin
         sim_gazebo:=false
-        sim_isaac:=false
-        isaac_joint_commands:=/isaac_joint_commands
-        isaac_joint_states:=/isaac_joint_states
+        sim_topic_based:=false
+        joint_commands_topic:=/sim/joint_commands
+        joint_states_topic:=/sim/joint_states
         use_fake_hardware:=false
         mock_sensor_commands:=false
         include_ros2_control:=true
@@ -28,9 +28,9 @@
             <xacro:robotiq_gripper_ros2_control
                 name="${name}" prefix="${prefix}"
                 sim_gazebo="${sim_gazebo}"
-                sim_isaac="${sim_isaac}"
-                isaac_joint_commands="${isaac_joint_commands}"
-                isaac_joint_states="${isaac_joint_states}"
+                sim_topic_based="${sim_topic_based}"
+                joint_commands_topic="${joint_commands_topic}"
+                joint_states_topic="${joint_states_topic}"
                 use_fake_hardware="${use_fake_hardware}"
                 mock_sensor_commands="${mock_sensor_commands}"
                 com_port="${com_port}"

--- a/grippers/robotiq_description/urdf/robotiq_2f_85_macro.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_85_macro.urdf.xacro
@@ -7,8 +7,8 @@
         *origin
         sim_gazebo:=false
         sim_topic_based:=false
-        joint_commands_topic:=/sim/joint_commands
-        joint_states_topic:=/sim/joint_states
+        sim_joint_commands_topic:=/sim/joint_commands
+        sim_joint_states_topic:=/sim/joint_states
         use_fake_hardware:=false
         mock_sensor_commands:=false
         include_ros2_control:=true
@@ -29,8 +29,8 @@
                 name="${name}" prefix="${prefix}"
                 sim_gazebo="${sim_gazebo}"
                 sim_topic_based="${sim_topic_based}"
-                joint_commands_topic="${joint_commands_topic}"
-                joint_states_topic="${joint_states_topic}"
+                sim_joint_commands_topic="${sim_joint_commands_topic}"
+                sim_joint_states_topic="${sim_joint_states_topic}"
                 use_fake_hardware="${use_fake_hardware}"
                 mock_sensor_commands="${mock_sensor_commands}"
                 com_port="${com_port}"

--- a/grippers/robotiq_description/urdf/robotiq_2f_85_macro.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_85_macro.urdf.xacro
@@ -9,6 +9,9 @@
         sim_topic_based:=false
         sim_joint_commands_topic:=/sim/joint_commands
         sim_joint_states_topic:=/sim/joint_states
+        sim_isaac:=false
+        isaac_joint_commands:=''
+        isaac_joint_states:=''
         use_fake_hardware:=false
         mock_sensor_commands:=false
         include_ros2_control:=true
@@ -20,6 +23,16 @@
         gripper_max_force:=235.0
         gripper_closed_position:=0.7929">
 
+        <!-- PickNik's names for the topic-based path, released in 1.1.0 and
+             deprecated since 1.2.0. sim_isaac keeps its old /isaac_joint_* topic
+             defaults; an explicit new-style argument wins over both. -->
+        <xacro:if value="${sim_isaac or isaac_joint_commands != '' or isaac_joint_states != ''}">
+            ${xacro.warning('sim_isaac, isaac_joint_commands and isaac_joint_states are deprecated since 1.2.0 and removed in the next major release; use sim_topic_based, sim_joint_commands_topic and sim_joint_states_topic')}
+        </xacro:if>
+        <xacro:property name="topic_based" value="${sim_topic_based or sim_isaac}"/>
+        <xacro:property name="commands_topic" value="${isaac_joint_commands or ('/isaac_joint_commands' if sim_isaac else sim_joint_commands_topic)}"/>
+        <xacro:property name="states_topic" value="${isaac_joint_states or ('/isaac_joint_states' if sim_isaac else sim_joint_states_topic)}"/>
+
 
         <!-- ros2 control include -->
         <xacro:include filename="$(find robotiq_description)/urdf/2f_85.ros2_control.xacro" />
@@ -28,9 +41,9 @@
             <xacro:robotiq_gripper_ros2_control
                 name="${name}" prefix="${prefix}"
                 sim_gazebo="${sim_gazebo}"
-                sim_topic_based="${sim_topic_based}"
-                sim_joint_commands_topic="${sim_joint_commands_topic}"
-                sim_joint_states_topic="${sim_joint_states_topic}"
+                sim_topic_based="${topic_based}"
+                sim_joint_commands_topic="${commands_topic}"
+                sim_joint_states_topic="${states_topic}"
                 use_fake_hardware="${use_fake_hardware}"
                 mock_sensor_commands="${mock_sensor_commands}"
                 com_port="${com_port}"

--- a/grippers/robotiq_description/urdf/robotiq_2f_gripper.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_gripper.urdf.xacro
@@ -8,17 +8,17 @@
     <xacro:arg name="use_fake_hardware" default="true" />
     <xacro:arg name="com_port" default="/dev/ttyUSB0" />
     <xacro:arg name="baudrate" default="115200" />
-    <xacro:arg name="sim_isaac" default="false" />
-    <xacro:arg name="isaac_joint_commands" default="/isaac_joint_commands" />
-    <xacro:arg name="isaac_joint_states" default="/isaac_joint_states" />
+    <xacro:arg name="sim_topic_based" default="false" />
+    <xacro:arg name="joint_commands_topic" default="/sim/joint_commands" />
+    <xacro:arg name="joint_states_topic" default="/sim/joint_states" />
 
     <!-- Import macros -->
     <xacro:include filename="$(find robotiq_description)/urdf/robotiq_$(arg gripper_model)_macro.urdf.xacro" />
 
     <link name="world" />
     <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg com_port)" baudrate="$(arg baudrate)"
-        sim_isaac="$(arg sim_isaac)"
-        isaac_joint_commands="$(arg isaac_joint_commands)" isaac_joint_states="$(arg isaac_joint_states)">
+        sim_topic_based="$(arg sim_topic_based)"
+        joint_commands_topic="$(arg joint_commands_topic)" joint_states_topic="$(arg joint_states_topic)">
         <origin xyz="0 0 0" rpy="0 0 0" />
     </xacro:robotiq_gripper>
 </robot>

--- a/grippers/robotiq_description/urdf/robotiq_2f_gripper.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_gripper.urdf.xacro
@@ -9,8 +9,8 @@
     <xacro:arg name="com_port" default="/dev/ttyUSB0" />
     <xacro:arg name="baudrate" default="115200" />
     <xacro:arg name="sim_topic_based" default="false" />
-    <xacro:arg name="joint_commands_topic" default="/sim/joint_commands" />
-    <xacro:arg name="joint_states_topic" default="/sim/joint_states" />
+    <xacro:arg name="sim_joint_commands_topic" default="/sim/joint_commands" />
+    <xacro:arg name="sim_joint_states_topic" default="/sim/joint_states" />
 
     <!-- Import macros -->
     <xacro:include filename="$(find robotiq_description)/urdf/robotiq_$(arg gripper_model)_macro.urdf.xacro" />
@@ -18,7 +18,7 @@
     <link name="world" />
     <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg com_port)" baudrate="$(arg baudrate)"
         sim_topic_based="$(arg sim_topic_based)"
-        joint_commands_topic="$(arg joint_commands_topic)" joint_states_topic="$(arg joint_states_topic)">
+        sim_joint_commands_topic="$(arg sim_joint_commands_topic)" sim_joint_states_topic="$(arg sim_joint_states_topic)">
         <origin xyz="0 0 0" rpy="0 0 0" />
     </xacro:robotiq_gripper>
 </robot>

--- a/grippers/robotiq_description/urdf/robotiq_2f_gripper.urdf.xacro
+++ b/grippers/robotiq_description/urdf/robotiq_2f_gripper.urdf.xacro
@@ -11,6 +11,10 @@
     <xacro:arg name="sim_topic_based" default="false" />
     <xacro:arg name="sim_joint_commands_topic" default="/sim/joint_commands" />
     <xacro:arg name="sim_joint_states_topic" default="/sim/joint_states" />
+    <!-- Deprecated since 1.2.0, PickNik's names; the macro warns and maps them. -->
+    <xacro:arg name="sim_isaac" default="false" />
+    <xacro:arg name="isaac_joint_commands" default="" />
+    <xacro:arg name="isaac_joint_states" default="" />
 
     <!-- Import macros -->
     <xacro:include filename="$(find robotiq_description)/urdf/robotiq_$(arg gripper_model)_macro.urdf.xacro" />
@@ -18,7 +22,8 @@
     <link name="world" />
     <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg com_port)" baudrate="$(arg baudrate)"
         sim_topic_based="$(arg sim_topic_based)"
-        sim_joint_commands_topic="$(arg sim_joint_commands_topic)" sim_joint_states_topic="$(arg sim_joint_states_topic)">
+        sim_joint_commands_topic="$(arg sim_joint_commands_topic)" sim_joint_states_topic="$(arg sim_joint_states_topic)"
+        sim_isaac="$(arg sim_isaac)" isaac_joint_commands="$(arg isaac_joint_commands)" isaac_joint_states="$(arg isaac_joint_states)">
         <origin xyz="0 0 0" rpy="0 0 0" />
     </xacro:robotiq_gripper>
 </robot>


### PR DESCRIPTION
Follow-up to the post-merge review on #52.

## What

- The topic-based simulator path is named after the plugin, not one simulator. `sim_isaac` → `sim_topic_based`; `isaac_joint_commands` / `isaac_joint_states` → `sim_joint_commands_topic` / `sim_joint_states_topic` (defaults `/sim/joint_commands` / `/sim/joint_states`, our own choice; the plugin's own defaults are `/robot_joint_commands` / `/robot_joint_states`); `config/robotiq_controllers.sim*.yaml` → `robotiq_controllers.topic_based*.yaml`. The plugin works with any simulator that exchanges `JointState` on two topics (Isaac Sim, or a bridge of your own), and "sim" read as if it also covered the `use_fake_hardware` mock, which keeps the hardware config. Both headers now say how the mock differs (it teleports, so stall detection never runs there; under the topic-based plugin the simulator integrates the joint and the velocity is real).
- The old names stay as deprecated aliases, at launch and macro level, with a warning; `sim_isaac:=true` keeps its `/isaac_joint_*` topic defaults, so nothing that worked in 1.1.0 stops working. Minor bump (1.2.0, with the MCP server); the aliases go at the next major.
- Drops the header sentence that justified the sim stall window as "wider than the driver's": the driver's velocity state is always 0 (#29), so there was nothing to compare against. The values and `allow_stalling` are untouched; the stall window itself is #63's.
- README: `topic_based_ros2_control` ships as a binary on Humble only; Jazzy and Lyrical build it in an overlay with `-DBUILD_TESTING=OFF`.

## Not in this PR

#63 (goals abort as stalled when the simulator omits velocities) is assigned and stays separate.

## Verification

`pytest test` in `robotiq_ros2:jazzy` and `robotiq_ros2:humble` with this branch's `robotiq_description` overlaid: 62 passed on each, and `ros2 launch ... sim_isaac:=true` in both images logs the deprecation and selects the topic-based plugin. `pre-commit` clean. No remaining references to the old file names in the repo.

